### PR TITLE
Support installing individual skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,29 @@ Also covered: **X**, **LinkedIn**
 
 ## Install
 
+Via the [skills.sh](https://skills.sh) CLI (no clone needed):
+
+```bash
+npx skills add scrollmark/social-skills                  # all seven
+npx skills add scrollmark/social-skills -s hook-anatomy  # just one
+```
+
+Or from a clone:
+
 ```bash
 git clone https://github.com/scrollmark/social-skills.git
 cd social-skills
-./install.sh
+./install.sh                            # all seven
+./install.sh hook-anatomy trend-radar   # just the ones you name
 ```
 
-Skills are symlinked into `~/.claude/skills/` and will be available in your next Claude Code session.
+Cloned skills are symlinked into `~/.claude/skills/` and will be available in your next Claude Code session. `./install.sh --help` lists the available skill names.
 
 ## Uninstall
 
 ```bash
-./uninstall.sh
+./uninstall.sh                # remove all
+./uninstall.sh hook-anatomy   # remove one
 ```
 
 ## Contributing

--- a/install.sh
+++ b/install.sh
@@ -4,10 +4,23 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$HOME/.claude/skills"
 
-mkdir -p "$SKILLS_DIR"
+usage() {
+  echo "Usage: ./install.sh [skill ...]"
+  echo ""
+  echo "With no arguments, installs all skills. Available:"
+  for d in "$REPO_DIR"/skills/*/; do
+    [ -f "$d/SKILL.md" ] && echo "  $(basename "$d")"
+  done
+}
 
-for skill_dir in "$REPO_DIR"/skills/*/; do
-  [ -f "$skill_dir/SKILL.md" ] || continue
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+install_one() {
+  local skill_dir="$1"
+  local name target
   name="$(basename "$skill_dir")"
   target="$SKILLS_DIR/social-skills--$name"
 
@@ -20,7 +33,27 @@ for skill_dir in "$REPO_DIR"/skills/*/; do
   fi
   ln -s "$skill_dir" "$target"
   echo "  installed: social-skills--$name"
-done
+}
+
+mkdir -p "$SKILLS_DIR"
+
+if [ $# -gt 0 ]; then
+  for name in "$@"; do
+    skill_dir="$REPO_DIR/skills/$name"
+    if [ ! -f "$skill_dir/SKILL.md" ]; then
+      echo "error: unknown skill '$name'" >&2
+      echo "" >&2
+      usage >&2
+      exit 1
+    fi
+    install_one "$skill_dir"
+  done
+else
+  for skill_dir in "$REPO_DIR"/skills/*/; do
+    [ -f "$skill_dir/SKILL.md" ] || continue
+    install_one "$skill_dir"
+  done
+fi
 
 echo ""
 echo "Done. $(ls -d "$SKILLS_DIR"/social-skills--* 2>/dev/null | wc -l | tr -d ' ') skills installed."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,16 +4,41 @@ set -euo pipefail
 SKILLS_DIR="$HOME/.claude/skills"
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-count=0
-for link in "$SKILLS_DIR"/social-skills--*; do
-  [ -L "$link" ] || continue
-  rm "$link"
-  count=$((count + 1))
-done
+usage() {
+  echo "Usage: ./uninstall.sh [skill ...]"
+  echo ""
+  echo "With no arguments, removes all installed social-skills."
+}
 
-# Clean up .root files
-for skill_dir in "$REPO_DIR"/skills/*/; do
-  rm -f "$skill_dir/.root"
-done
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+count=0
+
+if [ $# -gt 0 ]; then
+  for name in "$@"; do
+    link="$SKILLS_DIR/social-skills--$name"
+    if [ -L "$link" ]; then
+      rm "$link"
+      count=$((count + 1))
+    else
+      echo "not installed: $name" >&2
+    fi
+    rm -f "$REPO_DIR/skills/$name/.root"
+  done
+else
+  for link in "$SKILLS_DIR"/social-skills--*; do
+    [ -L "$link" ] || continue
+    rm "$link"
+    count=$((count + 1))
+  done
+
+  # Clean up .root files
+  for skill_dir in "$REPO_DIR"/skills/*/; do
+    rm -f "$skill_dir/.root"
+  done
+fi
 
 echo "Removed $count social-skills symlinks."


### PR DESCRIPTION
`./install.sh` and `./uninstall.sh` now take optional skill names:

```bash
./install.sh                            # all seven (unchanged default)
./install.sh hook-anatomy trend-radar   # just the ones you name
./install.sh --help                     # lists available names
./uninstall.sh hook-anatomy             # remove one
```

An unknown name exits 1 with the list of valid skills. README also now documents the [skills.sh](https://skills.sh) CLI route (`npx skills add scrollmark/social-skills -s <name>`), which already supported single-skill installs against this repo's layout — no restructuring was needed.

Tested with a scratch $HOME: single, multiple, unknown-name failure, per-skill and full uninstall, and the unchanged install-all path (7/7 symlinks, `.root` files cleaned up).