### PR TITLE
Self-contained skills, and the first four video-studio skills

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,17 @@
 # Contributing
 
-## Adding a Skill
+Seven rules. All of them are checkable, and `./scripts/verify-skills.sh` checks most of
+them for you. Run it before you open a PR.
 
-Create a directory under `skills/` with a `SKILL.md` file:
+## 1. Frontmatter shape
+
+Every skill is a directory under `skills/` containing a `SKILL.md`:
 
 ```
 skills/your-skill-name/SKILL.md
 ```
 
-The file needs YAML frontmatter with two fields:
+The file opens with YAML frontmatter containing **exactly two keys, in this order**:
 
 ```yaml
 ---
@@ -17,16 +20,59 @@ description: Use when [triggering conditions].
 ---
 ```
 
-- `name`: letters, numbers, hyphens only
-- `description`: must start with "Use when" — this is how Claude decides whether to load the skill. Max 1024 characters.
+- `name` — letters, numbers and hyphens only, and **identical to the directory name**.
+- `description` — one line, max 1024 characters, **must start with `Use when`**.
+- No other keys. Not `version`, not `tags`, not `author`. If you think you need one,
+  raise it in an issue first.
 
-The body should teach patterns, not specific trends. Keep it under 500 words. Write like you're explaining something to a peer, not writing a textbook.
+Immediately after the frontmatter comes a single `# Title Case Name` H1 matching the
+skill, then the body.
 
-If your skill references platform-specific knowledge, tell Claude to load the relevant reference file on demand rather than embedding the knowledge in the skill itself.
+## 2. Description voice
 
-## The Self-Containment Invariant
+The description is not documentation. It is the *only* text Claude sees when deciding
+whether to load the skill, so it must describe **when to reach for the skill**, never what
+the skill contains.
 
-**Every skill folder must be self-contained. A `SKILL.md` must never reference anything above its own directory.**
+- Write it as a trigger: `Use when <situation>` or `Use when <-ing something>`.
+- Name the concrete situations, in the words a user would actually use.
+- Do not describe the body ("Covers five techniques for…", "A guide to…"). A reader who
+  already knows what is inside cannot tell from that whether they need it.
+- Do not sell it. No "comprehensive", "powerful", "expert".
+- One extra sentence of scope is acceptable if it genuinely narrows the trigger — see
+  `video-formats`, which names its coverage. Two is too many.
+
+Compare:
+
+| | |
+|---|---|
+| Off-pattern | `description: A guide to hook writing with examples from TikTok and Reels.` |
+| On-pattern | `description: Use when analyzing, evaluating, or generating hooks for short-form video or text posts.` |
+
+Copy the finished description verbatim into the README skill table (see rule 7).
+
+## 3. Length discipline
+
+**Target 45–80 lines for a `SKILL.md`.** The skills in this repo currently run 45
+(`hook-anatomy`) to 83 (`agent-interview`) lines; 83 is the outlier, not the licence.
+
+```bash
+wc -l skills/*/SKILL.md
+```
+
+Under 45 lines and the skill probably has no substance an agent could not have guessed.
+Over 80 and it is either two skills, or it is holding knowledge that belongs in a
+reference file loaded on demand. `verify-skills.sh` prints a warning outside this band; it
+does not fail, because the judgement is yours.
+
+The body teaches **patterns, not instances**. Write like you are explaining something to a
+peer who works in this space — direct, specific, no filler. If a sentence adds no
+information, cut it.
+
+## 4. The self-containment invariant
+
+**Every skill folder must be self-contained. A `SKILL.md` must never reference anything
+above its own directory.**
 
 Skills are installed two ways, and both must work:
 
@@ -44,20 +90,74 @@ So:
 - Put the reference files your skill needs in `skills/<your-skill>/references/`.
 - Load them by a path relative to the skill: `` `references/platforms/tiktok.md` ``.
 - Never use `../`, an absolute path, a `{repo}` placeholder, or a `.root` file.
-- Only ship files the skill actually loads.
+- Only ship files the skill actually loads — an unreferenced `references/` file is a
+  failure too, because nobody will notice when it goes stale.
 
-The repo-root `references/` is the canonical source for shared files. Copy the ones your
-skill uses into the skill folder — duplication is the correct tradeoff for portability.
-When you change a shared reference, update the root copy and every skill copy of it.
+## 5. Shared references are duplicated on purpose
 
-Before opening a PR:
+The repo-root `references/` is the **canonical source** for any file more than one skill
+needs. Per-skill copies are derived from it.
+
+- Edit the canonical file at the repo root.
+- Copy it into **every** skill that ships it.
+- Do both **in the same commit**. `verify-skills.sh` catches a *missing* copy; nothing
+  catches a *stale* one.
+
+Duplication is the correct tradeoff. Skills are distributed as folders; anything above the
+folder is not part of the artifact, so every mechanism for escaping the folder works on
+your machine and fails on everyone else's. See [MIGRATION-NOTES.md](MIGRATION-NOTES.md).
+
+## 6. Declare your dependencies
+
+Some skills describe work that a machine outside this repo performs — most of the video
+production skills lean on the private `scrollmark/video-studio` engine (Python + Remotion).
+That is allowed. Hiding it is not.
+
+**Never vendor the external machinery.** No `.py`, no `package.json`, no vendored renderer,
+no checked-in binary. This repo ships prose. The engine is invoked, never copied.
+
+If your skill needs something this repo does not contain, it must:
+
+1. **Say so in the `SKILL.md` itself**, in a `## Requires` section directly under the H1,
+   naming the specific script or service and the repo it lives in — see `brand-kit` and
+   `studio-setup`. (`video-formats` predates this convention and calls its section
+   `## Toolchain Assumptions` at the foot of the file; new skills use `## Requires`.)
+2. **Be honest about the degraded case.** State what a reader *without* the dependency can
+   still do and what they cannot. "Requires X" is not enough; say whether the skill is
+   still 90% useful or entirely inert. `video-formats` does this per-format: eight formats
+   are pure structure, `boil` loses roughly 40% of its workflow without `gen_boil.py`, and
+   `pointer-popups` has no usable grammar at all without `track_pointing.py`.
+3. **Carry the same caveat into the README** row and the
+   [engine boundary section](README.md#the-video-studio-boundary).
+
+Do not write a skill whose instructions only make sense to someone inside Scrollmark. If
+the honest version of the skill would be unreadable to an outside user, it belongs in the
+private repo instead.
+
+## 7. Before you open a PR
 
 ```bash
 ./scripts/verify-skills.sh
 ```
 
-It fails if a `SKILL.md` reaches outside its folder, if any `.root` file exists, or if a
-skill names a reference file it does not contain.
+It fails if:
+
+- any `.root` file exists in the repo;
+- a `SKILL.md` mentions `.root` or `{repo}`, or contains `../` or `/skills/`;
+- a `SKILL.md` names a `references/...` file the skill folder does not contain;
+- a skill ships a `references/` directory its `SKILL.md` never loads from;
+- frontmatter is missing, `name` does not match the directory, or `description` does not
+  start with `Use when`;
+- a skill is not listed in the README skill table.
+
+It warns (without failing) if a `SKILL.md` falls outside 45–80 lines.
+
+Also update, by hand:
+
+- the **README skill table** — a row in the right group, with the description copied
+  verbatim from your frontmatter;
+- **[MIGRATION-NOTES.md](MIGRATION-NOTES.md)**, if you changed the structure of the repo
+  rather than its content.
 
 ## Adding a Platform Reference
 
@@ -81,6 +181,24 @@ Required sections:
 - **Comment Culture** — how people interact on this platform
 - **Creator Tiers** — how distribution differs by account size
 
+## Adding a Video Format
+
+Format grammars live in `skills/video-formats/references/formats/` as one kebab-case
+markdown file each. The format list *is* the directory listing — no index to update.
+
+Required sections, in order: `# Name — one-line description`, `## Composition`,
+`## Interview`, `## Slots`, `## Grammar`, `## Render notes`.
+
+Two rules, both from `video-formats` itself:
+
+- **A format earns its file by recurring.** Three or four independent uses is a format;
+  one is a video.
+- **The Grammar section must be able to say no.** A grammar that only describes what a
+  video may contain is a mood board.
+
+If the format depends on a video-studio script, rule 6 applies: say so in *Render notes*,
+and say what is left without it.
+
 ## Updating slang-and-signals.md
 
 Edit `references/slang-and-signals.md` at the repo root, then copy it into every skill that
@@ -96,8 +214,6 @@ After making changes, bump both `last_updated` and `version` in the frontmatter.
 
 ## Writing Test Scenarios
 
-Add scenario files to `tests/scenarios/{skill-name}/`. See [tests/TESTING.md](tests/TESTING.md) for the format. Every scenario needs behavioral markers — specific, checkable items that determine whether Claude's response reflects the skill's guidance.
-
-## Style
-
-Write like someone who works in this space. Be direct, be specific, skip the filler. If a sentence doesn't add information, cut it.
+Add scenario files to `tests/scenarios/{skill-name}/`. See [tests/TESTING.md](tests/TESTING.md)
+for the format. Every scenario needs behavioral markers — specific, checkable items that
+determine whether Claude's response reflects the skill's guidance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,46 @@ The body should teach patterns, not specific trends. Keep it under 500 words. Wr
 
 If your skill references platform-specific knowledge, tell Claude to load the relevant reference file on demand rather than embedding the knowledge in the skill itself.
 
+## The Self-Containment Invariant
+
+**Every skill folder must be self-contained. A `SKILL.md` must never reference anything above its own directory.**
+
+Skills are installed two ways, and both must work:
+
+```bash
+npx skills add scrollmark/social-skills   # users — COPIES each skills/<name>/ folder
+./install.sh                              # development — symlinks each folder
+```
+
+The `npx` route copies the skill folder and nothing else. Anything your `SKILL.md` points
+at outside that folder simply will not be there, and the skill degrades silently — no
+error, just worse answers. That is the bug this invariant exists to prevent.
+
+So:
+
+- Put the reference files your skill needs in `skills/<your-skill>/references/`.
+- Load them by a path relative to the skill: `` `references/platforms/tiktok.md` ``.
+- Never use `../`, an absolute path, a `{repo}` placeholder, or a `.root` file.
+- Only ship files the skill actually loads.
+
+The repo-root `references/` is the canonical source for shared files. Copy the ones your
+skill uses into the skill folder — duplication is the correct tradeoff for portability.
+When you change a shared reference, update the root copy and every skill copy of it.
+
+Before opening a PR:
+
+```bash
+./scripts/verify-skills.sh
+```
+
+It fails if a `SKILL.md` reaches outside its folder, if any `.root` file exists, or if a
+skill names a reference file it does not contain.
+
 ## Adding a Platform Reference
 
-Create a file at `references/platforms/{platform-name}.md` with this structure:
+Create the canonical file at `references/platforms/{platform-name}.md` (repo root), then
+copy it into `skills/<name>/references/platforms/` for every skill that loads platform
+references. Use this structure:
 
 ```yaml
 ---
@@ -46,7 +83,9 @@ Required sections:
 
 ## Updating slang-and-signals.md
 
-Add entries to the appropriate category. Each entry needs:
+Edit `references/slang-and-signals.md` at the repo root, then copy it into every skill that
+loads it (currently `skills/read-the-room/references/`). Add entries to the appropriate
+category. Each entry needs:
 
 - **Pattern/term** — what it is
 - **Signal** — what it actually means

--- a/MIGRATION-NOTES.md
+++ b/MIGRATION-NOTES.md
@@ -1,4 +1,13 @@
-# Migration: self-contained skills
+# Migration Notes
+
+Two structural migrations are recorded here, oldest first:
+
+1. **[Self-contained skills](#the-bug)** — why every skill folder now carries its own
+   `references/`, and what to do about an old install.
+2. **[The video-studio split](#migration-the-video-studio-split)** — why this repo holds
+   prose only, and where the video toolchain went.
+
+---
 
 ## The bug
 
@@ -162,3 +171,105 @@ find ~/.claude/skills -maxdepth 1 -name 'social-skills--*' -type l ! -exec test 
 Then reinstall by either route above.
 
 In all cases, restart Claude Code — skills are picked up at session start.
+
+---
+
+# Migration: the video-studio split
+
+## The decision
+
+This repo started as seven skills about *understanding* social media. It now also covers
+*making* short-form video. That second job came out of `scrollmark/video-studio`, a private
+repo containing a real production pipeline: Python scripts, a Remotion composer, local
+models, and a dozen third-party API integrations.
+
+The decision was a **split, not a move**.
+
+> Prose lives in social-skills. The toolchain stays in video-studio and is **invoked, never
+> vendored**.
+
+There is no copy of the pipeline here, and there never should be one. A skill in this repo
+may *name* a script from video-studio and *tell an agent to run it*. It may not ship it.
+
+## Why not just move the whole thing
+
+Three reasons, in order of how much they hurt.
+
+1. **The engine is not distributable.** It carries paid API keys, a downloaded segmentation
+   model, a Remotion install, and a 9.6 GB working tree in which project renders were being
+   written *inside the skill directory*. None of that survives `npx skills add`, which
+   copies a folder.
+2. **The valuable part is the prose.** The scene grammars, the interview rounds, the
+   rights tiering, the "measure the narration, don't trust the estimate" rules — those were
+   learned by failing at production, and they transfer to anyone with any editor. The
+   Python is the least portable and least interesting half.
+3. **The two halves have different licences and different audiences.** This repo is MIT and
+   public. The engine is not.
+
+## What moved here
+
+| Skill | What it is | Came from |
+|---|---|---|
+| `video-formats` | The ten scene grammars and the contract for writing an eleventh | `formats/*.md` |
+| `agent-interview` | The choice-question protocol: ask decisions, not essays | the interview rounds threaded through the pipeline |
+| `brand-kit` | Deciding and recording a brand: palette, type, card roles, logo, voice, CTA | the Title system prose + `styles/*.md` |
+| `studio-setup` | What to install, what each key unlocks, and how to triage a dead pipeline | `third-party.md` + the doctor/setup prose |
+
+## What stayed behind
+
+Everything executable, and everything that only makes sense with credentials:
+
+- the orchestrator (storyboard construction, preflight, render, quality gate, cost quoting);
+- media acquisition (stock providers, image and video generation, `yt-dlp`, clip verification);
+- audio acquisition (TTS, score generation, loudness normalisation, rights tiering);
+- subject compositing and hand tracking (`composite_subject.py`, `track_pointing.py`);
+- NLE handoff (`export_fcpxml.py`, `export_capcut.py`, and friends);
+- the setup and doctor scripts themselves (`setup.py`, `doctor.py`, `tutor.py`);
+- `styles.py`, which is what makes a brand preset *apply* rather than merely exist.
+
+## The seam, stated honestly
+
+A split leaves a seam, and the docs' job is to show it rather than paper over it. Three
+of the four migrated skills declare a dependency in a `## Requires` section; the honest
+summary for an outside reader is in [README.md](README.md#the-video-studio-boundary).
+
+The parts that genuinely do not work without the engine:
+
+- **`pointer-popups`** — its grammar *is* the tracker. Popup positions and timing windows
+  are `track_pointing.py` output; the storyboard consumes them. Without the tracker there
+  is no format, only a description of one.
+- **`boil`** — roughly 40% inoperative. The mark vocabulary (`gen_boil.py --list`), the
+  custom `boil_shapes.py` escape hatch, and the per-scene palette workflow are all the
+  generator. The composition rules and interview structure survive; the thing that answers
+  the interview does not.
+- **`brand-kit`'s preset verbs** — `--list`, `--show`, `--apply`, `--save` are `styles.py`.
+  Agreeing a brand and writing the files by hand still works.
+- **`studio-setup`'s status report** — the inventory is prose and readable; the diagnosis,
+  the install plan, and the auto/system/manual classification are `doctor.py`.
+
+The remaining eight formats — TalkingHead, PipStory, Cinematic, Explainer, ProductLaunch,
+BrandOrigin, TimelineExplainer, TitledVideo, plus the structural half of the two above —
+are pure structure and need nothing from the private repo.
+
+## The rule this leaves behind
+
+Rule 6 in [CONTRIBUTING.md](CONTRIBUTING.md#6-declare-your-dependencies): a skill that
+needs machinery this repo does not contain must name it, must say what a reader *without*
+it can still do, and must carry that caveat into the README. "Requires X" on its own is
+not a disclosure — it tells the reader nothing about whether the skill is 90% useful or
+entirely inert.
+
+The failure mode being prevented is the same one as the `.root` migration above: **silent
+degradation**. A skill that quietly assumes a script nobody has does not error. It just
+gives worse answers, and nobody finds out.
+
+## Consequences for the repo layout
+
+- The shared-reference convention now spans two domains. `references/platforms/*.md` is
+  social-media knowledge; `skills/video-formats/references/formats/*.md` is video knowledge
+  and is deliberately *not* mirrored at the repo root, because only one skill loads it.
+- `scripts/verify-skills.sh` gained frontmatter, README-listing and length checks, so that
+  a new skill from either domain has to satisfy the same shape.
+- The README is grouped rather than flat. Seven social-media skills, two video-production
+  skills, two working-method/toolchain skills — the split is visible in the table of
+  contents, not buried.

--- a/MIGRATION-NOTES.md
+++ b/MIGRATION-NOTES.md
@@ -1,0 +1,164 @@
+# Migration: self-contained skills
+
+## The bug
+
+`install.sh` symlinked each `skills/<name>/` into `~/.claude/skills/social-skills--<name>`
+and wrote a `.root` file containing the repo path. Six `SKILL.md` files then said, in
+effect: *read the `.root` file in this skill's directory for the repo path, then load
+`{repo}/references/...`*.
+
+That only ever worked for the clone-and-symlink install. The route the public website
+advertises —
+
+```bash
+npx skills add scrollmark/social-skills
+```
+
+— **copies** the skill folder. No symlink, no `.root`, no `references/`. The skills then
+failed to load their references and fell back to a degraded path with no error message
+and no signal to the user. Silent degradation: the skill still answers, just worse.
+
+The README did not document the `npx` route at all, so the failure mode was invisible
+from both ends.
+
+## What changed
+
+### 1. Each skill carries its own references
+
+| Skill | `references/` now shipped inside the skill |
+|-------|---------------------------------------------|
+| `read-the-room` | `slang-and-signals.md` + all 5 `platforms/*.md` |
+| `hook-anatomy` | all 5 `platforms/*.md` |
+| `platform-fluency` | all 5 `platforms/*.md` |
+| `content-autopsy` | all 5 `platforms/*.md` |
+| `trend-radar` | all 5 `platforms/*.md` |
+| `repurpose-engine` | all 5 `platforms/*.md` |
+| `voice-matching` | none — verified it references no files |
+
+The repo-root `references/` stays as the **canonical source**. The per-skill copies are
+derived from it.
+
+### 2. Reference loading is now relative
+
+Every affected `SKILL.md` had exactly one sentence rewritten. The prose and meaning are
+otherwise untouched — only *how the path resolves* changed:
+
+- before: read `.root` for the repo path, then load `{repo}/references/platforms/{platform}.md`
+- after: load `references/platforms/{platform}.md` from this skill's own directory
+
+No `.root`, no `{repo}` placeholder, no repo-path resolution, no `../`.
+
+### 3. `install.sh`
+
+- No longer writes `.root`.
+- Actively deletes any stale `.root` left by a previous install.
+- Idempotent: replaces whatever already sits at the target path (symlink, directory, or
+  a copy left by `npx skills add`), so re-running after a `git pull` is safe.
+- Prunes `social-skills--*` links whose skill no longer exists in the repo.
+- Honours `CLAUDE_SKILLS_DIR` for testing/alternate installs.
+- Iterates `skills/*/` generically, so new skills need no script changes.
+
+### 4. `uninstall.sh`
+
+- Removes copies and broken symlinks too, not just live symlinks.
+- Still cleans up legacy `.root` files.
+- Honours `CLAUDE_SKILLS_DIR`.
+
+### 5. `scripts/verify-skills.sh` (new)
+
+Fails (exit 1) if:
+
+- any `.root` file exists anywhere in the repo;
+- a `SKILL.md` mentions `.root` or `{repo}`, or contains `../` or `/skills/`;
+- a `SKILL.md` names a `references/...` file the skill folder does not contain
+  (placeholder segments like `{platform}` are satisfied by any `.md` in that directory);
+- a skill ships a `references/` directory its `SKILL.md` never loads from.
+
+It works for any number of skills and needs no per-skill configuration.
+
+### 6. Docs
+
+`README.md` documents both install routes (`npx skills add` for users, `./install.sh` for
+development) and explains the self-containment property. `CONTRIBUTING.md` states the
+invariant, explains *why* it exists, and tells contributors to run `verify-skills.sh`.
+
+## The duplication tradeoff
+
+There are only 6 shared reference files, copied into 6 skills — roughly 26 small markdown
+files where there were 6. That is cheap.
+
+The alternative — a single shared `references/` outside the skill folders — cannot survive
+the packaging model. Skills are distributed as *folders*; whatever sits above a folder is
+not part of the artifact. Any indirection to escape the folder (`.root`, `../`, an
+absolute path) works on the maintainer's machine and silently fails everywhere else. That
+is precisely the bug being fixed.
+
+Duplication buys correctness for every install route, and the cost is a maintenance rule
+rather than a runtime risk: **edit the canonical file at the repo root, then copy it into
+every skill that ships it.** `verify-skills.sh` catches a missing file; it does not catch
+a stale one, so keep the copies in the same commit.
+
+## What breaks for people who already installed
+
+Nothing breaks at runtime — the skills work better, not worse. But two kinds of debris can
+be left on machines that installed an earlier version:
+
+1. **Orphaned symlinks.** If someone ran the old `install.sh` and later moved or deleted
+   their clone, `~/.claude/skills/social-skills--*` contains dangling symlinks. Claude Code
+   may log noise about unreadable skills. The new `install.sh` prunes these; the new
+   `uninstall.sh` removes them.
+
+2. **Stale `.root` files.** The old installer wrote `skills/<name>/.root` into the clone.
+   They are gitignored, so a `git pull` will not remove them. They are now inert — no
+   `SKILL.md` reads them — but `verify-skills.sh` fails while any exists, so contributors
+   must clear them. Running the new `install.sh` or `uninstall.sh` does this automatically.
+
+3. **A previous `npx skills add` install is a copy, not a link.** It will not pick up this
+   fix until the user re-runs `npx skills add`. Until they do, they keep the old, degraded
+   copies — which is the original bug, so re-installing is the whole point.
+
+Mixed state is also possible: someone who used both routes may have a copied directory
+sitting where the symlink should go. The new `install.sh` overwrites it rather than
+failing.
+
+## Upgrade steps
+
+### If you cloned the repo
+
+```bash
+cd /path/to/social-skills
+git pull
+./install.sh              # rewrites symlinks, deletes stale .root, prunes dead links
+./scripts/verify-skills.sh
+```
+
+To remove an old install entirely first:
+
+```bash
+./uninstall.sh && ./install.sh
+```
+
+### If you installed with npx
+
+```bash
+npx skills add scrollmark/social-skills
+```
+
+Re-running picks up the self-contained folders. If your tool does not overwrite in place,
+remove the old copies first:
+
+```bash
+rm -rf ~/.claude/skills/social-skills--*
+npx skills add scrollmark/social-skills
+```
+
+### If you have debris and no clone
+
+```bash
+# remove dangling symlinks left by an old ./install.sh
+find ~/.claude/skills -maxdepth 1 -name 'social-skills--*' -type l ! -exec test -e {} \; -delete
+```
+
+Then reinstall by either route above.
+
+In all cases, restart Claude Code — skills are picked up at session start.

--- a/README.md
+++ b/README.md
@@ -26,19 +26,51 @@ Also covered: **X**, **LinkedIn**
 
 ## Install
 
+### For users (recommended)
+
+```bash
+npx skills add scrollmark/social-skills
+```
+
+This copies each skill folder into your Claude Code skills directory. Every skill is
+self-contained — it ships the reference files it needs — so a copied install has the
+exact same behaviour as a cloned one.
+
+### For development
+
 ```bash
 git clone https://github.com/scrollmark/social-skills.git
 cd social-skills
 ./install.sh
 ```
 
-Skills are symlinked into `~/.claude/skills/` and will be available in your next Claude Code session.
+`install.sh` symlinks each `skills/<name>/` into `~/.claude/skills/social-skills--<name>`,
+so edits in your clone take effect immediately. It is idempotent — re-run it any time,
+including after pulling new skills — and it prunes links whose skill no longer exists.
+Set `CLAUDE_SKILLS_DIR` to install somewhere other than `~/.claude/skills`.
+
+Either way, skills become available in your next Claude Code session.
 
 ## Uninstall
 
 ```bash
 ./uninstall.sh
 ```
+
+Removes every `social-skills--*` entry from your skills directory (symlinks and copies
+alike) and deletes any stale `.root` files left behind by older versions of `install.sh`.
+
+## Self-contained skills
+
+Every skill folder stands on its own. `skills/<name>/` contains its `SKILL.md` plus its
+own `references/`, and a `SKILL.md` never points at anything above its own directory.
+
+That is what makes the two install routes equivalent. Earlier versions resolved reference
+paths through a `.root` file that only `install.sh` wrote, so `npx skills add` installs
+silently ran without their references. The shared reference files under the repo-root
+`references/` remain the canonical source and are copied into each skill that uses them.
+
+Run `./scripts/verify-skills.sh` to check the invariant.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,97 @@
 # Social Skills
 
-Claude Code skills for understanding social media. Because even AI needs social skills.
+Claude Code skills for social media and short-form video. Because even AI needs social
+skills.
 
 ## What is this?
 
-A collection of installable [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code) that teach Claude the cultural literacy it needs to work with social media content — understanding tone, hooks, trends, platform conventions, and creator voice.
+A collection of installable [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code)
+covering two related jobs:
+
+- **Understanding social media** — tone, hooks, trends, platform conventions, creator voice.
+- **Producing short-form video** — scene grammars, brand consistency, and the interview
+  protocol used to pin down a plan before anything is built.
+
+Everything here is **prose**. These skills teach Claude how to think about a problem; they
+do not ship a renderer, a model, or a pipeline. A few of them describe work that a
+separate engine performs — see [The video-studio boundary](#the-video-studio-boundary).
+
+<!-- BEGIN SKILLS TABLE (descriptions are copied verbatim from each SKILL.md frontmatter) -->
 
 ## Skills
 
-| Skill | What it does |
-|-------|-------------|
-| `read-the-room` | Interpret tone, sarcasm, irony, and cultural context in social media text |
-| `hook-anatomy` | Analyze, evaluate, and generate hooks for short-form video and text |
-| `trend-radar` | Assess trend lifecycle, timing, and relevance for a specific creator |
-| `platform-fluency` | Understand platform conventions, algorithms, and audience behavior |
-| `content-autopsy` | Investigate why content performed well or poorly |
-| `voice-matching` | Capture and write in a specific creator's voice |
-| `repurpose-engine` | Adapt content across platforms while keeping it native |
+### Understanding social media
+
+Seven skills about reading and making social content. All standalone — no external tools,
+no accounts, no keys.
+
+| Skill | Use when |
+|-------|----------|
+| `read-the-room` | Interpreting social media content — comments, captions, replies, DMs — and you need to understand tone, subtext, or cultural context beyond the literal words. |
+| `hook-anatomy` | Analyzing, evaluating, or generating hooks for short-form video or text posts. |
+| `trend-radar` | Evaluating whether a trend is relevant, identifying emerging trends, or advising on trend participation timing. |
+| `platform-fluency` | Understanding platform-specific conventions, algorithm behavior, content formats, or audience expectations for Instagram, TikTok, YouTube, X, or LinkedIn. |
+| `content-autopsy` | Analyzing why content performed well or poorly, doing post-mortem analysis, or comparing content performance. |
+| `voice-matching` | Writing in a creator's voice, analyzing a creator's style, or maintaining voice consistency across content. |
+| `repurpose-engine` | Adapting content from one platform to another, or advising on multi-platform content strategy. |
+
+### Producing video
+
+Craft skills for planning a short-form video. The planning is standalone; some of what
+they describe is executed by the video-studio engine.
+
+| Skill | Use when | Standalone? |
+|-------|----------|-------------|
+| `video-formats` | Planning, structuring, or critiquing a short-form video — choosing a format, laying out its scenes, or defining a new format. Covers ten scene grammars from talking-head to hand-drawn motion graphics. | Mostly — 8 of the 10 formats are pure structure. **Boil** and **PointerPopups** are not (see below). |
+| `brand-kit` | A user wants their videos to stay visually consistent — saving caption styling, card colours and geometry, title treatment, logos, fonts, voice and CTA copy once instead of redeciding them per video. | Deciding and recording a brand, yes. Applying it automatically at render time needs the engine. |
+
+### Working method and toolchain
+
+| Skill | Use when | Standalone? |
+|-------|----------|-------------|
+| `agent-interview` | You need to ask a user a series of decisions — a guided setup, an intake, a wizard, an onboarding walkthrough — and want the questions to be answerable rather than open-ended. | Yes. Nothing video-specific in it. |
+| `studio-setup` | Checking whether a machine can actually produce video, triaging a pipeline that stopped working, or deciding which third-party tool or API key to add next. | Partly. Its tooling inventory is readable by anyone; the status report, install plan and triage come from `doctor.py` / `setup.py` in the private repo. |
+
+<!-- END SKILLS TABLE -->
+
+Every row's "Use when" text is the skill's own frontmatter `description`, copied verbatim,
+so this table cannot quietly drift from the skills. `./scripts/verify-skills.sh` fails if a
+skill is missing from it.
+
+## The video-studio boundary
+
+This repo is one half of a deliberate split.
+
+- **Here (public):** the prose. Formats, grammars, interview protocols, brand vocabulary,
+  the judgement calls. Readable and useful on its own.
+- **Elsewhere (private):** `scrollmark/video-studio` — the Python and Remotion toolchain
+  that actually composites, generates, tracks, and renders. It is **invoked, never
+  vendored**. No script from it is copied into this repo, and no skill here bundles one.
+
+If you do not have access to video-studio, here is exactly what that costs you:
+
+- The **seven social-media skills** are entirely unaffected. So is `agent-interview`.
+- `video-formats` still works for eight of its ten formats. Composition, Interview, Slots
+  and Grammar are structural; you can follow them with any editor.
+- **`boil` is roughly 40% inoperative.** Its mark vocabulary, shape files and palette
+  workflow are `gen_boil.py`; without it, the interview questions have no answers to pick
+  from and you are reading a style description, not instructions.
+- **`pointer-popups` does not work at all as written.** Its entire grammar is the output of
+  a `track_pointing.py` hand-tracking pass — popup position and timing come from the
+  tracker, not from a storyboard you write. Without the tracker there is nothing to follow.
+- `brand-kit` lets you agree a brand with a user and hand-write the files. The preset
+  mechanism — `--list`, `--show`, `--apply`, `--save` — is `styles.py`, and nothing expands
+  a preset into a storyboard without it, so applying a brand becomes manual editing.
+- `studio-setup` keeps its tooling inventory, but the single status report, the install
+  plan and the auto/system/manual classification all come from `doctor.py` and `setup.py`.
+  You can still check binaries by hand.
+
+Each of those skills states its own dependency in a `## Requires` section near the top —
+that is where the authoritative answer lives, not here.
+
+Format files also name other pipeline scripts (`measure.py`, `styles.py`) in their *Render
+notes*. Those are practical traps recorded from production, not requirements — the
+structural sections above them stand without any of it.
 
 ## Platforms
 
@@ -49,7 +124,8 @@ so edits in your clone take effect immediately. It is idempotent — re-run it a
 including after pulling new skills — and it prunes links whose skill no longer exists.
 Set `CLAUDE_SKILLS_DIR` to install somewhere other than `~/.claude/skills`.
 
-Either way, skills become available in your next Claude Code session.
+Either way, skills become available in your next Claude Code session. Neither route
+installs, downloads, or requires video-studio.
 
 ## Uninstall
 
@@ -74,8 +150,10 @@ Run `./scripts/verify-skills.sh` to check the invariant.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md). Structural history — the self-containment fix and
+the video-studio split — is in [MIGRATION-NOTES.md](MIGRATION-NOTES.md).
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE). Covers everything in this repo, prose included. It does not
+extend to video-studio, which is separately licensed and not distributed here.

--- a/install.sh
+++ b/install.sh
@@ -1,26 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Development install: symlink each skill folder into ~/.claude/skills/.
+# Each skill folder is self-contained — it carries its own references/ —
+# so a symlinked install and a copied install (npx skills add) behave identically.
+#
+# Regular users do not need this script:
+#   npx skills add scrollmark/social-skills
+
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
-SKILLS_DIR="$HOME/.claude/skills"
+SKILLS_DIR="${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills}"
 
 mkdir -p "$SKILLS_DIR"
 
+installed=0
 for skill_dir in "$REPO_DIR"/skills/*/; do
   [ -f "$skill_dir/SKILL.md" ] || continue
   name="$(basename "$skill_dir")"
   target="$SKILLS_DIR/social-skills--$name"
 
-  # Write .root so skills can resolve reference paths
-  echo "$REPO_DIR" > "$skill_dir/.root"
+  # Remove stale .root files written by older versions of this installer.
+  rm -f "$skill_dir/.root"
 
-  # Create or update symlink
-  if [ -L "$target" ]; then
-    rm "$target"
+  # Idempotent: replace whatever is already at the target path.
+  if [ -L "$target" ] || [ -e "$target" ]; then
+    rm -rf "$target"
   fi
-  ln -s "$skill_dir" "$target"
+  ln -s "${skill_dir%/}" "$target"
+  installed=$((installed + 1))
   echo "  installed: social-skills--$name"
 done
 
+# Remove links for skills that no longer exist in this repo.
+for link in "$SKILLS_DIR"/social-skills--*; do
+  [ -L "$link" ] || continue
+  if [ ! -e "$link" ]; then
+    rm -f "$link"
+    echo "  pruned (stale): $(basename "$link")"
+  fi
+done
+
 echo ""
-echo "Done. $(ls -d "$SKILLS_DIR"/social-skills--* 2>/dev/null | wc -l | tr -d ' ') skills installed."
+echo "Done. $installed skill(s) installed into $SKILLS_DIR."

--- a/scripts/verify-skills.sh
+++ b/scripts/verify-skills.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enforces the self-containment invariant:
+#   Every skills/<name>/ folder must work standalone. A SKILL.md may only
+#   reference files inside its own directory, and every referenced file
+#   must actually exist there. No .root indirection anywhere.
+#
+# Exits non-zero on the first class of failure found. Run from anywhere.
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS_ROOT="$REPO_DIR/skills"
+fail=0
+
+err() { echo "FAIL: $*" >&2; fail=1; }
+
+[ -d "$SKILLS_ROOT" ] || { echo "FAIL: no skills/ directory at $SKILLS_ROOT" >&2; exit 1; }
+
+# 1. No .root files may exist anywhere in the repo.
+while IFS= read -r rootfile; do
+  err ".root file present: ${rootfile#$REPO_DIR/} (skills must not resolve a repo path)"
+done < <(find "$REPO_DIR" -name '.root' -not -path '*/.git/*' 2>/dev/null)
+
+skill_count=0
+for skill_dir in "$SKILLS_ROOT"/*/; do
+  skill_md="$skill_dir/SKILL.md"
+  [ -f "$skill_md" ] || continue
+  name="$(basename "$skill_dir")"
+  skill_count=$((skill_count + 1))
+
+  # 2. No escape-hatch indirection or paths reaching above the skill folder.
+  if grep -qn '\.root' "$skill_md"; then
+    err "$name/SKILL.md mentions .root"
+  fi
+  if grep -qn '{repo}' "$skill_md"; then
+    err "$name/SKILL.md uses a {repo} placeholder"
+  fi
+  if grep -qn '\.\./' "$skill_md"; then
+    err "$name/SKILL.md contains a '../' path (must not reference outside its own folder)"
+  fi
+  if grep -qn '/skills/' "$skill_md"; then
+    err "$name/SKILL.md contains an absolute-looking '/skills/' path"
+  fi
+
+  # 3. Every referenced references/... file must exist inside this skill.
+  #    Placeholder segments like {platform} expand to every sibling file.
+  while IFS= read -r ref; do
+    ref="${ref#./}"
+    if [[ "$ref" == *"{"* ]]; then
+      dir="$(dirname "$ref")"
+      if [ ! -d "$skill_dir/$dir" ]; then
+        err "$name/SKILL.md references '$ref' but $name/$dir/ does not exist"
+      elif [ -z "$(find "$skill_dir/$dir" -maxdepth 1 -name '*.md' -print -quit)" ]; then
+        err "$name/SKILL.md references '$ref' but $name/$dir/ contains no .md files"
+      fi
+    elif [ ! -f "$skill_dir/$ref" ]; then
+      err "$name/SKILL.md references '$ref' but $name/$ref does not exist"
+    fi
+  done < <(grep -oE '(\./)?references/[A-Za-z0-9_{}./-]+\.md' "$skill_md" | sort -u)
+
+  # 4. Anything shipped under the skill's references/ should be reachable.
+  if [ -d "$skill_dir/references" ]; then
+    if ! grep -q 'references/' "$skill_md"; then
+      err "$name ships references/ but SKILL.md never loads anything from it"
+    fi
+  fi
+done
+
+if [ "$skill_count" -eq 0 ]; then
+  echo "FAIL: no skills with a SKILL.md found under skills/" >&2
+  exit 1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "" >&2
+  echo "verify-skills: FAILED ($skill_count skill(s) checked)" >&2
+  exit 1
+fi
+
+echo "verify-skills: OK — $skill_count skill(s) are self-contained."

--- a/scripts/verify-skills.sh
+++ b/scripts/verify-skills.sh
@@ -6,13 +6,22 @@ set -euo pipefail
 #   reference files inside its own directory, and every referenced file
 #   must actually exist there. No .root indirection anywhere.
 #
+# Also enforces the frontmatter shape and README listing described in
+# CONTRIBUTING.md, and warns on SKILL.md length outside 45-80 lines.
+#
 # Exits non-zero on the first class of failure found. Run from anywhere.
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SKILLS_ROOT="$REPO_DIR/skills"
+README="$REPO_DIR/README.md"
 fail=0
+warned=0
 
 err() { echo "FAIL: $*" >&2; fail=1; }
+warn() { echo "WARN: $*" >&2; warned=$((warned + 1)); }
+
+# Prints the frontmatter block (between the first two --- lines) of a file.
+frontmatter() { awk 'NR==1 && $0!="---"{exit} /^---$/{n++; next} n==1' "$1"; }
 
 [ -d "$SKILLS_ROOT" ] || { echo "FAIL: no skills/ directory at $SKILLS_ROOT" >&2; exit 1; }
 
@@ -27,6 +36,37 @@ for skill_dir in "$SKILLS_ROOT"/*/; do
   [ -f "$skill_md" ] || continue
   name="$(basename "$skill_dir")"
   skill_count=$((skill_count + 1))
+
+  # 2a. Frontmatter shape: exactly `name` + `description`, name matches the
+  #     directory, description is a "Use when" trigger under 1024 chars.
+  fm="$(frontmatter "$skill_md")"
+  if [ -z "$fm" ]; then
+    err "$name/SKILL.md has no YAML frontmatter"
+  else
+    fm_name="$(printf '%s\n' "$fm" | sed -n 's/^name:[[:space:]]*//p' | head -1)"
+    fm_desc="$(printf '%s\n' "$fm" | sed -n 's/^description:[[:space:]]*//p' | head -1)"
+    fm_keys="$(printf '%s\n' "$fm" | grep -cE '^[A-Za-z_-]+:' || true)"
+
+    [ "$fm_name" = "$name" ] || err "$name/SKILL.md frontmatter name is '$fm_name', expected '$name'"
+    case "$fm_desc" in
+      "Use when"*) ;;
+      "") err "$name/SKILL.md frontmatter has no description" ;;
+      *) err "$name/SKILL.md description must start with 'Use when' (got: ${fm_desc:0:40}...)" ;;
+    esac
+    [ "${#fm_desc}" -le 1024 ] || err "$name/SKILL.md description is ${#fm_desc} chars (max 1024)"
+    [ "$fm_keys" -eq 2 ] || err "$name/SKILL.md frontmatter has $fm_keys keys; only 'name' and 'description' are allowed"
+  fi
+
+  # 2b. Every skill must appear in the README skill table.
+  if [ -f "$README" ] && ! grep -q "\`$name\`" "$README"; then
+    err "$name is not listed in README.md (add a row to the skill table)"
+  fi
+
+  # 2c. Length discipline — advisory only, see CONTRIBUTING.md rule 3.
+  lines="$(wc -l < "$skill_md" | tr -d ' ')"
+  if [ "$lines" -lt 45 ] || [ "$lines" -gt 80 ]; then
+    warn "$name/SKILL.md is $lines lines (target 45-80)"
+  fi
 
   # 2. No escape-hatch indirection or paths reaching above the skill folder.
   if grep -qn '\.root' "$skill_md"; then
@@ -77,4 +117,8 @@ if [ "$fail" -ne 0 ]; then
   exit 1
 fi
 
-echo "verify-skills: OK — $skill_count skill(s) are self-contained."
+if [ "$warned" -ne 0 ]; then
+  echo "verify-skills: OK with $warned warning(s) — $skill_count skill(s) are self-contained."
+else
+  echo "verify-skills: OK — $skill_count skill(s) are self-contained."
+fi

--- a/skills/agent-interview/SKILL.md
+++ b/skills/agent-interview/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: agent-interview
+description: Use when you need to ask a user a series of decisions — a guided setup, an intake, a wizard, an onboarding walkthrough — and want the questions to be answerable rather than open-ended.
+---
+
+# Agent Interview
+
+An interview is a protocol, not a conversation where you happen to ask things:
+one decision at a time, real options to pick from, one consistent name per
+thing, and a readback before anything expensive. Open questions get vague
+answers, and vague answers get silently invented into specifics later.
+
+## Asking
+
+Ask **choice questions** — a real question with named options. Use the highest
+rung the host offers:
+
+1. **A native question tool** (e.g. AskUserQuestion). Best — the user picks,
+   and "Other" is always there for freeform.
+2. **A question MCP**, if registered. Same affordance, no native picker needed.
+3. **Numbered choices in the message.** The fallback below — a real path, not
+   a failure.
+
+There is no fourth rung, and know why before inventing one: **your shell has no
+terminal attached** — no tty, no stdin. `read` returns immediately, so a prompt
+script hangs or silently takes a default nobody chose.
+
+## The numbered fallback
+
+One round at a time, every question of it in a single block, labels unique
+across the whole round:
+
+```
+**Q1. Which filing status?**  (pick one · default: a)
+   a) Single   b) Married filing jointly   c) Head of household
+**Q2. Which apply to you?**  (pick any · default: none)
+   a) Dependents   b) Self-employed income   c) Rental income
+
+Reply like `1a 2c`, or say it in words. Anything the options miss, say
+plainly and it goes in as-is.
+```
+
+Each rule below exists because the loose version fails a specific way.
+
+- **Label across the round, not within a question.** `Q1`/`Q2` crossed with
+  `a`/`b`/`c` parses one way; per-question `1) 2) 3)` makes "the second one"
+  ambiguous the moment a round has two questions.
+- **Mark pick-one or pick-any on every question.** Unmarked, a multi-select
+  answer reads as a single choice and the extras vanish unnoticed.
+- **Name a default per question**, honoured ONLY for one visibly skipped while
+  others in the round were answered. Silence on a whole round is not consent.
+- **Never infer an unanswered question.** "Yeah, the first one sounds good"
+  against a three-question round answers one. Re-ask just that one.
+- **Read the set back before the first thing that costs money or time or is hard
+  to undo** — one line, every answer, while a misparse is still free.
+- **Rounds stay ≤4 questions**, with a freeform door open. Long rounds get
+  partially answered, which is the failure this protocol prevents.
+
+## House vocabulary
+
+Decide the user-facing name for each moving part before the first message and
+never introduce a second — someone taught two names for one thing assumes they
+are two things, and asks questions that have no answer. Name what a step does
+for them ("checking your answers"), not what it is built from. If they ask what
+it runs on, answer honestly: don't volunteer machinery, don't conceal it.
+
+## Teaching as you go
+
+**Deliver ONE step per message.** A walkthrough pasted as one block is a
+document that happened to land in a chat: nobody reads the middle, nobody does
+the exercises, and you learn nothing about what landed. Plan it all for
+yourself; show one beat. Every step carries a **TRY** — something the user
+actually runs or says, absent which the step is a lecture — and a **CHECK**,
+asked as a real choice question before moving on. Wrong or missing answer means
+re-teach, not advance. Check what they already have before explaining how to
+get it.
+
+## Anti-patterns
+
+- Stacking five questions into one paragraph and hoping
+- Bare "does that work?" — it invites yes and confirms nothing
+- Spending before the readback
+- Renaming a thing mid-interview because a tool's output used another word

--- a/skills/brand-kit/SKILL.md
+++ b/skills/brand-kit/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: brand-kit
+description: Use when a user wants their videos to stay visually consistent — saving caption styling, card colours and geometry, title treatment, logos, fonts, voice and CTA copy once instead of redeciding them per video.
+---
+
+# Brand Kit
+
+A look is something the USER has, not something a project has. It is reusable across every video they will ever make, so it belongs in a file — not inside one generator script, and not in your memory of this session.
+
+## Requires
+
+The preset mechanism is `scripts/styles.py` from **scrollmark/video-studio** (private). Without that script there is no `--list`, `--show`, `--apply` or `--save`, and nothing expands a preset into a storyboard — you can still agree a brand with the user and hand-write the files, but applying it becomes manual editing. `--apply` and `--save` also assume a storyboard JSON in that repo's shape.
+
+## What Ships Today: Look Presets
+
+    uv run scripts/styles.py --list
+    uv run scripts/styles.py --show tourism
+    uv run scripts/styles.py --apply tourism --storyboard <project>/storyboard.json
+    uv run scripts/styles.py --save theirs --from <project>/storyboard.json
+
+A preset is one markdown file: frontmatter (`name`, `description`), prose saying when to reach for it, and a single fenced JSON block holding the values. The JSON covers exactly two things — `captions` (colour, `stroke`, `strokeWidth`, `fontSize`, `wordGap`, `wordsPerPage`, `uppercase`, `bottom`, `palette`) and `cards`, a named role such as `label`, `stat`, `title` or `cta` mapped to `bg`, `fg`, `tracking`, `align` and a `rect`. Unknown keys are reported, not silently dropped, because a misspelled key renders as nothing and reads like a styling choice.
+
+Resolution order, first match winning: `<project>/styles/` → `$VIDEO_STUDIO_STYLES` → the user's own `~/.config/video-studio/styles/` → the presets shipped with the toolchain. The user-level directory is the load-bearing one; a preset kept in a checkout dies with the checkout.
+
+**Author cards against a role, not a colour.** Write `{"card": {"style": "label", "heading": "TOKYO"}}` and let `--apply` fill in bg, fg, tracking and rect. Anything the scene sets explicitly wins, so a one-off override never means abandoning the brand.
+
+**When a user describes a look they want, save it.** `--save` lifts the look out of a finished storyboard into a preset file, by default into their own config directory. A look that exists only in this conversation is gone tomorrow — that is the whole point of the feature. Tell them where it went and what to call it next time.
+
+Applying is an expansion step, not a render-time lookup: the storyboard ends up holding the real values, so it stays a document you can read, and editing a preset later cannot silently restyle a video that was already approved.
+
+## Title Consistency
+
+Classify every text element before layout. Do not treat all on-screen text as "titles".
+
+- **Subtitles** are narration support. They come from the voice timing files and render through `captionStyle` — the preset's `captions` block is what keeps them identical across videos. Keep them near the lower safe zone; override per scene only when artwork occupies that band.
+- **Labels** are editorial overlays: names, rankings, dates, stats, category tags, lower-thirds, CTAs. Build them as card roles so the brand owns them. Labels carry the personality — they may slide, pop, badge or frame.
+- **Signs** are in-world text objects: posters, placards, scoreboards, phone notifications. Composite them as cards. Never ask a generator for readable text; it invents letterforms.
+
+Keep contrast decisions systematic — brand-level colours, strokes, shadows and panels before per-scene exceptions. Default label motion to slide/fly-in plus scale/pop, one entrance vocabulary per brand, varying only direction, delay and intensity by scene energy. Do not mix unrelated label styles in one video; if a treatment changes, make the change narratively motivated and reuse the new treatment from that point forward.
+
+## What a Brand Bundle Would Add — PROPOSED, NOT BUILT
+
+Presets cover colour, captions and card geometry. They do not cover the rest of an identity. The proposal is a bundle directory at `~/.config/video-studio/brands/<name>/`, resolved by the same chain (`<project>/brands/` → `$VIDEO_STUDIO_BRANDS` → user → shipped) and written in the same frontmatter-plus-JSON format:
+
+- `brand.md` — the look JSON exactly as today, plus a bundle name so a user can say "use Northwind" instead of naming a colour.
+- `logo/` — wordmark and mark as SVG plus transparent PNG, with the safe-area and minimum-size rule beside them.
+- `fonts/` — the actual font files. `fontFamily` today names a face the render host may not have installed.
+- `voice.md` — narration identity: which voice, pace, and the words this brand does not say.
+- `cta.md` — the closing lines, in the two or three lengths different formats ask for.
+
+**None of that resolves today.** `styles.py` reads `captions` and `cards` and flags every other key as unknown, so a brand bundle needs new code before you can promise it. Until it exists: agree the extra pieces with the user, write them into the project, and say plainly that only captions, card colours and card geometry survive to the next video automatically.
+
+## Anti-patterns
+
+- **Redeciding the palette per video.** Three spots built by hand in one session drifted to three different label heights for the same kind of label. That drift is what the preset file prevents.
+- **Describing the brand bundle as if it works.** Logos, fonts, voice and CTA copy are a proposal. Saying "saved to your brand" when only the look persisted is a promise the next session will break.
+- **A brand that exists only in the chat.** If you did not write it to a file and name the path out loud, it is not saved.
+- **Naming a font instead of shipping it.** A `fontFamily` the render host lacks silently falls back, and the fallback is what ships.

--- a/skills/content-autopsy/SKILL.md
+++ b/skills/content-autopsy/SKILL.md
@@ -50,4 +50,4 @@ When investigating why something performed the way it did, check these in order:
 
 It's usually one or two of these, not all five. Start with the most likely culprit based on the metrics.
 
-For platform-specific metric interpretation, read the `.root` file in this skill's directory for the repo path, then load `{repo}/references/platforms/{platform}.md`.
+For platform-specific metric interpretation, load `references/platforms/{platform}.md` from this skill's own directory.

--- a/skills/content-autopsy/references/platforms/instagram.md
+++ b/skills/content-autopsy/references/platforms/instagram.md
@@ -1,0 +1,54 @@
+---
+platform: instagram
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Reels** are the primary distribution vehicle. Up to 3 minutes, 9:16 aspect ratio (1080x1920). Shorter Reels (30-90s) tend to perform better because completion rate matters.
+
+**Stories** play in 15-second segments, 9:16, and expire after 24 hours. Primarily reach existing followers. Stickers (polls, questions, sliders) boost engagement signals.
+
+**Feed posts** support 1:1 (1080x1080), 4:5 (1080x1350), and 1.91:1 (1080x566). The 4:5 ratio takes up the most screen real estate and generally outperforms.
+
+**Carousels** allow up to 20 slides mixing photos and video. Instagram re-serves carousels to users who didn't swipe the first time, giving them a second shot at reach.
+
+**Lives** are real-time, notify followers, and can be saved. **Notes** are short-form text (60 chars) that sit on DM inboxes. **Broadcast Channels** are one-to-many messaging for creator updates.
+
+## Algorithm Signals
+
+Ranked roughly by weight:
+
+1. **Sends/DM shares** -- the strongest signal right now. Content people share privately gets massive distribution.
+2. **Watch time and rewatch rate** -- especially for Reels. Completion rate matters more than raw views.
+3. **Saves** -- a strong intent signal. Instagram treats saves as high-value engagement.
+4. **Shares to Stories** -- public reshares extend reach into new follower graphs.
+5. **Comments** -- longer comments carry more weight than emoji-only replies.
+6. **Profile visits after viewing** -- indicates the content made someone curious about the creator.
+7. **Likes** -- still counted but the weakest signal relative to the others.
+
+## Audience Behavior
+
+Stories and feed posts primarily reach followers. Reels are the discovery format -- they surface to non-followers through the Reels tab, Explore page, and suggested content in the home feed.
+
+The home feed is heavily algorithmic now. Chronological feeds exist but most users stay on the default. Discovery is visual-first; text-heavy content underperforms unless it's in carousel format.
+
+## Conventions
+
+Caption length is flexible -- short and punchy works for Reels, longer storytelling works for carousels and feed posts. Hashtags have minimal impact compared to a few years ago; 3-5 relevant ones are fine, stuffing 30 does nothing useful.
+
+For Reels, the first frame is everything. You have about 1 second before someone swipes. Carousels need a strong first slide that creates curiosity to swipe. Text overlays on the first slide outperform plain images.
+
+## Comment Culture
+
+Comments function as social spaces. Common patterns: tagging friends, "send this to your..." prompts, emoji-only reactions, and short affirmations. Creator replies boost the post's engagement signals and encourage more comments. Pinning a top comment can steer the conversation and increase dwell time.
+
+## Creator Tiers
+
+**<10K:** Reels are the growth lever. A single Reel can reach 10-50x your follower count. Feed posts mostly reach existing followers. Focus on volume and iteration.
+
+**10K-100K:** Distribution becomes more consistent. Stories engagement rate matters for maintaining algorithmic favor. Carousels start performing well as the audience is invested enough to swipe.
+
+**100K-1M:** Feed posts get meaningful reach again at this level. Brand deals become viable. Algorithm rewards consistency -- gaps in posting are penalized more noticeably.
+
+**1M+:** Distribution is reliable across all formats. Lives pull large audiences. The algorithm is less make-or-break because the follower base drives baseline reach. Broadcast Channels become useful for maintaining direct audience connection.

--- a/skills/content-autopsy/references/platforms/linkedin.md
+++ b/skills/content-autopsy/references/platforms/linkedin.md
@@ -1,0 +1,32 @@
+---
+platform: linkedin
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Text posts** are the workhorse -- up to 3,000 characters, no media required. The "broetry" format dominates: one short sentence per line, lots of whitespace, reads like a motivational staircase. It works because it inflates dwell time.
+
+**Carousels/documents** are uploaded as PDFs and displayed as swipeable slides. Great for frameworks, step-by-step breakdowns, and listicles. Consistently strong reach.
+
+**Articles** are long-form blog posts hosted on LinkedIn. Lower reach than text posts but useful for SEO and credibility. **Newsletters** are recurring articles that notify subscribers directly -- solid for building a captive audience.
+
+**Video** is natively supported but still underused. LinkedIn is pushing it, so early movers get algorithmic tailwind. **Polls** drive easy engagement but are widely seen as low-effort content.
+
+## Algorithm Signals
+
+**Dwell time** is the quiet giant -- how long someone pauses on your post matters more than most people realize. **Comments** are weighted heavily, especially substantive ones. A two-sentence reply counts for far more than "Great post!" or a clap emoji. **Shares** and **reaction types** (insightful, celebrate) carry more signal than a basic like.
+
+The first hour is critical. Early engagement determines whether a post breaks out of your immediate network. The algorithm strongly favors on-platform content -- external links get suppressed.
+
+## Audience Behavior
+
+People scroll LinkedIn during work hours, often between meetings or while procrastinating. The content that performs is career lessons, industry takes, personal stories with a professional angle, and contrarian opinions. Who engages matters as much as how many -- a comment from a recognizable name amplifies reach into their network.
+
+## Conventions
+
+Only the first 2-3 lines show before the "see more" fold. That's your hook -- waste it and nobody clicks. Line breaks improve readability and boost dwell time. Common hook patterns: "I did X. Here's what happened." or agree/disagree framing that invites debate. Carousel posts work well for packaging frameworks or checklists into something swipeable.
+
+## Comment Culture
+
+Professionally toned but getting more casual. "Congrats!" under every job change is reflexive at this point. Thoughtful, specific comments get rewarded -- they surface higher and the algorithm notices. Tagging people pulls them (and their network's attention) into the conversation.

--- a/skills/content-autopsy/references/platforms/tiktok.md
+++ b/skills/content-autopsy/references/platforms/tiktok.md
@@ -1,0 +1,44 @@
+---
+platform: tiktok
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+Standard video is the backbone. Max length is 10 minutes, but the sweet spot is 15-60 seconds for most creators. Anything over 3 minutes needs a genuinely compelling hook or serialized narrative. Photo mode (carousel-style slideshows) works well for listicles and educational content. LIVE requires 1,000 followers to unlock and is where real-time community happens. Stories exist but see minimal traction compared to main feed. Series lets creators paywall multi-episode content, though adoption is still niche.
+
+Everything is 9:16. Horizontal video gets cropped or ignored.
+
+## Algorithm Signals
+
+Ranked by importance:
+
+1. **Average watch time and completion rate.** This is the single biggest factor. A 15-second video watched to the end outranks a 3-minute video abandoned at 30 seconds.
+2. **Shares.** The "send to friend" action is weighted extremely heavily. TikTok wants content that sparks private conversation.
+3. **Saves.** Signals lasting value. Tutorial and reference content benefits here.
+4. **Comments.** Volume and speed both matter. Replies from the creator boost the signal further.
+5. **Follows from the video.** Indicates the content was compelling enough to earn a subscription.
+
+The FYP is content-graph, not social-graph. Who follows you barely matters for distribution. Every video is tested on a small batch (roughly 200-500 views) and either graduates to broader distribution or dies. This is why a brand-new account can go viral on its first post.
+
+## Audience Behavior
+
+TikTok is discovery-first. The majority of views on any given video come from non-followers via the For You Page. Users aren't browsing profiles -- they're swiping a feed. The first 1-2 seconds are everything; if the hook doesn't land, they're gone.
+
+Sound is on by default, unlike Instagram. Audio choice directly affects reach. Duets and Stitches function as native reply formats and drive cross-pollination between audiences. Gen Z increasingly uses TikTok as a search engine for restaurants, product reviews, how-tos, and travel.
+
+## Conventions
+
+Text overlays are non-negotiable. Many users watch without reading captions, so key information must be on screen. Captions (the text below the video) are secondary -- used for hashtags, CTAs, or extra context, not the main message.
+
+Trending sounds provide a distribution boost but have a short shelf life. Green screen (talking over a screenshot or article) is a staple format for commentary. POV-style framing remains popular for storytelling. Serialization ("Part 1," "Part 2") drives follows and return views, especially for storytelling or drama content.
+
+## Comment Culture
+
+Comments on TikTok are a content layer, not an afterthought. Running jokes, bit-commits, and meme replies are the norm. "The comments won't disappoint" is its own genre. Pinned comments let creators extend the narrative or add corrections. Engagement bait works (asking a polarizing question, leaving an intentional mistake). Ratio culture exists but is less hostile than Twitter -- getting ratioed usually means a reply was funnier than the original.
+
+## Creator Tiers
+
+Follower count matters less on TikTok than any other major platform. An account with 500 followers can land 5 million views if the content hits. The algorithm evaluates each video independently, so consistency and trend-awareness outweigh audience size.
+
+That said, monetization thresholds exist: 10,000 followers for the Creativity Program, 1,000 for LIVE access, 100,000+ for meaningful brand deal leverage. Creators above 500K can monetize LIVE gifts at scale. But for organic reach, a small account and a large account are playing the same game.

--- a/skills/content-autopsy/references/platforms/x.md
+++ b/skills/content-autopsy/references/platforms/x.md
@@ -1,0 +1,34 @@
+---
+platform: x
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Posts** are the core unit. Free accounts get 280 characters; Premium subscribers can go up to 25,000. Most high-performing posts stay under 280 regardless -- brevity wins here.
+
+**Threads** chain posts together for longer narratives. The opener needs to stand on its own because most people won't click through. Thread openers typically end with a thread emoji (🧵) to signal there's more.
+
+**Quote posts** let you add commentary on someone else's post. They carry more weight than retweets because they add context and spark new conversations.
+
+**Spaces** are live audio rooms. Useful for real-time discussion and community building but ephemeral by default. **Polls** drive quick engagement. **Video** and **images** are supported but X remains a text-first platform -- visuals supplement the take, they don't replace it.
+
+## Algorithm Signals
+
+Engagement velocity in the first 30-60 minutes is critical. The algorithm decides early whether to push a post wider.
+
+Quote posts are weighted heavily -- they signal that your content was worth someone adding their own take. Reply depth matters; a post that sparks a long thread of genuine back-and-forth gets boosted. Bookmarks relative to likes indicate high-value content people want to revisit. Premium subscribers get a baseline distribution boost.
+
+## Audience Behavior
+
+X runs on real-time. News breaks here first, and the commentary cycle moves fast. If you're not posting while something is happening, you're late.
+
+Niche communities drive most of the value -- "Tech Twitter," "Film Twitter," "Med Twitter." Finding your pocket matters more than chasing broad reach. The culture rewards strong opinions and fast reactions over polished content.
+
+## Conventions
+
+First line is the hook. Most people see your post in a feed moving quickly, so front-load the point or the provocation. Engagement is reciprocal -- replying to others, quote-posting, and participating in conversations builds your audience faster than posting into the void.
+
+## Comment Culture
+
+Replies are fully public and function as open debate. Getting "ratioed" -- when replies or quote posts dwarf your likes -- is a form of collective social judgment. Quote posts serve as the primary commentary layer. Community Notes let users fact-check posts with crowd-sourced context. Meme replies and reaction images are a language of their own.

--- a/skills/content-autopsy/references/platforms/youtube.md
+++ b/skills/content-autopsy/references/platforms/youtube.md
@@ -1,0 +1,62 @@
+---
+platform: youtube
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Long-form video** is YouTube's core. The 8-20 minute range hits the sweet spot for mid-roll ad placements, which is where real revenue lives. Longer isn't automatically better -- you need the retention to justify the runtime.
+
+**Shorts** are vertical (9:16), under 60 seconds, and live in a completely separate feed with a separate algorithm. They drive subscribers but monetize poorly compared to long-form.
+
+**Live streams** notify subscribers and build watch time. **Premieres** combine the live chat experience with a pre-produced video. **Podcasts** are YouTube's push into audio-first content, surfaced in a dedicated tab and Google Podcasts integration.
+
+**Community posts** (text, polls, images) keep the audience engaged between uploads. Polls especially drive interaction.
+
+**Thumbnails** are a content format unto themselves. A video with a bad thumbnail doesn't get clicked, period. Custom thumbnails outperform auto-generated ones by a wide margin.
+
+## Algorithm Signals
+
+Ranked by weight for long-form:
+
+1. **Click-through rate (CTR)** -- the single most important metric. If nobody clicks, nothing else matters. 4-10% is typical; above 10% is exceptional.
+2. **Average view duration (AVD)** -- raw minutes watched. YouTube wants to keep people on the platform.
+3. **Average percentage viewed (APV)** -- how much of the video people actually watch. A 50%+ APV on a 15-minute video is strong.
+4. **Session time** -- does your video lead to more YouTube watching? Videos that start sessions get boosted hard.
+5. **Engagement velocity** -- likes, comments, and shares in the first 1-2 hours after upload.
+
+Shorts run on a separate algorithm. **Watch-through rate** (did they watch the whole thing) and **swipe-away rate** (did they leave mid-Short) are what matter. CTR is less relevant because Shorts auto-play.
+
+## Audience Behavior
+
+YouTube is intent-driven. Traffic comes from three main surfaces: **Search** (people looking for answers), **Suggested** (sidebar and end-screen recommendations), and **Browse** (home feed). Each rewards different content strategies.
+
+Attention spans are longer here than any other social platform. Viewers expect depth and will watch 10+ minutes if the content earns it. The subscribe relationship is meaningful -- subscribers get notifications and drive early view velocity that triggers broader distribution.
+
+Playlists drive binge behavior. A well-structured playlist can double session time per viewer.
+
+## Conventions
+
+**Thumbnail + title is the most important creative decision on YouTube.** Everything else is secondary. The title creates a curiosity gap; the thumbnail provides visual proof or emotional intrigue. They work as a pair -- redundancy between them wastes real estate.
+
+The **first 30 seconds** must justify the click. If the intro doesn't match what the thumbnail promised, viewers bounce and your AVD tanks.
+
+**Chapters/timestamps** improve viewer experience and show up in search results. **Cards** link to related content mid-video. **End screens** drive the next click in the last 20 seconds. All three directly influence session time.
+
+## Comment Culture
+
+YouTube comments are more substantive than short-form platforms. Viewers leave timestamps referencing specific moments, ask genuine questions, and write paragraph-length responses.
+
+Recurring patterns: "who's watching in 2026," first-commenter culture, and debates in reply threads. **Pinned comments** from the creator steer conversation and often add context to the video. **Heart reactions** from the creator are a lightweight way to acknowledge top comments. The Community tab extends this conversation between uploads.
+
+## Creator Tiers
+
+**<1K subscribers:** No access to the YouTube Partner Program. Shorts and search-optimized content are the growth path. A single video can break out regardless of subscriber count -- YouTube is less follower-gated than other platforms.
+
+**1K-10K:** Partner Program eligible (1K subs + 4K watch hours or 10M Shorts views). Ad revenue starts, but it's modest. Consistency matters -- the algorithm learns your upload cadence.
+
+**10K-100K:** Suggested traffic becomes a reliable growth engine. The algorithm has enough data on your audience to recommend your videos effectively. Sponsorships start to become meaningful income.
+
+**100K-1M:** Silver play button. Brand deals often exceed ad revenue. Your back catalog generates significant passive income. New uploads get a strong initial push from the subscriber base.
+
+**1M+:** Gold play button. Multiple revenue streams (ads, sponsors, memberships, merch shelf). The algorithm treats you as a known quantity -- even experimental content gets distribution. Premiere and live events pull large concurrent audiences.

--- a/skills/hook-anatomy/SKILL.md
+++ b/skills/hook-anatomy/SKILL.md
@@ -33,7 +33,7 @@ Three questions:
 
 ## Platform Differences
 
-Hooks work differently by platform. Read the `.root` file in this skill's directory for the repo path, then load the relevant `{repo}/references/platforms/{platform}.md`.
+Hooks work differently by platform. Load the relevant `references/platforms/{platform}.md` from this skill's own directory.
 
 Key distinction: TikTok hooks are visual + text overlay (the first frame and on-screen text do the work). Instagram Reels hooks are often spoken — the first words matter most. YouTube hooks happen *before* the video — the thumbnail and title ARE the hook. First 30 seconds then justify the click.
 

--- a/skills/hook-anatomy/references/platforms/instagram.md
+++ b/skills/hook-anatomy/references/platforms/instagram.md
@@ -1,0 +1,54 @@
+---
+platform: instagram
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Reels** are the primary distribution vehicle. Up to 3 minutes, 9:16 aspect ratio (1080x1920). Shorter Reels (30-90s) tend to perform better because completion rate matters.
+
+**Stories** play in 15-second segments, 9:16, and expire after 24 hours. Primarily reach existing followers. Stickers (polls, questions, sliders) boost engagement signals.
+
+**Feed posts** support 1:1 (1080x1080), 4:5 (1080x1350), and 1.91:1 (1080x566). The 4:5 ratio takes up the most screen real estate and generally outperforms.
+
+**Carousels** allow up to 20 slides mixing photos and video. Instagram re-serves carousels to users who didn't swipe the first time, giving them a second shot at reach.
+
+**Lives** are real-time, notify followers, and can be saved. **Notes** are short-form text (60 chars) that sit on DM inboxes. **Broadcast Channels** are one-to-many messaging for creator updates.
+
+## Algorithm Signals
+
+Ranked roughly by weight:
+
+1. **Sends/DM shares** -- the strongest signal right now. Content people share privately gets massive distribution.
+2. **Watch time and rewatch rate** -- especially for Reels. Completion rate matters more than raw views.
+3. **Saves** -- a strong intent signal. Instagram treats saves as high-value engagement.
+4. **Shares to Stories** -- public reshares extend reach into new follower graphs.
+5. **Comments** -- longer comments carry more weight than emoji-only replies.
+6. **Profile visits after viewing** -- indicates the content made someone curious about the creator.
+7. **Likes** -- still counted but the weakest signal relative to the others.
+
+## Audience Behavior
+
+Stories and feed posts primarily reach followers. Reels are the discovery format -- they surface to non-followers through the Reels tab, Explore page, and suggested content in the home feed.
+
+The home feed is heavily algorithmic now. Chronological feeds exist but most users stay on the default. Discovery is visual-first; text-heavy content underperforms unless it's in carousel format.
+
+## Conventions
+
+Caption length is flexible -- short and punchy works for Reels, longer storytelling works for carousels and feed posts. Hashtags have minimal impact compared to a few years ago; 3-5 relevant ones are fine, stuffing 30 does nothing useful.
+
+For Reels, the first frame is everything. You have about 1 second before someone swipes. Carousels need a strong first slide that creates curiosity to swipe. Text overlays on the first slide outperform plain images.
+
+## Comment Culture
+
+Comments function as social spaces. Common patterns: tagging friends, "send this to your..." prompts, emoji-only reactions, and short affirmations. Creator replies boost the post's engagement signals and encourage more comments. Pinning a top comment can steer the conversation and increase dwell time.
+
+## Creator Tiers
+
+**<10K:** Reels are the growth lever. A single Reel can reach 10-50x your follower count. Feed posts mostly reach existing followers. Focus on volume and iteration.
+
+**10K-100K:** Distribution becomes more consistent. Stories engagement rate matters for maintaining algorithmic favor. Carousels start performing well as the audience is invested enough to swipe.
+
+**100K-1M:** Feed posts get meaningful reach again at this level. Brand deals become viable. Algorithm rewards consistency -- gaps in posting are penalized more noticeably.
+
+**1M+:** Distribution is reliable across all formats. Lives pull large audiences. The algorithm is less make-or-break because the follower base drives baseline reach. Broadcast Channels become useful for maintaining direct audience connection.

--- a/skills/hook-anatomy/references/platforms/linkedin.md
+++ b/skills/hook-anatomy/references/platforms/linkedin.md
@@ -1,0 +1,32 @@
+---
+platform: linkedin
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Text posts** are the workhorse -- up to 3,000 characters, no media required. The "broetry" format dominates: one short sentence per line, lots of whitespace, reads like a motivational staircase. It works because it inflates dwell time.
+
+**Carousels/documents** are uploaded as PDFs and displayed as swipeable slides. Great for frameworks, step-by-step breakdowns, and listicles. Consistently strong reach.
+
+**Articles** are long-form blog posts hosted on LinkedIn. Lower reach than text posts but useful for SEO and credibility. **Newsletters** are recurring articles that notify subscribers directly -- solid for building a captive audience.
+
+**Video** is natively supported but still underused. LinkedIn is pushing it, so early movers get algorithmic tailwind. **Polls** drive easy engagement but are widely seen as low-effort content.
+
+## Algorithm Signals
+
+**Dwell time** is the quiet giant -- how long someone pauses on your post matters more than most people realize. **Comments** are weighted heavily, especially substantive ones. A two-sentence reply counts for far more than "Great post!" or a clap emoji. **Shares** and **reaction types** (insightful, celebrate) carry more signal than a basic like.
+
+The first hour is critical. Early engagement determines whether a post breaks out of your immediate network. The algorithm strongly favors on-platform content -- external links get suppressed.
+
+## Audience Behavior
+
+People scroll LinkedIn during work hours, often between meetings or while procrastinating. The content that performs is career lessons, industry takes, personal stories with a professional angle, and contrarian opinions. Who engages matters as much as how many -- a comment from a recognizable name amplifies reach into their network.
+
+## Conventions
+
+Only the first 2-3 lines show before the "see more" fold. That's your hook -- waste it and nobody clicks. Line breaks improve readability and boost dwell time. Common hook patterns: "I did X. Here's what happened." or agree/disagree framing that invites debate. Carousel posts work well for packaging frameworks or checklists into something swipeable.
+
+## Comment Culture
+
+Professionally toned but getting more casual. "Congrats!" under every job change is reflexive at this point. Thoughtful, specific comments get rewarded -- they surface higher and the algorithm notices. Tagging people pulls them (and their network's attention) into the conversation.

--- a/skills/hook-anatomy/references/platforms/tiktok.md
+++ b/skills/hook-anatomy/references/platforms/tiktok.md
@@ -1,0 +1,44 @@
+---
+platform: tiktok
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+Standard video is the backbone. Max length is 10 minutes, but the sweet spot is 15-60 seconds for most creators. Anything over 3 minutes needs a genuinely compelling hook or serialized narrative. Photo mode (carousel-style slideshows) works well for listicles and educational content. LIVE requires 1,000 followers to unlock and is where real-time community happens. Stories exist but see minimal traction compared to main feed. Series lets creators paywall multi-episode content, though adoption is still niche.
+
+Everything is 9:16. Horizontal video gets cropped or ignored.
+
+## Algorithm Signals
+
+Ranked by importance:
+
+1. **Average watch time and completion rate.** This is the single biggest factor. A 15-second video watched to the end outranks a 3-minute video abandoned at 30 seconds.
+2. **Shares.** The "send to friend" action is weighted extremely heavily. TikTok wants content that sparks private conversation.
+3. **Saves.** Signals lasting value. Tutorial and reference content benefits here.
+4. **Comments.** Volume and speed both matter. Replies from the creator boost the signal further.
+5. **Follows from the video.** Indicates the content was compelling enough to earn a subscription.
+
+The FYP is content-graph, not social-graph. Who follows you barely matters for distribution. Every video is tested on a small batch (roughly 200-500 views) and either graduates to broader distribution or dies. This is why a brand-new account can go viral on its first post.
+
+## Audience Behavior
+
+TikTok is discovery-first. The majority of views on any given video come from non-followers via the For You Page. Users aren't browsing profiles -- they're swiping a feed. The first 1-2 seconds are everything; if the hook doesn't land, they're gone.
+
+Sound is on by default, unlike Instagram. Audio choice directly affects reach. Duets and Stitches function as native reply formats and drive cross-pollination between audiences. Gen Z increasingly uses TikTok as a search engine for restaurants, product reviews, how-tos, and travel.
+
+## Conventions
+
+Text overlays are non-negotiable. Many users watch without reading captions, so key information must be on screen. Captions (the text below the video) are secondary -- used for hashtags, CTAs, or extra context, not the main message.
+
+Trending sounds provide a distribution boost but have a short shelf life. Green screen (talking over a screenshot or article) is a staple format for commentary. POV-style framing remains popular for storytelling. Serialization ("Part 1," "Part 2") drives follows and return views, especially for storytelling or drama content.
+
+## Comment Culture
+
+Comments on TikTok are a content layer, not an afterthought. Running jokes, bit-commits, and meme replies are the norm. "The comments won't disappoint" is its own genre. Pinned comments let creators extend the narrative or add corrections. Engagement bait works (asking a polarizing question, leaving an intentional mistake). Ratio culture exists but is less hostile than Twitter -- getting ratioed usually means a reply was funnier than the original.
+
+## Creator Tiers
+
+Follower count matters less on TikTok than any other major platform. An account with 500 followers can land 5 million views if the content hits. The algorithm evaluates each video independently, so consistency and trend-awareness outweigh audience size.
+
+That said, monetization thresholds exist: 10,000 followers for the Creativity Program, 1,000 for LIVE access, 100,000+ for meaningful brand deal leverage. Creators above 500K can monetize LIVE gifts at scale. But for organic reach, a small account and a large account are playing the same game.

--- a/skills/hook-anatomy/references/platforms/x.md
+++ b/skills/hook-anatomy/references/platforms/x.md
@@ -1,0 +1,34 @@
+---
+platform: x
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Posts** are the core unit. Free accounts get 280 characters; Premium subscribers can go up to 25,000. Most high-performing posts stay under 280 regardless -- brevity wins here.
+
+**Threads** chain posts together for longer narratives. The opener needs to stand on its own because most people won't click through. Thread openers typically end with a thread emoji (🧵) to signal there's more.
+
+**Quote posts** let you add commentary on someone else's post. They carry more weight than retweets because they add context and spark new conversations.
+
+**Spaces** are live audio rooms. Useful for real-time discussion and community building but ephemeral by default. **Polls** drive quick engagement. **Video** and **images** are supported but X remains a text-first platform -- visuals supplement the take, they don't replace it.
+
+## Algorithm Signals
+
+Engagement velocity in the first 30-60 minutes is critical. The algorithm decides early whether to push a post wider.
+
+Quote posts are weighted heavily -- they signal that your content was worth someone adding their own take. Reply depth matters; a post that sparks a long thread of genuine back-and-forth gets boosted. Bookmarks relative to likes indicate high-value content people want to revisit. Premium subscribers get a baseline distribution boost.
+
+## Audience Behavior
+
+X runs on real-time. News breaks here first, and the commentary cycle moves fast. If you're not posting while something is happening, you're late.
+
+Niche communities drive most of the value -- "Tech Twitter," "Film Twitter," "Med Twitter." Finding your pocket matters more than chasing broad reach. The culture rewards strong opinions and fast reactions over polished content.
+
+## Conventions
+
+First line is the hook. Most people see your post in a feed moving quickly, so front-load the point or the provocation. Engagement is reciprocal -- replying to others, quote-posting, and participating in conversations builds your audience faster than posting into the void.
+
+## Comment Culture
+
+Replies are fully public and function as open debate. Getting "ratioed" -- when replies or quote posts dwarf your likes -- is a form of collective social judgment. Quote posts serve as the primary commentary layer. Community Notes let users fact-check posts with crowd-sourced context. Meme replies and reaction images are a language of their own.

--- a/skills/hook-anatomy/references/platforms/youtube.md
+++ b/skills/hook-anatomy/references/platforms/youtube.md
@@ -1,0 +1,62 @@
+---
+platform: youtube
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Long-form video** is YouTube's core. The 8-20 minute range hits the sweet spot for mid-roll ad placements, which is where real revenue lives. Longer isn't automatically better -- you need the retention to justify the runtime.
+
+**Shorts** are vertical (9:16), under 60 seconds, and live in a completely separate feed with a separate algorithm. They drive subscribers but monetize poorly compared to long-form.
+
+**Live streams** notify subscribers and build watch time. **Premieres** combine the live chat experience with a pre-produced video. **Podcasts** are YouTube's push into audio-first content, surfaced in a dedicated tab and Google Podcasts integration.
+
+**Community posts** (text, polls, images) keep the audience engaged between uploads. Polls especially drive interaction.
+
+**Thumbnails** are a content format unto themselves. A video with a bad thumbnail doesn't get clicked, period. Custom thumbnails outperform auto-generated ones by a wide margin.
+
+## Algorithm Signals
+
+Ranked by weight for long-form:
+
+1. **Click-through rate (CTR)** -- the single most important metric. If nobody clicks, nothing else matters. 4-10% is typical; above 10% is exceptional.
+2. **Average view duration (AVD)** -- raw minutes watched. YouTube wants to keep people on the platform.
+3. **Average percentage viewed (APV)** -- how much of the video people actually watch. A 50%+ APV on a 15-minute video is strong.
+4. **Session time** -- does your video lead to more YouTube watching? Videos that start sessions get boosted hard.
+5. **Engagement velocity** -- likes, comments, and shares in the first 1-2 hours after upload.
+
+Shorts run on a separate algorithm. **Watch-through rate** (did they watch the whole thing) and **swipe-away rate** (did they leave mid-Short) are what matter. CTR is less relevant because Shorts auto-play.
+
+## Audience Behavior
+
+YouTube is intent-driven. Traffic comes from three main surfaces: **Search** (people looking for answers), **Suggested** (sidebar and end-screen recommendations), and **Browse** (home feed). Each rewards different content strategies.
+
+Attention spans are longer here than any other social platform. Viewers expect depth and will watch 10+ minutes if the content earns it. The subscribe relationship is meaningful -- subscribers get notifications and drive early view velocity that triggers broader distribution.
+
+Playlists drive binge behavior. A well-structured playlist can double session time per viewer.
+
+## Conventions
+
+**Thumbnail + title is the most important creative decision on YouTube.** Everything else is secondary. The title creates a curiosity gap; the thumbnail provides visual proof or emotional intrigue. They work as a pair -- redundancy between them wastes real estate.
+
+The **first 30 seconds** must justify the click. If the intro doesn't match what the thumbnail promised, viewers bounce and your AVD tanks.
+
+**Chapters/timestamps** improve viewer experience and show up in search results. **Cards** link to related content mid-video. **End screens** drive the next click in the last 20 seconds. All three directly influence session time.
+
+## Comment Culture
+
+YouTube comments are more substantive than short-form platforms. Viewers leave timestamps referencing specific moments, ask genuine questions, and write paragraph-length responses.
+
+Recurring patterns: "who's watching in 2026," first-commenter culture, and debates in reply threads. **Pinned comments** from the creator steer conversation and often add context to the video. **Heart reactions** from the creator are a lightweight way to acknowledge top comments. The Community tab extends this conversation between uploads.
+
+## Creator Tiers
+
+**<1K subscribers:** No access to the YouTube Partner Program. Shorts and search-optimized content are the growth path. A single video can break out regardless of subscriber count -- YouTube is less follower-gated than other platforms.
+
+**1K-10K:** Partner Program eligible (1K subs + 4K watch hours or 10M Shorts views). Ad revenue starts, but it's modest. Consistency matters -- the algorithm learns your upload cadence.
+
+**10K-100K:** Suggested traffic becomes a reliable growth engine. The algorithm has enough data on your audience to recommend your videos effectively. Sponsorships start to become meaningful income.
+
+**100K-1M:** Silver play button. Brand deals often exceed ad revenue. Your back catalog generates significant passive income. New uploads get a strong initial push from the subscriber base.
+
+**1M+:** Gold play button. Multiple revenue streams (ads, sponsors, memberships, merch shelf). The algorithm treats you as a known quantity -- even experimental content gets distribution. Premiere and live events pull large concurrent audiences.

--- a/skills/platform-fluency/SKILL.md
+++ b/skills/platform-fluency/SKILL.md
@@ -30,7 +30,7 @@ Platforms differ on three axes. Knowing where a platform sits on each one shapes
 
 ## When to Load References
 
-If the conversation involves a specific platform, read the `.root` file in this skill's directory for the repo path, then load `{repo}/references/platforms/{platform}.md`. If comparing platforms or adapting content across them, load both.
+If the conversation involves a specific platform, load `references/platforms/{platform}.md` from this skill's own directory. If comparing platforms or adapting content across them, load both.
 
 ## Native vs. Cross-Posted
 

--- a/skills/platform-fluency/references/platforms/instagram.md
+++ b/skills/platform-fluency/references/platforms/instagram.md
@@ -1,0 +1,54 @@
+---
+platform: instagram
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Reels** are the primary distribution vehicle. Up to 3 minutes, 9:16 aspect ratio (1080x1920). Shorter Reels (30-90s) tend to perform better because completion rate matters.
+
+**Stories** play in 15-second segments, 9:16, and expire after 24 hours. Primarily reach existing followers. Stickers (polls, questions, sliders) boost engagement signals.
+
+**Feed posts** support 1:1 (1080x1080), 4:5 (1080x1350), and 1.91:1 (1080x566). The 4:5 ratio takes up the most screen real estate and generally outperforms.
+
+**Carousels** allow up to 20 slides mixing photos and video. Instagram re-serves carousels to users who didn't swipe the first time, giving them a second shot at reach.
+
+**Lives** are real-time, notify followers, and can be saved. **Notes** are short-form text (60 chars) that sit on DM inboxes. **Broadcast Channels** are one-to-many messaging for creator updates.
+
+## Algorithm Signals
+
+Ranked roughly by weight:
+
+1. **Sends/DM shares** -- the strongest signal right now. Content people share privately gets massive distribution.
+2. **Watch time and rewatch rate** -- especially for Reels. Completion rate matters more than raw views.
+3. **Saves** -- a strong intent signal. Instagram treats saves as high-value engagement.
+4. **Shares to Stories** -- public reshares extend reach into new follower graphs.
+5. **Comments** -- longer comments carry more weight than emoji-only replies.
+6. **Profile visits after viewing** -- indicates the content made someone curious about the creator.
+7. **Likes** -- still counted but the weakest signal relative to the others.
+
+## Audience Behavior
+
+Stories and feed posts primarily reach followers. Reels are the discovery format -- they surface to non-followers through the Reels tab, Explore page, and suggested content in the home feed.
+
+The home feed is heavily algorithmic now. Chronological feeds exist but most users stay on the default. Discovery is visual-first; text-heavy content underperforms unless it's in carousel format.
+
+## Conventions
+
+Caption length is flexible -- short and punchy works for Reels, longer storytelling works for carousels and feed posts. Hashtags have minimal impact compared to a few years ago; 3-5 relevant ones are fine, stuffing 30 does nothing useful.
+
+For Reels, the first frame is everything. You have about 1 second before someone swipes. Carousels need a strong first slide that creates curiosity to swipe. Text overlays on the first slide outperform plain images.
+
+## Comment Culture
+
+Comments function as social spaces. Common patterns: tagging friends, "send this to your..." prompts, emoji-only reactions, and short affirmations. Creator replies boost the post's engagement signals and encourage more comments. Pinning a top comment can steer the conversation and increase dwell time.
+
+## Creator Tiers
+
+**<10K:** Reels are the growth lever. A single Reel can reach 10-50x your follower count. Feed posts mostly reach existing followers. Focus on volume and iteration.
+
+**10K-100K:** Distribution becomes more consistent. Stories engagement rate matters for maintaining algorithmic favor. Carousels start performing well as the audience is invested enough to swipe.
+
+**100K-1M:** Feed posts get meaningful reach again at this level. Brand deals become viable. Algorithm rewards consistency -- gaps in posting are penalized more noticeably.
+
+**1M+:** Distribution is reliable across all formats. Lives pull large audiences. The algorithm is less make-or-break because the follower base drives baseline reach. Broadcast Channels become useful for maintaining direct audience connection.

--- a/skills/platform-fluency/references/platforms/linkedin.md
+++ b/skills/platform-fluency/references/platforms/linkedin.md
@@ -1,0 +1,32 @@
+---
+platform: linkedin
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Text posts** are the workhorse -- up to 3,000 characters, no media required. The "broetry" format dominates: one short sentence per line, lots of whitespace, reads like a motivational staircase. It works because it inflates dwell time.
+
+**Carousels/documents** are uploaded as PDFs and displayed as swipeable slides. Great for frameworks, step-by-step breakdowns, and listicles. Consistently strong reach.
+
+**Articles** are long-form blog posts hosted on LinkedIn. Lower reach than text posts but useful for SEO and credibility. **Newsletters** are recurring articles that notify subscribers directly -- solid for building a captive audience.
+
+**Video** is natively supported but still underused. LinkedIn is pushing it, so early movers get algorithmic tailwind. **Polls** drive easy engagement but are widely seen as low-effort content.
+
+## Algorithm Signals
+
+**Dwell time** is the quiet giant -- how long someone pauses on your post matters more than most people realize. **Comments** are weighted heavily, especially substantive ones. A two-sentence reply counts for far more than "Great post!" or a clap emoji. **Shares** and **reaction types** (insightful, celebrate) carry more signal than a basic like.
+
+The first hour is critical. Early engagement determines whether a post breaks out of your immediate network. The algorithm strongly favors on-platform content -- external links get suppressed.
+
+## Audience Behavior
+
+People scroll LinkedIn during work hours, often between meetings or while procrastinating. The content that performs is career lessons, industry takes, personal stories with a professional angle, and contrarian opinions. Who engages matters as much as how many -- a comment from a recognizable name amplifies reach into their network.
+
+## Conventions
+
+Only the first 2-3 lines show before the "see more" fold. That's your hook -- waste it and nobody clicks. Line breaks improve readability and boost dwell time. Common hook patterns: "I did X. Here's what happened." or agree/disagree framing that invites debate. Carousel posts work well for packaging frameworks or checklists into something swipeable.
+
+## Comment Culture
+
+Professionally toned but getting more casual. "Congrats!" under every job change is reflexive at this point. Thoughtful, specific comments get rewarded -- they surface higher and the algorithm notices. Tagging people pulls them (and their network's attention) into the conversation.

--- a/skills/platform-fluency/references/platforms/tiktok.md
+++ b/skills/platform-fluency/references/platforms/tiktok.md
@@ -1,0 +1,44 @@
+---
+platform: tiktok
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+Standard video is the backbone. Max length is 10 minutes, but the sweet spot is 15-60 seconds for most creators. Anything over 3 minutes needs a genuinely compelling hook or serialized narrative. Photo mode (carousel-style slideshows) works well for listicles and educational content. LIVE requires 1,000 followers to unlock and is where real-time community happens. Stories exist but see minimal traction compared to main feed. Series lets creators paywall multi-episode content, though adoption is still niche.
+
+Everything is 9:16. Horizontal video gets cropped or ignored.
+
+## Algorithm Signals
+
+Ranked by importance:
+
+1. **Average watch time and completion rate.** This is the single biggest factor. A 15-second video watched to the end outranks a 3-minute video abandoned at 30 seconds.
+2. **Shares.** The "send to friend" action is weighted extremely heavily. TikTok wants content that sparks private conversation.
+3. **Saves.** Signals lasting value. Tutorial and reference content benefits here.
+4. **Comments.** Volume and speed both matter. Replies from the creator boost the signal further.
+5. **Follows from the video.** Indicates the content was compelling enough to earn a subscription.
+
+The FYP is content-graph, not social-graph. Who follows you barely matters for distribution. Every video is tested on a small batch (roughly 200-500 views) and either graduates to broader distribution or dies. This is why a brand-new account can go viral on its first post.
+
+## Audience Behavior
+
+TikTok is discovery-first. The majority of views on any given video come from non-followers via the For You Page. Users aren't browsing profiles -- they're swiping a feed. The first 1-2 seconds are everything; if the hook doesn't land, they're gone.
+
+Sound is on by default, unlike Instagram. Audio choice directly affects reach. Duets and Stitches function as native reply formats and drive cross-pollination between audiences. Gen Z increasingly uses TikTok as a search engine for restaurants, product reviews, how-tos, and travel.
+
+## Conventions
+
+Text overlays are non-negotiable. Many users watch without reading captions, so key information must be on screen. Captions (the text below the video) are secondary -- used for hashtags, CTAs, or extra context, not the main message.
+
+Trending sounds provide a distribution boost but have a short shelf life. Green screen (talking over a screenshot or article) is a staple format for commentary. POV-style framing remains popular for storytelling. Serialization ("Part 1," "Part 2") drives follows and return views, especially for storytelling or drama content.
+
+## Comment Culture
+
+Comments on TikTok are a content layer, not an afterthought. Running jokes, bit-commits, and meme replies are the norm. "The comments won't disappoint" is its own genre. Pinned comments let creators extend the narrative or add corrections. Engagement bait works (asking a polarizing question, leaving an intentional mistake). Ratio culture exists but is less hostile than Twitter -- getting ratioed usually means a reply was funnier than the original.
+
+## Creator Tiers
+
+Follower count matters less on TikTok than any other major platform. An account with 500 followers can land 5 million views if the content hits. The algorithm evaluates each video independently, so consistency and trend-awareness outweigh audience size.
+
+That said, monetization thresholds exist: 10,000 followers for the Creativity Program, 1,000 for LIVE access, 100,000+ for meaningful brand deal leverage. Creators above 500K can monetize LIVE gifts at scale. But for organic reach, a small account and a large account are playing the same game.

--- a/skills/platform-fluency/references/platforms/x.md
+++ b/skills/platform-fluency/references/platforms/x.md
@@ -1,0 +1,34 @@
+---
+platform: x
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Posts** are the core unit. Free accounts get 280 characters; Premium subscribers can go up to 25,000. Most high-performing posts stay under 280 regardless -- brevity wins here.
+
+**Threads** chain posts together for longer narratives. The opener needs to stand on its own because most people won't click through. Thread openers typically end with a thread emoji (🧵) to signal there's more.
+
+**Quote posts** let you add commentary on someone else's post. They carry more weight than retweets because they add context and spark new conversations.
+
+**Spaces** are live audio rooms. Useful for real-time discussion and community building but ephemeral by default. **Polls** drive quick engagement. **Video** and **images** are supported but X remains a text-first platform -- visuals supplement the take, they don't replace it.
+
+## Algorithm Signals
+
+Engagement velocity in the first 30-60 minutes is critical. The algorithm decides early whether to push a post wider.
+
+Quote posts are weighted heavily -- they signal that your content was worth someone adding their own take. Reply depth matters; a post that sparks a long thread of genuine back-and-forth gets boosted. Bookmarks relative to likes indicate high-value content people want to revisit. Premium subscribers get a baseline distribution boost.
+
+## Audience Behavior
+
+X runs on real-time. News breaks here first, and the commentary cycle moves fast. If you're not posting while something is happening, you're late.
+
+Niche communities drive most of the value -- "Tech Twitter," "Film Twitter," "Med Twitter." Finding your pocket matters more than chasing broad reach. The culture rewards strong opinions and fast reactions over polished content.
+
+## Conventions
+
+First line is the hook. Most people see your post in a feed moving quickly, so front-load the point or the provocation. Engagement is reciprocal -- replying to others, quote-posting, and participating in conversations builds your audience faster than posting into the void.
+
+## Comment Culture
+
+Replies are fully public and function as open debate. Getting "ratioed" -- when replies or quote posts dwarf your likes -- is a form of collective social judgment. Quote posts serve as the primary commentary layer. Community Notes let users fact-check posts with crowd-sourced context. Meme replies and reaction images are a language of their own.

--- a/skills/platform-fluency/references/platforms/youtube.md
+++ b/skills/platform-fluency/references/platforms/youtube.md
@@ -1,0 +1,62 @@
+---
+platform: youtube
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Long-form video** is YouTube's core. The 8-20 minute range hits the sweet spot for mid-roll ad placements, which is where real revenue lives. Longer isn't automatically better -- you need the retention to justify the runtime.
+
+**Shorts** are vertical (9:16), under 60 seconds, and live in a completely separate feed with a separate algorithm. They drive subscribers but monetize poorly compared to long-form.
+
+**Live streams** notify subscribers and build watch time. **Premieres** combine the live chat experience with a pre-produced video. **Podcasts** are YouTube's push into audio-first content, surfaced in a dedicated tab and Google Podcasts integration.
+
+**Community posts** (text, polls, images) keep the audience engaged between uploads. Polls especially drive interaction.
+
+**Thumbnails** are a content format unto themselves. A video with a bad thumbnail doesn't get clicked, period. Custom thumbnails outperform auto-generated ones by a wide margin.
+
+## Algorithm Signals
+
+Ranked by weight for long-form:
+
+1. **Click-through rate (CTR)** -- the single most important metric. If nobody clicks, nothing else matters. 4-10% is typical; above 10% is exceptional.
+2. **Average view duration (AVD)** -- raw minutes watched. YouTube wants to keep people on the platform.
+3. **Average percentage viewed (APV)** -- how much of the video people actually watch. A 50%+ APV on a 15-minute video is strong.
+4. **Session time** -- does your video lead to more YouTube watching? Videos that start sessions get boosted hard.
+5. **Engagement velocity** -- likes, comments, and shares in the first 1-2 hours after upload.
+
+Shorts run on a separate algorithm. **Watch-through rate** (did they watch the whole thing) and **swipe-away rate** (did they leave mid-Short) are what matter. CTR is less relevant because Shorts auto-play.
+
+## Audience Behavior
+
+YouTube is intent-driven. Traffic comes from three main surfaces: **Search** (people looking for answers), **Suggested** (sidebar and end-screen recommendations), and **Browse** (home feed). Each rewards different content strategies.
+
+Attention spans are longer here than any other social platform. Viewers expect depth and will watch 10+ minutes if the content earns it. The subscribe relationship is meaningful -- subscribers get notifications and drive early view velocity that triggers broader distribution.
+
+Playlists drive binge behavior. A well-structured playlist can double session time per viewer.
+
+## Conventions
+
+**Thumbnail + title is the most important creative decision on YouTube.** Everything else is secondary. The title creates a curiosity gap; the thumbnail provides visual proof or emotional intrigue. They work as a pair -- redundancy between them wastes real estate.
+
+The **first 30 seconds** must justify the click. If the intro doesn't match what the thumbnail promised, viewers bounce and your AVD tanks.
+
+**Chapters/timestamps** improve viewer experience and show up in search results. **Cards** link to related content mid-video. **End screens** drive the next click in the last 20 seconds. All three directly influence session time.
+
+## Comment Culture
+
+YouTube comments are more substantive than short-form platforms. Viewers leave timestamps referencing specific moments, ask genuine questions, and write paragraph-length responses.
+
+Recurring patterns: "who's watching in 2026," first-commenter culture, and debates in reply threads. **Pinned comments** from the creator steer conversation and often add context to the video. **Heart reactions** from the creator are a lightweight way to acknowledge top comments. The Community tab extends this conversation between uploads.
+
+## Creator Tiers
+
+**<1K subscribers:** No access to the YouTube Partner Program. Shorts and search-optimized content are the growth path. A single video can break out regardless of subscriber count -- YouTube is less follower-gated than other platforms.
+
+**1K-10K:** Partner Program eligible (1K subs + 4K watch hours or 10M Shorts views). Ad revenue starts, but it's modest. Consistency matters -- the algorithm learns your upload cadence.
+
+**10K-100K:** Suggested traffic becomes a reliable growth engine. The algorithm has enough data on your audience to recommend your videos effectively. Sponsorships start to become meaningful income.
+
+**100K-1M:** Silver play button. Brand deals often exceed ad revenue. Your back catalog generates significant passive income. New uploads get a strong initial push from the subscriber base.
+
+**1M+:** Gold play button. Multiple revenue streams (ads, sponsors, memberships, merch shelf). The algorithm treats you as a known quantity -- even experimental content gets distribution. Premiere and live events pull large concurrent audiences.

--- a/skills/read-the-room/SKILL.md
+++ b/skills/read-the-room/SKILL.md
@@ -51,7 +51,7 @@ Context matters: who's talking to whom, what's the post about, what platform is 
 
 ## When to Load References
 
-If you encounter unfamiliar slang or emoji usage, read the `.root` file in this skill's directory for the repo path, then read `{repo}/references/slang-and-signals.md`. For platform-specific comment culture, read `{repo}/references/platforms/{platform}.md`. If the references can't be loaded, work with the patterns above and note the gap to the user.
+If you encounter unfamiliar slang or emoji usage, read `references/slang-and-signals.md` from this skill's own directory. For platform-specific comment culture, read `references/platforms/{platform}.md` from this skill's own directory. If the references can't be loaded, work with the patterns above and note the gap to the user.
 
 ## Anti-patterns
 

--- a/skills/read-the-room/references/platforms/instagram.md
+++ b/skills/read-the-room/references/platforms/instagram.md
@@ -1,0 +1,54 @@
+---
+platform: instagram
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Reels** are the primary distribution vehicle. Up to 3 minutes, 9:16 aspect ratio (1080x1920). Shorter Reels (30-90s) tend to perform better because completion rate matters.
+
+**Stories** play in 15-second segments, 9:16, and expire after 24 hours. Primarily reach existing followers. Stickers (polls, questions, sliders) boost engagement signals.
+
+**Feed posts** support 1:1 (1080x1080), 4:5 (1080x1350), and 1.91:1 (1080x566). The 4:5 ratio takes up the most screen real estate and generally outperforms.
+
+**Carousels** allow up to 20 slides mixing photos and video. Instagram re-serves carousels to users who didn't swipe the first time, giving them a second shot at reach.
+
+**Lives** are real-time, notify followers, and can be saved. **Notes** are short-form text (60 chars) that sit on DM inboxes. **Broadcast Channels** are one-to-many messaging for creator updates.
+
+## Algorithm Signals
+
+Ranked roughly by weight:
+
+1. **Sends/DM shares** -- the strongest signal right now. Content people share privately gets massive distribution.
+2. **Watch time and rewatch rate** -- especially for Reels. Completion rate matters more than raw views.
+3. **Saves** -- a strong intent signal. Instagram treats saves as high-value engagement.
+4. **Shares to Stories** -- public reshares extend reach into new follower graphs.
+5. **Comments** -- longer comments carry more weight than emoji-only replies.
+6. **Profile visits after viewing** -- indicates the content made someone curious about the creator.
+7. **Likes** -- still counted but the weakest signal relative to the others.
+
+## Audience Behavior
+
+Stories and feed posts primarily reach followers. Reels are the discovery format -- they surface to non-followers through the Reels tab, Explore page, and suggested content in the home feed.
+
+The home feed is heavily algorithmic now. Chronological feeds exist but most users stay on the default. Discovery is visual-first; text-heavy content underperforms unless it's in carousel format.
+
+## Conventions
+
+Caption length is flexible -- short and punchy works for Reels, longer storytelling works for carousels and feed posts. Hashtags have minimal impact compared to a few years ago; 3-5 relevant ones are fine, stuffing 30 does nothing useful.
+
+For Reels, the first frame is everything. You have about 1 second before someone swipes. Carousels need a strong first slide that creates curiosity to swipe. Text overlays on the first slide outperform plain images.
+
+## Comment Culture
+
+Comments function as social spaces. Common patterns: tagging friends, "send this to your..." prompts, emoji-only reactions, and short affirmations. Creator replies boost the post's engagement signals and encourage more comments. Pinning a top comment can steer the conversation and increase dwell time.
+
+## Creator Tiers
+
+**<10K:** Reels are the growth lever. A single Reel can reach 10-50x your follower count. Feed posts mostly reach existing followers. Focus on volume and iteration.
+
+**10K-100K:** Distribution becomes more consistent. Stories engagement rate matters for maintaining algorithmic favor. Carousels start performing well as the audience is invested enough to swipe.
+
+**100K-1M:** Feed posts get meaningful reach again at this level. Brand deals become viable. Algorithm rewards consistency -- gaps in posting are penalized more noticeably.
+
+**1M+:** Distribution is reliable across all formats. Lives pull large audiences. The algorithm is less make-or-break because the follower base drives baseline reach. Broadcast Channels become useful for maintaining direct audience connection.

--- a/skills/read-the-room/references/platforms/linkedin.md
+++ b/skills/read-the-room/references/platforms/linkedin.md
@@ -1,0 +1,32 @@
+---
+platform: linkedin
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Text posts** are the workhorse -- up to 3,000 characters, no media required. The "broetry" format dominates: one short sentence per line, lots of whitespace, reads like a motivational staircase. It works because it inflates dwell time.
+
+**Carousels/documents** are uploaded as PDFs and displayed as swipeable slides. Great for frameworks, step-by-step breakdowns, and listicles. Consistently strong reach.
+
+**Articles** are long-form blog posts hosted on LinkedIn. Lower reach than text posts but useful for SEO and credibility. **Newsletters** are recurring articles that notify subscribers directly -- solid for building a captive audience.
+
+**Video** is natively supported but still underused. LinkedIn is pushing it, so early movers get algorithmic tailwind. **Polls** drive easy engagement but are widely seen as low-effort content.
+
+## Algorithm Signals
+
+**Dwell time** is the quiet giant -- how long someone pauses on your post matters more than most people realize. **Comments** are weighted heavily, especially substantive ones. A two-sentence reply counts for far more than "Great post!" or a clap emoji. **Shares** and **reaction types** (insightful, celebrate) carry more signal than a basic like.
+
+The first hour is critical. Early engagement determines whether a post breaks out of your immediate network. The algorithm strongly favors on-platform content -- external links get suppressed.
+
+## Audience Behavior
+
+People scroll LinkedIn during work hours, often between meetings or while procrastinating. The content that performs is career lessons, industry takes, personal stories with a professional angle, and contrarian opinions. Who engages matters as much as how many -- a comment from a recognizable name amplifies reach into their network.
+
+## Conventions
+
+Only the first 2-3 lines show before the "see more" fold. That's your hook -- waste it and nobody clicks. Line breaks improve readability and boost dwell time. Common hook patterns: "I did X. Here's what happened." or agree/disagree framing that invites debate. Carousel posts work well for packaging frameworks or checklists into something swipeable.
+
+## Comment Culture
+
+Professionally toned but getting more casual. "Congrats!" under every job change is reflexive at this point. Thoughtful, specific comments get rewarded -- they surface higher and the algorithm notices. Tagging people pulls them (and their network's attention) into the conversation.

--- a/skills/read-the-room/references/platforms/tiktok.md
+++ b/skills/read-the-room/references/platforms/tiktok.md
@@ -1,0 +1,44 @@
+---
+platform: tiktok
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+Standard video is the backbone. Max length is 10 minutes, but the sweet spot is 15-60 seconds for most creators. Anything over 3 minutes needs a genuinely compelling hook or serialized narrative. Photo mode (carousel-style slideshows) works well for listicles and educational content. LIVE requires 1,000 followers to unlock and is where real-time community happens. Stories exist but see minimal traction compared to main feed. Series lets creators paywall multi-episode content, though adoption is still niche.
+
+Everything is 9:16. Horizontal video gets cropped or ignored.
+
+## Algorithm Signals
+
+Ranked by importance:
+
+1. **Average watch time and completion rate.** This is the single biggest factor. A 15-second video watched to the end outranks a 3-minute video abandoned at 30 seconds.
+2. **Shares.** The "send to friend" action is weighted extremely heavily. TikTok wants content that sparks private conversation.
+3. **Saves.** Signals lasting value. Tutorial and reference content benefits here.
+4. **Comments.** Volume and speed both matter. Replies from the creator boost the signal further.
+5. **Follows from the video.** Indicates the content was compelling enough to earn a subscription.
+
+The FYP is content-graph, not social-graph. Who follows you barely matters for distribution. Every video is tested on a small batch (roughly 200-500 views) and either graduates to broader distribution or dies. This is why a brand-new account can go viral on its first post.
+
+## Audience Behavior
+
+TikTok is discovery-first. The majority of views on any given video come from non-followers via the For You Page. Users aren't browsing profiles -- they're swiping a feed. The first 1-2 seconds are everything; if the hook doesn't land, they're gone.
+
+Sound is on by default, unlike Instagram. Audio choice directly affects reach. Duets and Stitches function as native reply formats and drive cross-pollination between audiences. Gen Z increasingly uses TikTok as a search engine for restaurants, product reviews, how-tos, and travel.
+
+## Conventions
+
+Text overlays are non-negotiable. Many users watch without reading captions, so key information must be on screen. Captions (the text below the video) are secondary -- used for hashtags, CTAs, or extra context, not the main message.
+
+Trending sounds provide a distribution boost but have a short shelf life. Green screen (talking over a screenshot or article) is a staple format for commentary. POV-style framing remains popular for storytelling. Serialization ("Part 1," "Part 2") drives follows and return views, especially for storytelling or drama content.
+
+## Comment Culture
+
+Comments on TikTok are a content layer, not an afterthought. Running jokes, bit-commits, and meme replies are the norm. "The comments won't disappoint" is its own genre. Pinned comments let creators extend the narrative or add corrections. Engagement bait works (asking a polarizing question, leaving an intentional mistake). Ratio culture exists but is less hostile than Twitter -- getting ratioed usually means a reply was funnier than the original.
+
+## Creator Tiers
+
+Follower count matters less on TikTok than any other major platform. An account with 500 followers can land 5 million views if the content hits. The algorithm evaluates each video independently, so consistency and trend-awareness outweigh audience size.
+
+That said, monetization thresholds exist: 10,000 followers for the Creativity Program, 1,000 for LIVE access, 100,000+ for meaningful brand deal leverage. Creators above 500K can monetize LIVE gifts at scale. But for organic reach, a small account and a large account are playing the same game.

--- a/skills/read-the-room/references/platforms/x.md
+++ b/skills/read-the-room/references/platforms/x.md
@@ -1,0 +1,34 @@
+---
+platform: x
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Posts** are the core unit. Free accounts get 280 characters; Premium subscribers can go up to 25,000. Most high-performing posts stay under 280 regardless -- brevity wins here.
+
+**Threads** chain posts together for longer narratives. The opener needs to stand on its own because most people won't click through. Thread openers typically end with a thread emoji (🧵) to signal there's more.
+
+**Quote posts** let you add commentary on someone else's post. They carry more weight than retweets because they add context and spark new conversations.
+
+**Spaces** are live audio rooms. Useful for real-time discussion and community building but ephemeral by default. **Polls** drive quick engagement. **Video** and **images** are supported but X remains a text-first platform -- visuals supplement the take, they don't replace it.
+
+## Algorithm Signals
+
+Engagement velocity in the first 30-60 minutes is critical. The algorithm decides early whether to push a post wider.
+
+Quote posts are weighted heavily -- they signal that your content was worth someone adding their own take. Reply depth matters; a post that sparks a long thread of genuine back-and-forth gets boosted. Bookmarks relative to likes indicate high-value content people want to revisit. Premium subscribers get a baseline distribution boost.
+
+## Audience Behavior
+
+X runs on real-time. News breaks here first, and the commentary cycle moves fast. If you're not posting while something is happening, you're late.
+
+Niche communities drive most of the value -- "Tech Twitter," "Film Twitter," "Med Twitter." Finding your pocket matters more than chasing broad reach. The culture rewards strong opinions and fast reactions over polished content.
+
+## Conventions
+
+First line is the hook. Most people see your post in a feed moving quickly, so front-load the point or the provocation. Engagement is reciprocal -- replying to others, quote-posting, and participating in conversations builds your audience faster than posting into the void.
+
+## Comment Culture
+
+Replies are fully public and function as open debate. Getting "ratioed" -- when replies or quote posts dwarf your likes -- is a form of collective social judgment. Quote posts serve as the primary commentary layer. Community Notes let users fact-check posts with crowd-sourced context. Meme replies and reaction images are a language of their own.

--- a/skills/read-the-room/references/platforms/youtube.md
+++ b/skills/read-the-room/references/platforms/youtube.md
@@ -1,0 +1,62 @@
+---
+platform: youtube
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Long-form video** is YouTube's core. The 8-20 minute range hits the sweet spot for mid-roll ad placements, which is where real revenue lives. Longer isn't automatically better -- you need the retention to justify the runtime.
+
+**Shorts** are vertical (9:16), under 60 seconds, and live in a completely separate feed with a separate algorithm. They drive subscribers but monetize poorly compared to long-form.
+
+**Live streams** notify subscribers and build watch time. **Premieres** combine the live chat experience with a pre-produced video. **Podcasts** are YouTube's push into audio-first content, surfaced in a dedicated tab and Google Podcasts integration.
+
+**Community posts** (text, polls, images) keep the audience engaged between uploads. Polls especially drive interaction.
+
+**Thumbnails** are a content format unto themselves. A video with a bad thumbnail doesn't get clicked, period. Custom thumbnails outperform auto-generated ones by a wide margin.
+
+## Algorithm Signals
+
+Ranked by weight for long-form:
+
+1. **Click-through rate (CTR)** -- the single most important metric. If nobody clicks, nothing else matters. 4-10% is typical; above 10% is exceptional.
+2. **Average view duration (AVD)** -- raw minutes watched. YouTube wants to keep people on the platform.
+3. **Average percentage viewed (APV)** -- how much of the video people actually watch. A 50%+ APV on a 15-minute video is strong.
+4. **Session time** -- does your video lead to more YouTube watching? Videos that start sessions get boosted hard.
+5. **Engagement velocity** -- likes, comments, and shares in the first 1-2 hours after upload.
+
+Shorts run on a separate algorithm. **Watch-through rate** (did they watch the whole thing) and **swipe-away rate** (did they leave mid-Short) are what matter. CTR is less relevant because Shorts auto-play.
+
+## Audience Behavior
+
+YouTube is intent-driven. Traffic comes from three main surfaces: **Search** (people looking for answers), **Suggested** (sidebar and end-screen recommendations), and **Browse** (home feed). Each rewards different content strategies.
+
+Attention spans are longer here than any other social platform. Viewers expect depth and will watch 10+ minutes if the content earns it. The subscribe relationship is meaningful -- subscribers get notifications and drive early view velocity that triggers broader distribution.
+
+Playlists drive binge behavior. A well-structured playlist can double session time per viewer.
+
+## Conventions
+
+**Thumbnail + title is the most important creative decision on YouTube.** Everything else is secondary. The title creates a curiosity gap; the thumbnail provides visual proof or emotional intrigue. They work as a pair -- redundancy between them wastes real estate.
+
+The **first 30 seconds** must justify the click. If the intro doesn't match what the thumbnail promised, viewers bounce and your AVD tanks.
+
+**Chapters/timestamps** improve viewer experience and show up in search results. **Cards** link to related content mid-video. **End screens** drive the next click in the last 20 seconds. All three directly influence session time.
+
+## Comment Culture
+
+YouTube comments are more substantive than short-form platforms. Viewers leave timestamps referencing specific moments, ask genuine questions, and write paragraph-length responses.
+
+Recurring patterns: "who's watching in 2026," first-commenter culture, and debates in reply threads. **Pinned comments** from the creator steer conversation and often add context to the video. **Heart reactions** from the creator are a lightweight way to acknowledge top comments. The Community tab extends this conversation between uploads.
+
+## Creator Tiers
+
+**<1K subscribers:** No access to the YouTube Partner Program. Shorts and search-optimized content are the growth path. A single video can break out regardless of subscriber count -- YouTube is less follower-gated than other platforms.
+
+**1K-10K:** Partner Program eligible (1K subs + 4K watch hours or 10M Shorts views). Ad revenue starts, but it's modest. Consistency matters -- the algorithm learns your upload cadence.
+
+**10K-100K:** Suggested traffic becomes a reliable growth engine. The algorithm has enough data on your audience to recommend your videos effectively. Sponsorships start to become meaningful income.
+
+**100K-1M:** Silver play button. Brand deals often exceed ad revenue. Your back catalog generates significant passive income. New uploads get a strong initial push from the subscriber base.
+
+**1M+:** Gold play button. Multiple revenue streams (ads, sponsors, memberships, merch shelf). The algorithm treats you as a known quantity -- even experimental content gets distribution. Premiere and live events pull large concurrent audiences.

--- a/skills/read-the-room/references/slang-and-signals.md
+++ b/skills/read-the-room/references/slang-and-signals.md
@@ -1,0 +1,69 @@
+---
+last_updated: 2026-03-17
+version: 1
+---
+
+Snapshot of how language works on social media as of the date above. Terms peak, shift, and die within months. When something here feels outdated, flag it to the user rather than assuming it holds.
+
+## Intensity Modifiers
+
+**lowkey / highkey** — Degree markers. "Lowkey obsessed" = genuinely obsessed but downplaying it. "Highkey" drops the pretense. Careful: "lowkey" almost never means mild — it's strong interest with plausible deniability.
+
+**literally / actually** — Pure emphasis, not literal truth. "I literally cannot" = "this is affecting me." Never interpret as factual claims.
+
+**fr / for real / deadass / no cap** — Sincerity markers, escalating intensity. "Fr" = casual agreement. "Deadass" and "no cap" = "I am not joking." Careful: overused "no cap" reads ironic.
+
+**valid** — Affirms someone's opinion or feelings. "That take is valid" = "I respect that." Rarely misread.
+
+**ate / slay** — Performance praise. "She ate that" = executed perfectly. "Slay" is broader approval. Careful: both can be sarcastic — context matters.
+
+## Death and Violence as Humor
+
+"I'm dead," "I'm screaming," "that took me out," "I can't breathe," "bury me" — all mean something is extremely funny. Not distress. "Slay" and "killed it" are compliments. Careful: "I can't breathe" is almost always humor, but post-2020, read the room.
+
+## Abbreviations as Tone Markers
+
+**ngl** (not gonna lie) — Incoming honesty, soft opinion. **tbh** — Same energy, more casual. **fr** — Agreement or emphasis. **imo/imho** — Hedging a hot take. **iykyk** (if you know you know) — In-group signal, deliberately excludes outsiders. **istg** (I swear to god) — Frustration or emphasis. **smh** (shaking my head) — Disapproval. **nvm** — Withdrawal, often passive-aggressive.
+
+Careful: these set tone more than they save keystrokes. "Ngl that's mid" is a different sentence without the "ngl."
+
+## Emoji as Grammar
+
+These function as punctuation, not decoration:
+
+- 💀 — Laughing so hard I'm dead. The modern "lol."
+- 😭 — Funny OR genuinely sad. Check what it's replying to.
+- 👀 — Interest, drama, "I see this."
+- 🔥 — Approval.
+- ✨ — Positive emphasis, BUT around a word (✨boundaries✨) it's sarcastic.
+- 🫠 — Overwhelmed, melting, barely coping.
+- 💅 — Unbothered, sassy, "and what about it."
+- 🤡 — Self-deprecation or calling someone foolish.
+- 😮‍💨 — Relief or exasperation, context-dependent.
+- 🚩 / 🟢 — Red flag / green flag. Evaluates people, behaviors, situations.
+
+## Generational Markers
+
+**"understood the assignment"** — Millennial-coded. Means someone nailed it. Still used but aging.
+
+**"very demure, very mindful"** — Gen Z trend from mid-2025. Satirical modesty, now ironic. Already fading — may read as dated.
+
+**"it's giving..."** — Gen Z core. "It's giving main character" = "this radiates that energy." Left unfinished ("it's giving...") implies something negative.
+
+**"main character energy"** — Crossover term. Aspirational or a roast depending on delivery.
+
+**"that's so coded"** — Gen Alpha emerging. Means something strongly signals a particular identity or vibe. Still unstable.
+
+## Reclaimed and Shifted Terms
+
+**unhinged** — Positive. Authentic, chaotic, entertaining. "Her response was unhinged" = compliment. Careful: still negative in serious discussions.
+
+**delulu** — From "delusional." Aspirational self-delusion, manifesting through denial. Can be affectionate or genuinely critical.
+
+**brainrot** — Overconsumption of internet content to where it affects your speech. Sometimes a badge of honor, sometimes genuine concern.
+
+**cooked** — Done for, ruined, finished. "He's cooked" = no recovery. Careful: occasionally positive in gaming, but usually negative.
+
+**ate and left no crumbs** — Did something perfectly with nothing to criticize. Pure praise.
+
+**gaslight gatekeep girlboss** — Ironic inversion of girlboss feminism. Always satirical, never sincere — meme format, not a value statement.

--- a/skills/repurpose-engine/SKILL.md
+++ b/skills/repurpose-engine/SKILL.md
@@ -23,7 +23,7 @@ For each target platform, run through these:
 
 **Audience context** — the same person on LinkedIn and TikTok wants different things from the same topic. Professional framing for LinkedIn. Entertainment framing for TikTok. Educational framing for YouTube. The core insight can be identical — the packaging changes.
 
-**Convention check** — load the target platform's reference file (read `.root` for repo path, then `{repo}/references/platforms/{platform}.md`). Does the adapted version feel native? Would someone scrolling past think "this was made for this platform"?
+**Convention check** — load the target platform's reference file `references/platforms/{platform}.md` from this skill's own directory. Does the adapted version feel native? Would someone scrolling past think "this was made for this platform"?
 
 ## Repurposing Hierarchy
 

--- a/skills/repurpose-engine/references/platforms/instagram.md
+++ b/skills/repurpose-engine/references/platforms/instagram.md
@@ -1,0 +1,54 @@
+---
+platform: instagram
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Reels** are the primary distribution vehicle. Up to 3 minutes, 9:16 aspect ratio (1080x1920). Shorter Reels (30-90s) tend to perform better because completion rate matters.
+
+**Stories** play in 15-second segments, 9:16, and expire after 24 hours. Primarily reach existing followers. Stickers (polls, questions, sliders) boost engagement signals.
+
+**Feed posts** support 1:1 (1080x1080), 4:5 (1080x1350), and 1.91:1 (1080x566). The 4:5 ratio takes up the most screen real estate and generally outperforms.
+
+**Carousels** allow up to 20 slides mixing photos and video. Instagram re-serves carousels to users who didn't swipe the first time, giving them a second shot at reach.
+
+**Lives** are real-time, notify followers, and can be saved. **Notes** are short-form text (60 chars) that sit on DM inboxes. **Broadcast Channels** are one-to-many messaging for creator updates.
+
+## Algorithm Signals
+
+Ranked roughly by weight:
+
+1. **Sends/DM shares** -- the strongest signal right now. Content people share privately gets massive distribution.
+2. **Watch time and rewatch rate** -- especially for Reels. Completion rate matters more than raw views.
+3. **Saves** -- a strong intent signal. Instagram treats saves as high-value engagement.
+4. **Shares to Stories** -- public reshares extend reach into new follower graphs.
+5. **Comments** -- longer comments carry more weight than emoji-only replies.
+6. **Profile visits after viewing** -- indicates the content made someone curious about the creator.
+7. **Likes** -- still counted but the weakest signal relative to the others.
+
+## Audience Behavior
+
+Stories and feed posts primarily reach followers. Reels are the discovery format -- they surface to non-followers through the Reels tab, Explore page, and suggested content in the home feed.
+
+The home feed is heavily algorithmic now. Chronological feeds exist but most users stay on the default. Discovery is visual-first; text-heavy content underperforms unless it's in carousel format.
+
+## Conventions
+
+Caption length is flexible -- short and punchy works for Reels, longer storytelling works for carousels and feed posts. Hashtags have minimal impact compared to a few years ago; 3-5 relevant ones are fine, stuffing 30 does nothing useful.
+
+For Reels, the first frame is everything. You have about 1 second before someone swipes. Carousels need a strong first slide that creates curiosity to swipe. Text overlays on the first slide outperform plain images.
+
+## Comment Culture
+
+Comments function as social spaces. Common patterns: tagging friends, "send this to your..." prompts, emoji-only reactions, and short affirmations. Creator replies boost the post's engagement signals and encourage more comments. Pinning a top comment can steer the conversation and increase dwell time.
+
+## Creator Tiers
+
+**<10K:** Reels are the growth lever. A single Reel can reach 10-50x your follower count. Feed posts mostly reach existing followers. Focus on volume and iteration.
+
+**10K-100K:** Distribution becomes more consistent. Stories engagement rate matters for maintaining algorithmic favor. Carousels start performing well as the audience is invested enough to swipe.
+
+**100K-1M:** Feed posts get meaningful reach again at this level. Brand deals become viable. Algorithm rewards consistency -- gaps in posting are penalized more noticeably.
+
+**1M+:** Distribution is reliable across all formats. Lives pull large audiences. The algorithm is less make-or-break because the follower base drives baseline reach. Broadcast Channels become useful for maintaining direct audience connection.

--- a/skills/repurpose-engine/references/platforms/linkedin.md
+++ b/skills/repurpose-engine/references/platforms/linkedin.md
@@ -1,0 +1,32 @@
+---
+platform: linkedin
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Text posts** are the workhorse -- up to 3,000 characters, no media required. The "broetry" format dominates: one short sentence per line, lots of whitespace, reads like a motivational staircase. It works because it inflates dwell time.
+
+**Carousels/documents** are uploaded as PDFs and displayed as swipeable slides. Great for frameworks, step-by-step breakdowns, and listicles. Consistently strong reach.
+
+**Articles** are long-form blog posts hosted on LinkedIn. Lower reach than text posts but useful for SEO and credibility. **Newsletters** are recurring articles that notify subscribers directly -- solid for building a captive audience.
+
+**Video** is natively supported but still underused. LinkedIn is pushing it, so early movers get algorithmic tailwind. **Polls** drive easy engagement but are widely seen as low-effort content.
+
+## Algorithm Signals
+
+**Dwell time** is the quiet giant -- how long someone pauses on your post matters more than most people realize. **Comments** are weighted heavily, especially substantive ones. A two-sentence reply counts for far more than "Great post!" or a clap emoji. **Shares** and **reaction types** (insightful, celebrate) carry more signal than a basic like.
+
+The first hour is critical. Early engagement determines whether a post breaks out of your immediate network. The algorithm strongly favors on-platform content -- external links get suppressed.
+
+## Audience Behavior
+
+People scroll LinkedIn during work hours, often between meetings or while procrastinating. The content that performs is career lessons, industry takes, personal stories with a professional angle, and contrarian opinions. Who engages matters as much as how many -- a comment from a recognizable name amplifies reach into their network.
+
+## Conventions
+
+Only the first 2-3 lines show before the "see more" fold. That's your hook -- waste it and nobody clicks. Line breaks improve readability and boost dwell time. Common hook patterns: "I did X. Here's what happened." or agree/disagree framing that invites debate. Carousel posts work well for packaging frameworks or checklists into something swipeable.
+
+## Comment Culture
+
+Professionally toned but getting more casual. "Congrats!" under every job change is reflexive at this point. Thoughtful, specific comments get rewarded -- they surface higher and the algorithm notices. Tagging people pulls them (and their network's attention) into the conversation.

--- a/skills/repurpose-engine/references/platforms/tiktok.md
+++ b/skills/repurpose-engine/references/platforms/tiktok.md
@@ -1,0 +1,44 @@
+---
+platform: tiktok
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+Standard video is the backbone. Max length is 10 minutes, but the sweet spot is 15-60 seconds for most creators. Anything over 3 minutes needs a genuinely compelling hook or serialized narrative. Photo mode (carousel-style slideshows) works well for listicles and educational content. LIVE requires 1,000 followers to unlock and is where real-time community happens. Stories exist but see minimal traction compared to main feed. Series lets creators paywall multi-episode content, though adoption is still niche.
+
+Everything is 9:16. Horizontal video gets cropped or ignored.
+
+## Algorithm Signals
+
+Ranked by importance:
+
+1. **Average watch time and completion rate.** This is the single biggest factor. A 15-second video watched to the end outranks a 3-minute video abandoned at 30 seconds.
+2. **Shares.** The "send to friend" action is weighted extremely heavily. TikTok wants content that sparks private conversation.
+3. **Saves.** Signals lasting value. Tutorial and reference content benefits here.
+4. **Comments.** Volume and speed both matter. Replies from the creator boost the signal further.
+5. **Follows from the video.** Indicates the content was compelling enough to earn a subscription.
+
+The FYP is content-graph, not social-graph. Who follows you barely matters for distribution. Every video is tested on a small batch (roughly 200-500 views) and either graduates to broader distribution or dies. This is why a brand-new account can go viral on its first post.
+
+## Audience Behavior
+
+TikTok is discovery-first. The majority of views on any given video come from non-followers via the For You Page. Users aren't browsing profiles -- they're swiping a feed. The first 1-2 seconds are everything; if the hook doesn't land, they're gone.
+
+Sound is on by default, unlike Instagram. Audio choice directly affects reach. Duets and Stitches function as native reply formats and drive cross-pollination between audiences. Gen Z increasingly uses TikTok as a search engine for restaurants, product reviews, how-tos, and travel.
+
+## Conventions
+
+Text overlays are non-negotiable. Many users watch without reading captions, so key information must be on screen. Captions (the text below the video) are secondary -- used for hashtags, CTAs, or extra context, not the main message.
+
+Trending sounds provide a distribution boost but have a short shelf life. Green screen (talking over a screenshot or article) is a staple format for commentary. POV-style framing remains popular for storytelling. Serialization ("Part 1," "Part 2") drives follows and return views, especially for storytelling or drama content.
+
+## Comment Culture
+
+Comments on TikTok are a content layer, not an afterthought. Running jokes, bit-commits, and meme replies are the norm. "The comments won't disappoint" is its own genre. Pinned comments let creators extend the narrative or add corrections. Engagement bait works (asking a polarizing question, leaving an intentional mistake). Ratio culture exists but is less hostile than Twitter -- getting ratioed usually means a reply was funnier than the original.
+
+## Creator Tiers
+
+Follower count matters less on TikTok than any other major platform. An account with 500 followers can land 5 million views if the content hits. The algorithm evaluates each video independently, so consistency and trend-awareness outweigh audience size.
+
+That said, monetization thresholds exist: 10,000 followers for the Creativity Program, 1,000 for LIVE access, 100,000+ for meaningful brand deal leverage. Creators above 500K can monetize LIVE gifts at scale. But for organic reach, a small account and a large account are playing the same game.

--- a/skills/repurpose-engine/references/platforms/x.md
+++ b/skills/repurpose-engine/references/platforms/x.md
@@ -1,0 +1,34 @@
+---
+platform: x
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Posts** are the core unit. Free accounts get 280 characters; Premium subscribers can go up to 25,000. Most high-performing posts stay under 280 regardless -- brevity wins here.
+
+**Threads** chain posts together for longer narratives. The opener needs to stand on its own because most people won't click through. Thread openers typically end with a thread emoji (🧵) to signal there's more.
+
+**Quote posts** let you add commentary on someone else's post. They carry more weight than retweets because they add context and spark new conversations.
+
+**Spaces** are live audio rooms. Useful for real-time discussion and community building but ephemeral by default. **Polls** drive quick engagement. **Video** and **images** are supported but X remains a text-first platform -- visuals supplement the take, they don't replace it.
+
+## Algorithm Signals
+
+Engagement velocity in the first 30-60 minutes is critical. The algorithm decides early whether to push a post wider.
+
+Quote posts are weighted heavily -- they signal that your content was worth someone adding their own take. Reply depth matters; a post that sparks a long thread of genuine back-and-forth gets boosted. Bookmarks relative to likes indicate high-value content people want to revisit. Premium subscribers get a baseline distribution boost.
+
+## Audience Behavior
+
+X runs on real-time. News breaks here first, and the commentary cycle moves fast. If you're not posting while something is happening, you're late.
+
+Niche communities drive most of the value -- "Tech Twitter," "Film Twitter," "Med Twitter." Finding your pocket matters more than chasing broad reach. The culture rewards strong opinions and fast reactions over polished content.
+
+## Conventions
+
+First line is the hook. Most people see your post in a feed moving quickly, so front-load the point or the provocation. Engagement is reciprocal -- replying to others, quote-posting, and participating in conversations builds your audience faster than posting into the void.
+
+## Comment Culture
+
+Replies are fully public and function as open debate. Getting "ratioed" -- when replies or quote posts dwarf your likes -- is a form of collective social judgment. Quote posts serve as the primary commentary layer. Community Notes let users fact-check posts with crowd-sourced context. Meme replies and reaction images are a language of their own.

--- a/skills/repurpose-engine/references/platforms/youtube.md
+++ b/skills/repurpose-engine/references/platforms/youtube.md
@@ -1,0 +1,62 @@
+---
+platform: youtube
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Long-form video** is YouTube's core. The 8-20 minute range hits the sweet spot for mid-roll ad placements, which is where real revenue lives. Longer isn't automatically better -- you need the retention to justify the runtime.
+
+**Shorts** are vertical (9:16), under 60 seconds, and live in a completely separate feed with a separate algorithm. They drive subscribers but monetize poorly compared to long-form.
+
+**Live streams** notify subscribers and build watch time. **Premieres** combine the live chat experience with a pre-produced video. **Podcasts** are YouTube's push into audio-first content, surfaced in a dedicated tab and Google Podcasts integration.
+
+**Community posts** (text, polls, images) keep the audience engaged between uploads. Polls especially drive interaction.
+
+**Thumbnails** are a content format unto themselves. A video with a bad thumbnail doesn't get clicked, period. Custom thumbnails outperform auto-generated ones by a wide margin.
+
+## Algorithm Signals
+
+Ranked by weight for long-form:
+
+1. **Click-through rate (CTR)** -- the single most important metric. If nobody clicks, nothing else matters. 4-10% is typical; above 10% is exceptional.
+2. **Average view duration (AVD)** -- raw minutes watched. YouTube wants to keep people on the platform.
+3. **Average percentage viewed (APV)** -- how much of the video people actually watch. A 50%+ APV on a 15-minute video is strong.
+4. **Session time** -- does your video lead to more YouTube watching? Videos that start sessions get boosted hard.
+5. **Engagement velocity** -- likes, comments, and shares in the first 1-2 hours after upload.
+
+Shorts run on a separate algorithm. **Watch-through rate** (did they watch the whole thing) and **swipe-away rate** (did they leave mid-Short) are what matter. CTR is less relevant because Shorts auto-play.
+
+## Audience Behavior
+
+YouTube is intent-driven. Traffic comes from three main surfaces: **Search** (people looking for answers), **Suggested** (sidebar and end-screen recommendations), and **Browse** (home feed). Each rewards different content strategies.
+
+Attention spans are longer here than any other social platform. Viewers expect depth and will watch 10+ minutes if the content earns it. The subscribe relationship is meaningful -- subscribers get notifications and drive early view velocity that triggers broader distribution.
+
+Playlists drive binge behavior. A well-structured playlist can double session time per viewer.
+
+## Conventions
+
+**Thumbnail + title is the most important creative decision on YouTube.** Everything else is secondary. The title creates a curiosity gap; the thumbnail provides visual proof or emotional intrigue. They work as a pair -- redundancy between them wastes real estate.
+
+The **first 30 seconds** must justify the click. If the intro doesn't match what the thumbnail promised, viewers bounce and your AVD tanks.
+
+**Chapters/timestamps** improve viewer experience and show up in search results. **Cards** link to related content mid-video. **End screens** drive the next click in the last 20 seconds. All three directly influence session time.
+
+## Comment Culture
+
+YouTube comments are more substantive than short-form platforms. Viewers leave timestamps referencing specific moments, ask genuine questions, and write paragraph-length responses.
+
+Recurring patterns: "who's watching in 2026," first-commenter culture, and debates in reply threads. **Pinned comments** from the creator steer conversation and often add context to the video. **Heart reactions** from the creator are a lightweight way to acknowledge top comments. The Community tab extends this conversation between uploads.
+
+## Creator Tiers
+
+**<1K subscribers:** No access to the YouTube Partner Program. Shorts and search-optimized content are the growth path. A single video can break out regardless of subscriber count -- YouTube is less follower-gated than other platforms.
+
+**1K-10K:** Partner Program eligible (1K subs + 4K watch hours or 10M Shorts views). Ad revenue starts, but it's modest. Consistency matters -- the algorithm learns your upload cadence.
+
+**10K-100K:** Suggested traffic becomes a reliable growth engine. The algorithm has enough data on your audience to recommend your videos effectively. Sponsorships start to become meaningful income.
+
+**100K-1M:** Silver play button. Brand deals often exceed ad revenue. Your back catalog generates significant passive income. New uploads get a strong initial push from the subscriber base.
+
+**1M+:** Gold play button. Multiple revenue streams (ads, sponsors, memberships, merch shelf). The algorithm treats you as a known quantity -- even experimental content gets distribution. Premiere and live events pull large concurrent audiences.

--- a/skills/studio-setup/SERVICES.md
+++ b/skills/studio-setup/SERVICES.md
@@ -1,0 +1,97 @@
+# External services and their licences
+
+Every third-party service a `studio-setup` workflow can reach, what it costs,
+and what you are allowed to do with the output. `references/tooling-inventory.md`
+covers how to switch each one on; this file is only about rights.
+
+**Read the rights column before you publish anything.** Generation cost and
+usage rights are independent — several of the cheapest options carry the least
+certain terms, and a rights problem found after the edit means re-cutting, not
+re-tagging.
+
+Terms below were correct when written and are summarised, not quoted. Providers
+change them. For anything commercial, confirm against the provider's own licence
+page — linked in each row — rather than trusting this table.
+
+---
+
+## Local tools — no service, no licence question
+
+| Tool | Licence | Notes |
+|---|---|---|
+| `ffmpeg` / `ffprobe` | LGPL-2.1+ / GPL-2.0+ depending on build | Only processes your files; nothing leaves the machine |
+| `node` 18+ | MIT | Runtime for the composer |
+| `uv` | MIT / Apache-2.0 | Runs the bundled scripts |
+| Kokoro (local voice) | Apache-2.0 | Narration synthesised on your own machine; no upload, no per-use terms |
+| MediaPipe HandLandmarker | Apache-2.0 | Gesture analysis, runs locally |
+
+Rendering uses **Remotion 4.x**, which is *source-available, not open source*.
+It is free for individuals and companies of three or fewer people; larger
+companies need a paid Company Licence. See <https://remotion.dev/license>.
+This applies to whoever runs the renderer, so it matters for anyone adopting
+these skills — not only for Scrollmark.
+
+---
+
+## Stock and archive sources
+
+| Service | Cost | Rights | Licence page |
+|---|---|---|---|
+| **Pexels** | Free, API key | Free for commercial use, no attribution required; may not be resold as stock or used to train models | <https://pexels.com/license> |
+| Pixabay | Free, API key | Free for commercial use; same no-resale restriction | <https://pixabay.com/service/license-summary> |
+| NASA archive | Free, no key | Generally public domain, but some material carries third-party rights and NASA's identity may not imply endorsement | <https://nasa.gov/nasa-brand-center/images-and-media> |
+| Wikimedia Commons | Free, no key | **Varies per file** — CC0 through CC BY-SA to fair-use claims. The script filters, but attribution is per-item and is yours to carry | <https://commons.wikimedia.org/wiki/Commons:Licensing> |
+| Freesound | Free, API key | **Varies per sound** — CC0, CC BY, CC BY-NC. The script filters; NC-licensed sound cannot go in client work | <https://freesound.org/help/faq> |
+| Shutterstock | Search free; **download requires a subscription** | Standard licence covers most commercial use; extended licence needed for merchandise or resale | <https://shutterstock.com/license> |
+
+Wikimedia and Freesound are the two that need care: both are per-item, so a
+single clip can carry an obligation the rest of the timeline does not.
+
+---
+
+## Generative services
+
+| Service | Cost | Rights | Licence page |
+|---|---|---|---|
+| Gemini image | ~$0.02–0.03 / still | Clean for commercial use under Google's terms; output not exclusive to you | <https://ai.google.dev/terms> |
+| Veo | ~$0.40 / second | Clean under the same Google terms | <https://ai.google.dev/terms> |
+| Lyria (music) | Paid, free-tier quota is zero | Clean under the same Google terms | <https://ai.google.dev/terms> |
+| MiniMax video | ~$0.36 per 6s clip | Clean for commercial use under MiniMax's terms | <https://intl.minimaxi.com/protocol/terms-of-service> |
+| **MiniMax music** | Free tier available | **Unclear for commercial redistribution.** Training data is not disclosed, and the terms do not clearly grant redistribution of generated music. Treat as unsuitable for published or client work until confirmed | <https://intl.minimaxi.com/protocol/terms-of-service> |
+| **ElevenLabs Music** | from ~$6/month | **Clean.** Trained exclusively on licensed catalogue (Merlin, Kobalt) and includes commercial use on paid plans | <https://elevenlabs.io/terms> |
+| Luma / Runway via Replicate | ~$0.075 / ~$0.40–0.48 per clip | **Per-model** — each model on Replicate carries its own licence; check the specific model page | <https://replicate.com/terms> |
+
+### The music decision, stated plainly
+
+This is the one row where the cheap option and the safe option differ, and it
+is the most consequential choice in the table.
+
+MiniMax music has a free tier, which makes it the path of least resistance.
+Its rights for commercial redistribution are unclear. ElevenLabs Music is
+trained on licensed catalogue and permits commercial use from roughly six
+dollars a month.
+
+**For anything that will be published, use ElevenLabs.** Say which backend is
+in use *before* the user commits to a track — the whole cut gets shaped around
+whichever music arrives, so discovering a rights problem afterwards costs an
+edit, not a tag.
+
+---
+
+## Not integrated, but worth knowing
+
+Suno and Udio produce strong output and are both subject to active litigation
+over training data. Neither is wired in, and neither should be until that
+settles.
+
+---
+
+## If you are adopting these skills
+
+Three obligations travel with you, not with Scrollmark:
+
+1. **Remotion** — a Company Licence if you are a company of more than three people.
+2. **Per-item sources** — Wikimedia and Freesound licences attach to individual
+   files, so attribution and non-commercial restrictions are yours to honour.
+3. **API keys** — every service above bills the key holder. The scripts never
+   ship credentials; you supply your own and you pay for your own usage.

--- a/skills/studio-setup/SKILL.md
+++ b/skills/studio-setup/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: studio-setup
+description: Use when checking whether a machine can actually produce video, triaging a pipeline that stopped working, or deciding which third-party tool or API key to add next.
+---
+
+# Studio Setup
+
+Two questions, two scripts. *What can I use right now* is `doctor.py`. *How do I get the rest* is `setup.py`. Answer both against the machine in front of you — describing an installed tool as missing wastes the user's time and makes everything else you say suspect.
+
+## Requires
+
+`scripts/doctor.py` and `scripts/setup.py` from **scrollmark/video-studio** (private). Without them you can still check binaries by hand (`which ffmpeg ffprobe node uv`) and read the env vars listed below, but there is no single status report, no install plan, and no auto/system/manual classification — so you lose the one thing that stops an agent from running a package-manager install nobody asked for. `references/tooling-inventory.md` in this skill is the map; only doctor knows the state.
+
+## Checking an Environment
+
+    uv run scripts/doctor.py           # what is reachable right now
+    uv run scripts/doctor.py --json    # same, machine-readable
+
+Doctor reports per category — public-domain archives, stock, generated video, generated images, generated audio, voice — plus the required binaries. It checks that a key is *present*, not that it works; a key can still be rejected at call time for spent quota or a withdrawn model, and the individual scripts report that.
+
+Run it **before** offering sourcing options. Offering a source that turns out to have no key makes the estimate wrong as well as the offer.
+
+## Fixing a Broken One
+
+    uv run scripts/setup.py            # report + the exact plan, changes NOTHING
+    uv run scripts/setup.py --yes      # actually run the runnable fixes
+    uv run scripts/setup.py --yes --only composer,voice
+
+Every missing component is classified, and the split is the whole point:
+
+- **auto** — scoped to the toolchain directory, idempotent, safe to re-run: installing the composer's npm packages, warming the local voice model, copying `.env.example` to `.env`.
+- **system** — changes the machine outside that directory, such as a package manager installing `ffmpeg` or `node`. Still runnable, but it is somebody's computer.
+- **manual** — a human has to act: get an API key, enable billing, accept terms, restart a sandboxed host with network access. Never runnable. Printing "run this command" for something a machine cannot do erodes trust in the rest of the output.
+
+**Ask first, every time, even for the safe ones.** Nothing runs without `--yes`, and `--yes` also runs the system-level installs. Tell the user what is missing in their terms ("the renderer isn't installed"), say whether you can fix it, then ask.
+
+If everything is present, say nothing and get on with the work. Narrating a clean bill of health is noise.
+
+## The Tier-0 Floor
+
+Three things, and without any one of them nothing works: `ffmpeg` + `ffprobe` (every duration measured, every trim, all loudness and keying), `node` 18+ (the composer renders and previews through it), and `uv` (runs every bundled script with its own pinned dependencies). Everything else widens what you can reach; these three decide whether there is a pipeline at all.
+
+After that, the single highest-value addition is a free Pexels key. It converts "find me footage of that" from a coin flip into the normal answer, and costs nothing. Full inventory, tiers, costs and rights in `references/tooling-inventory.md`.
+
+## Licences
+
+Every external service this skill can reach, with its cost and what you may do
+with the output, is in `SERVICES.md` next to this file. Check it before anything
+gets published. The music row is the one that actually bites: the free backend's
+redistribution rights are unclear, the paid one is licensed catalogue.
+
+## showwatcher Is Not Installed
+
+The automated quality gate documented as step 8 of the workflow is a separate internal CLI, installed from its own repo, and it has been **absent on every machine seen so far**. `setup.py` lists it as an optional system component with no install command; `doctor.py` reports it as an optional tool that is missing.
+
+So: do not tell a user the quality check will run. Verify frames by hand and **say out loud that you are doing so**. It is the only step in the pipeline whose guarantee depends on somebody remembering, and a hand check silently skipped is worse than no gate at all.
+
+## Anti-patterns
+
+- **Quoting the docs instead of the machine.** The inventory is the map, not the state. Run doctor before saying a tool is available.
+- **Installing without asking.** `--yes` touches the whole system. It is their computer, every time.
+- **Dressing up a manual step as a command.** Nobody can `brew install` an API key or a billing account. Hand over the specific link.
+- **Treating a present key as a working key.** Presence is all doctor can see. Quota, billing and withdrawn models fail at call time.
+- **Assuming the sandbox has network.** Every stock lookup and generation call needs it; a host launched without it produces timeouts that look like provider outages.

--- a/skills/studio-setup/references/tooling-inventory.md
+++ b/skills/studio-setup/references/tooling-inventory.md
@@ -1,0 +1,126 @@
+# Third-party tooling — inventory, triage, and how to switch each on
+
+What exists, what it costs, what it buys, and how to turn it on. This is the
+map. Run `doctor.py` (from scrollmark/video-studio) for live state on the
+machine in front of you — this file never knows whether a key is set.
+
+Every entry is something a bundled script actually calls. Nothing here is
+aspirational.
+
+---
+
+## Tier 0 — without these, nothing works
+
+| Tool | Why | Activate |
+|---|---|---|
+| `ffmpeg` + `ffprobe` | Every duration measured, every clip trimmed, all loudness and keying | `brew install ffmpeg` |
+| `node` 18+ | The composer renders and previews through it | `brew install node` |
+| `uv` | Runs every bundled script with its own pinned dependencies | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+
+## Tier 1 — free, no billing, the single biggest jump in quality
+
+| Tool | Gives you | Activate |
+|---|---|---|
+| **Pexels** | Modern everyday footage and stills. The one key that converts "find me footage of that" from a coin flip into the normal answer | `PEXELS_API_KEY` — free at pexels.com/api |
+| NASA archive | Space, earth, science. Public domain | nothing — no key at all |
+| Wikimedia Commons | History, places, artefacts. Licence varies per item; the script filters | nothing — no key at all |
+| Local voice | Narration generated on the user's own machine | nothing — runs locally |
+
+**If you add exactly one thing on this page, add Pexels.**
+
+## Tier 2 — free keys, narrower use
+
+| Tool | Gives you | Activate |
+|---|---|---|
+| Pixabay | Second stock library, for subjects where Pexels is thin | `PIXABAY_API_KEY` |
+| Freesound | Sound effects. Licence varies per sound; the script filters | `FREESOUND_API_KEY` |
+
+## Tier 3 — paid. Quote the cost before spending, every time
+
+| Tool | Cost | Rights | Activate |
+|---|---|---|---|
+| Gemini image | ~0.02–0.03 / still | Clean | `GEMINI_API_KEY` — needs billing, no free tier |
+| Veo | ~0.40 / s | Clean | `GEMINI_API_KEY` — free-tier quota is tiny |
+| MiniMax video | ~0.36 per 6s clip | Clean | `MINIMAX_API_KEY` |
+| **ElevenLabs Music** | **from ~6 USD/mo** | **Clean — licensed catalogue only (Merlin, Kobalt)** | `ELEVENLABS_API_KEY` |
+| Lyria (Google) | Paid | Clean | `GEMINI_API_KEY` — free-tier quota is literally 0 |
+| MiniMax music | Free tier available | **Rights unclear for commercial redistribution — verify before client work** | `MINIMAX_API_KEY` |
+| Luma / Runway (via Replicate) | ~0.075 / ~0.40–0.48 per clip | Per-model | `REPLICATE_API_TOKEN` |
+| Shutterstock | Search free; **download needs a subscription** | Standard licence | `SHUTTERSTOCK_TOKEN` |
+
+**The music rights split is the most consequential line here, and cheaper to
+fix than it looks.** MiniMax music has a free tier, which makes it the path of least resistance,
+and its output rights are unclear for commercial redistribution. ElevenLabs
+Music trains exclusively on licensed catalogue and includes commercial use from
+roughly six dollars a month. For anything that will be published, that is the
+answer. Say which backend is in use BEFORE the user chooses — the whole cut
+gets shaped around whichever track arrives, so a rights problem found
+afterwards means re-cutting, not re-tagging.
+
+Two others worth knowing and not integrated: Suno has the best measured output
+but no official API and lawsuits in flight; Udio has clean label deals but no
+public API below enterprise.
+
+## Tier 4 — present in the code, not currently reachable
+
+| Tool | State | Notes |
+|---|---|---|
+| `showwatcher` | **Not installed, on any machine seen so far** | The automated quality gate in step 8. Internal tool, installed from its own repo. Without it, verify frames by hand and SAY that you are doing so |
+| `yt-dlp` | One call site | Used for `url:` sources. `brew install yt-dlp` if you intend to pull from URLs |
+
+---
+
+## What to add next
+
+Ranked by what actually went wrong in production, not by feature count.
+
+1. **A verified-provenance stock source.** The largest defect class so far.
+   Stock search does not respect geography: Japanese queries returned a Hawaii
+   temple, Mexican queries returned San Francisco and Colorado. Twenty-one
+   shots were replaced across three videos. Automated checks catch duplicates,
+   monochrome and short clips; they cannot verify that a place is the place.
+2. **`showwatcher`, actually installed.** Documented as step 8, absent
+   everywhere, so every render has been verified by hand. It is the only step
+   whose guarantee depends on somebody remembering.
+3. **A music generator that honours a requested length.** Asking for 140s has
+   returned 25s, 66s, 128s and 148s. Every track must be measured after
+   generation and the video designed to what arrived.
+4. **Subject detection for poster frames.** Ranking on colour and contrast put
+   an underwater reef above a marigold market for a Mexico spot.
+5. **A brand-mark detector for generated imagery.** Image models reproduce real
+   trade dress unprompted — a generated sneaker sequence came back with legible
+   swooshes. Currently caught only by zooming frames by hand before publishing.
+
+## Deliberately not integrated
+
+- **Anything requiring an account to read.** Archives and stock behind a login
+  break the "make a whole video without signing up for anything" promise.
+- **Paid stock libraries.** The free tier covers everyday subjects well enough.
+- **Cloud rendering.** The composer renders locally in minutes; a queue and a
+  bill would buy nothing at this scale.
+
+## Activation, end to end
+
+```bash
+cp .env.example .env          # gitignored
+$EDITOR .env                  # paste the keys you have
+uv run scripts/doctor.py      # what is reachable right now
+uv run scripts/setup.py       # what is missing and what can be installed
+uv run scripts/setup.py --yes # actually install it — ask the user first
+```
+
+Keys live in `.env` at the toolchain root. Every script reads plain environment
+variables, so exporting by hand works identically; the file just saves doing it
+per shell. Holding a key costs nothing — only calls do.
+
+## What this actually runs on
+
+User-facing prose says "the editor", "the quality check", "the built-in voice".
+Behind those names: Remotion 4.0.x for composing and rendering, showwatcher for
+the quality gate, MiniMax and Veo for clip generation, Kokoro locally for
+voice, MediaPipe HandLandmarker for gesture analysis, ffmpeg for probing and
+keying. The abstraction exists because every row is expected to change and because a
+creative session is the wrong place to field "why MiniMax?". Answer honestly
+whenever asked — this is about not volunteering implementation detail
+mid-session, not concealing it. Licence terms for every service are in
+SERVICES.md.

--- a/skills/trend-radar/SKILL.md
+++ b/skills/trend-radar/SKILL.md
@@ -54,4 +54,4 @@ Rule of thumb: if you have to ask "is this still trending?" — you're probably 
 
 ## Platform-Specific Mechanics
 
-Load the relevant platform reference from `{repo}/references/platforms/{platform}.md` (read `.root` for repo path). Key differences: TikTok trends are often sound-driven, Instagram trends are format/template-driven, YouTube trends are topic/challenge-driven and move slower. X trends are conversation-driven and move fastest but burn out within hours.
+Load the relevant platform reference from `references/platforms/{platform}.md` in this skill's own directory. Key differences: TikTok trends are often sound-driven, Instagram trends are format/template-driven, YouTube trends are topic/challenge-driven and move slower. X trends are conversation-driven and move fastest but burn out within hours.

--- a/skills/trend-radar/references/platforms/instagram.md
+++ b/skills/trend-radar/references/platforms/instagram.md
@@ -1,0 +1,54 @@
+---
+platform: instagram
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Reels** are the primary distribution vehicle. Up to 3 minutes, 9:16 aspect ratio (1080x1920). Shorter Reels (30-90s) tend to perform better because completion rate matters.
+
+**Stories** play in 15-second segments, 9:16, and expire after 24 hours. Primarily reach existing followers. Stickers (polls, questions, sliders) boost engagement signals.
+
+**Feed posts** support 1:1 (1080x1080), 4:5 (1080x1350), and 1.91:1 (1080x566). The 4:5 ratio takes up the most screen real estate and generally outperforms.
+
+**Carousels** allow up to 20 slides mixing photos and video. Instagram re-serves carousels to users who didn't swipe the first time, giving them a second shot at reach.
+
+**Lives** are real-time, notify followers, and can be saved. **Notes** are short-form text (60 chars) that sit on DM inboxes. **Broadcast Channels** are one-to-many messaging for creator updates.
+
+## Algorithm Signals
+
+Ranked roughly by weight:
+
+1. **Sends/DM shares** -- the strongest signal right now. Content people share privately gets massive distribution.
+2. **Watch time and rewatch rate** -- especially for Reels. Completion rate matters more than raw views.
+3. **Saves** -- a strong intent signal. Instagram treats saves as high-value engagement.
+4. **Shares to Stories** -- public reshares extend reach into new follower graphs.
+5. **Comments** -- longer comments carry more weight than emoji-only replies.
+6. **Profile visits after viewing** -- indicates the content made someone curious about the creator.
+7. **Likes** -- still counted but the weakest signal relative to the others.
+
+## Audience Behavior
+
+Stories and feed posts primarily reach followers. Reels are the discovery format -- they surface to non-followers through the Reels tab, Explore page, and suggested content in the home feed.
+
+The home feed is heavily algorithmic now. Chronological feeds exist but most users stay on the default. Discovery is visual-first; text-heavy content underperforms unless it's in carousel format.
+
+## Conventions
+
+Caption length is flexible -- short and punchy works for Reels, longer storytelling works for carousels and feed posts. Hashtags have minimal impact compared to a few years ago; 3-5 relevant ones are fine, stuffing 30 does nothing useful.
+
+For Reels, the first frame is everything. You have about 1 second before someone swipes. Carousels need a strong first slide that creates curiosity to swipe. Text overlays on the first slide outperform plain images.
+
+## Comment Culture
+
+Comments function as social spaces. Common patterns: tagging friends, "send this to your..." prompts, emoji-only reactions, and short affirmations. Creator replies boost the post's engagement signals and encourage more comments. Pinning a top comment can steer the conversation and increase dwell time.
+
+## Creator Tiers
+
+**<10K:** Reels are the growth lever. A single Reel can reach 10-50x your follower count. Feed posts mostly reach existing followers. Focus on volume and iteration.
+
+**10K-100K:** Distribution becomes more consistent. Stories engagement rate matters for maintaining algorithmic favor. Carousels start performing well as the audience is invested enough to swipe.
+
+**100K-1M:** Feed posts get meaningful reach again at this level. Brand deals become viable. Algorithm rewards consistency -- gaps in posting are penalized more noticeably.
+
+**1M+:** Distribution is reliable across all formats. Lives pull large audiences. The algorithm is less make-or-break because the follower base drives baseline reach. Broadcast Channels become useful for maintaining direct audience connection.

--- a/skills/trend-radar/references/platforms/linkedin.md
+++ b/skills/trend-radar/references/platforms/linkedin.md
@@ -1,0 +1,32 @@
+---
+platform: linkedin
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Text posts** are the workhorse -- up to 3,000 characters, no media required. The "broetry" format dominates: one short sentence per line, lots of whitespace, reads like a motivational staircase. It works because it inflates dwell time.
+
+**Carousels/documents** are uploaded as PDFs and displayed as swipeable slides. Great for frameworks, step-by-step breakdowns, and listicles. Consistently strong reach.
+
+**Articles** are long-form blog posts hosted on LinkedIn. Lower reach than text posts but useful for SEO and credibility. **Newsletters** are recurring articles that notify subscribers directly -- solid for building a captive audience.
+
+**Video** is natively supported but still underused. LinkedIn is pushing it, so early movers get algorithmic tailwind. **Polls** drive easy engagement but are widely seen as low-effort content.
+
+## Algorithm Signals
+
+**Dwell time** is the quiet giant -- how long someone pauses on your post matters more than most people realize. **Comments** are weighted heavily, especially substantive ones. A two-sentence reply counts for far more than "Great post!" or a clap emoji. **Shares** and **reaction types** (insightful, celebrate) carry more signal than a basic like.
+
+The first hour is critical. Early engagement determines whether a post breaks out of your immediate network. The algorithm strongly favors on-platform content -- external links get suppressed.
+
+## Audience Behavior
+
+People scroll LinkedIn during work hours, often between meetings or while procrastinating. The content that performs is career lessons, industry takes, personal stories with a professional angle, and contrarian opinions. Who engages matters as much as how many -- a comment from a recognizable name amplifies reach into their network.
+
+## Conventions
+
+Only the first 2-3 lines show before the "see more" fold. That's your hook -- waste it and nobody clicks. Line breaks improve readability and boost dwell time. Common hook patterns: "I did X. Here's what happened." or agree/disagree framing that invites debate. Carousel posts work well for packaging frameworks or checklists into something swipeable.
+
+## Comment Culture
+
+Professionally toned but getting more casual. "Congrats!" under every job change is reflexive at this point. Thoughtful, specific comments get rewarded -- they surface higher and the algorithm notices. Tagging people pulls them (and their network's attention) into the conversation.

--- a/skills/trend-radar/references/platforms/tiktok.md
+++ b/skills/trend-radar/references/platforms/tiktok.md
@@ -1,0 +1,44 @@
+---
+platform: tiktok
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+Standard video is the backbone. Max length is 10 minutes, but the sweet spot is 15-60 seconds for most creators. Anything over 3 minutes needs a genuinely compelling hook or serialized narrative. Photo mode (carousel-style slideshows) works well for listicles and educational content. LIVE requires 1,000 followers to unlock and is where real-time community happens. Stories exist but see minimal traction compared to main feed. Series lets creators paywall multi-episode content, though adoption is still niche.
+
+Everything is 9:16. Horizontal video gets cropped or ignored.
+
+## Algorithm Signals
+
+Ranked by importance:
+
+1. **Average watch time and completion rate.** This is the single biggest factor. A 15-second video watched to the end outranks a 3-minute video abandoned at 30 seconds.
+2. **Shares.** The "send to friend" action is weighted extremely heavily. TikTok wants content that sparks private conversation.
+3. **Saves.** Signals lasting value. Tutorial and reference content benefits here.
+4. **Comments.** Volume and speed both matter. Replies from the creator boost the signal further.
+5. **Follows from the video.** Indicates the content was compelling enough to earn a subscription.
+
+The FYP is content-graph, not social-graph. Who follows you barely matters for distribution. Every video is tested on a small batch (roughly 200-500 views) and either graduates to broader distribution or dies. This is why a brand-new account can go viral on its first post.
+
+## Audience Behavior
+
+TikTok is discovery-first. The majority of views on any given video come from non-followers via the For You Page. Users aren't browsing profiles -- they're swiping a feed. The first 1-2 seconds are everything; if the hook doesn't land, they're gone.
+
+Sound is on by default, unlike Instagram. Audio choice directly affects reach. Duets and Stitches function as native reply formats and drive cross-pollination between audiences. Gen Z increasingly uses TikTok as a search engine for restaurants, product reviews, how-tos, and travel.
+
+## Conventions
+
+Text overlays are non-negotiable. Many users watch without reading captions, so key information must be on screen. Captions (the text below the video) are secondary -- used for hashtags, CTAs, or extra context, not the main message.
+
+Trending sounds provide a distribution boost but have a short shelf life. Green screen (talking over a screenshot or article) is a staple format for commentary. POV-style framing remains popular for storytelling. Serialization ("Part 1," "Part 2") drives follows and return views, especially for storytelling or drama content.
+
+## Comment Culture
+
+Comments on TikTok are a content layer, not an afterthought. Running jokes, bit-commits, and meme replies are the norm. "The comments won't disappoint" is its own genre. Pinned comments let creators extend the narrative or add corrections. Engagement bait works (asking a polarizing question, leaving an intentional mistake). Ratio culture exists but is less hostile than Twitter -- getting ratioed usually means a reply was funnier than the original.
+
+## Creator Tiers
+
+Follower count matters less on TikTok than any other major platform. An account with 500 followers can land 5 million views if the content hits. The algorithm evaluates each video independently, so consistency and trend-awareness outweigh audience size.
+
+That said, monetization thresholds exist: 10,000 followers for the Creativity Program, 1,000 for LIVE access, 100,000+ for meaningful brand deal leverage. Creators above 500K can monetize LIVE gifts at scale. But for organic reach, a small account and a large account are playing the same game.

--- a/skills/trend-radar/references/platforms/x.md
+++ b/skills/trend-radar/references/platforms/x.md
@@ -1,0 +1,34 @@
+---
+platform: x
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Posts** are the core unit. Free accounts get 280 characters; Premium subscribers can go up to 25,000. Most high-performing posts stay under 280 regardless -- brevity wins here.
+
+**Threads** chain posts together for longer narratives. The opener needs to stand on its own because most people won't click through. Thread openers typically end with a thread emoji (🧵) to signal there's more.
+
+**Quote posts** let you add commentary on someone else's post. They carry more weight than retweets because they add context and spark new conversations.
+
+**Spaces** are live audio rooms. Useful for real-time discussion and community building but ephemeral by default. **Polls** drive quick engagement. **Video** and **images** are supported but X remains a text-first platform -- visuals supplement the take, they don't replace it.
+
+## Algorithm Signals
+
+Engagement velocity in the first 30-60 minutes is critical. The algorithm decides early whether to push a post wider.
+
+Quote posts are weighted heavily -- they signal that your content was worth someone adding their own take. Reply depth matters; a post that sparks a long thread of genuine back-and-forth gets boosted. Bookmarks relative to likes indicate high-value content people want to revisit. Premium subscribers get a baseline distribution boost.
+
+## Audience Behavior
+
+X runs on real-time. News breaks here first, and the commentary cycle moves fast. If you're not posting while something is happening, you're late.
+
+Niche communities drive most of the value -- "Tech Twitter," "Film Twitter," "Med Twitter." Finding your pocket matters more than chasing broad reach. The culture rewards strong opinions and fast reactions over polished content.
+
+## Conventions
+
+First line is the hook. Most people see your post in a feed moving quickly, so front-load the point or the provocation. Engagement is reciprocal -- replying to others, quote-posting, and participating in conversations builds your audience faster than posting into the void.
+
+## Comment Culture
+
+Replies are fully public and function as open debate. Getting "ratioed" -- when replies or quote posts dwarf your likes -- is a form of collective social judgment. Quote posts serve as the primary commentary layer. Community Notes let users fact-check posts with crowd-sourced context. Meme replies and reaction images are a language of their own.

--- a/skills/trend-radar/references/platforms/youtube.md
+++ b/skills/trend-radar/references/platforms/youtube.md
@@ -1,0 +1,62 @@
+---
+platform: youtube
+last_updated: 2026-03-17
+---
+
+## Content Formats
+
+**Long-form video** is YouTube's core. The 8-20 minute range hits the sweet spot for mid-roll ad placements, which is where real revenue lives. Longer isn't automatically better -- you need the retention to justify the runtime.
+
+**Shorts** are vertical (9:16), under 60 seconds, and live in a completely separate feed with a separate algorithm. They drive subscribers but monetize poorly compared to long-form.
+
+**Live streams** notify subscribers and build watch time. **Premieres** combine the live chat experience with a pre-produced video. **Podcasts** are YouTube's push into audio-first content, surfaced in a dedicated tab and Google Podcasts integration.
+
+**Community posts** (text, polls, images) keep the audience engaged between uploads. Polls especially drive interaction.
+
+**Thumbnails** are a content format unto themselves. A video with a bad thumbnail doesn't get clicked, period. Custom thumbnails outperform auto-generated ones by a wide margin.
+
+## Algorithm Signals
+
+Ranked by weight for long-form:
+
+1. **Click-through rate (CTR)** -- the single most important metric. If nobody clicks, nothing else matters. 4-10% is typical; above 10% is exceptional.
+2. **Average view duration (AVD)** -- raw minutes watched. YouTube wants to keep people on the platform.
+3. **Average percentage viewed (APV)** -- how much of the video people actually watch. A 50%+ APV on a 15-minute video is strong.
+4. **Session time** -- does your video lead to more YouTube watching? Videos that start sessions get boosted hard.
+5. **Engagement velocity** -- likes, comments, and shares in the first 1-2 hours after upload.
+
+Shorts run on a separate algorithm. **Watch-through rate** (did they watch the whole thing) and **swipe-away rate** (did they leave mid-Short) are what matter. CTR is less relevant because Shorts auto-play.
+
+## Audience Behavior
+
+YouTube is intent-driven. Traffic comes from three main surfaces: **Search** (people looking for answers), **Suggested** (sidebar and end-screen recommendations), and **Browse** (home feed). Each rewards different content strategies.
+
+Attention spans are longer here than any other social platform. Viewers expect depth and will watch 10+ minutes if the content earns it. The subscribe relationship is meaningful -- subscribers get notifications and drive early view velocity that triggers broader distribution.
+
+Playlists drive binge behavior. A well-structured playlist can double session time per viewer.
+
+## Conventions
+
+**Thumbnail + title is the most important creative decision on YouTube.** Everything else is secondary. The title creates a curiosity gap; the thumbnail provides visual proof or emotional intrigue. They work as a pair -- redundancy between them wastes real estate.
+
+The **first 30 seconds** must justify the click. If the intro doesn't match what the thumbnail promised, viewers bounce and your AVD tanks.
+
+**Chapters/timestamps** improve viewer experience and show up in search results. **Cards** link to related content mid-video. **End screens** drive the next click in the last 20 seconds. All three directly influence session time.
+
+## Comment Culture
+
+YouTube comments are more substantive than short-form platforms. Viewers leave timestamps referencing specific moments, ask genuine questions, and write paragraph-length responses.
+
+Recurring patterns: "who's watching in 2026," first-commenter culture, and debates in reply threads. **Pinned comments** from the creator steer conversation and often add context to the video. **Heart reactions** from the creator are a lightweight way to acknowledge top comments. The Community tab extends this conversation between uploads.
+
+## Creator Tiers
+
+**<1K subscribers:** No access to the YouTube Partner Program. Shorts and search-optimized content are the growth path. A single video can break out regardless of subscriber count -- YouTube is less follower-gated than other platforms.
+
+**1K-10K:** Partner Program eligible (1K subs + 4K watch hours or 10M Shorts views). Ad revenue starts, but it's modest. Consistency matters -- the algorithm learns your upload cadence.
+
+**10K-100K:** Suggested traffic becomes a reliable growth engine. The algorithm has enough data on your audience to recommend your videos effectively. Sponsorships start to become meaningful income.
+
+**100K-1M:** Silver play button. Brand deals often exceed ad revenue. Your back catalog generates significant passive income. New uploads get a strong initial push from the subscriber base.
+
+**1M+:** Gold play button. Multiple revenue streams (ads, sponsors, memberships, merch shelf). The algorithm treats you as a known quantity -- even experimental content gets distribution. Premiere and live events pull large concurrent audiences.

--- a/skills/video-formats/SKILL.md
+++ b/skills/video-formats/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: video-formats
+description: Use when planning, structuring, or critiquing a short-form video — choosing a format, laying out its scenes, or defining a new format. Covers ten scene grammars from talking-head to hand-drawn motion graphics.
+---
+
+# Video Formats
+
+This skill is a router. The ten format grammars live in `references/formats/` — this skill tells you what a format is, which one to reach for, and how to write an eleventh.
+
+## What a Format Is
+
+A format is a **scene grammar**: a repeatable structure that says how many scenes a video has, what each one is for, what goes in each one, and what questions to ask before you can build it. It is not a template to fill in and not a style preset. Two videos in the same format can look nothing alike and still be the same shape.
+
+Every format file has the same five sections:
+
+- **Composition** — aspect ratio, frame rate, scene count and lengths, whether captions are on.
+- **Interview** — the questions to ask before planning. Rounds are numbered and headed; some formats insist on an order (Cinematic demands audio first, because every cut gets shaped around the track).
+- **Slots** — the named assets the format needs. `hero`, `beat-N`, `endcard`, `host`, `popup-N`. Slots are the shopping list.
+- **Grammar** — the scene-by-scene construction rules. This is the load-bearing section: which beat opens, how long each runs, what belongs on screen at once, and what the format refuses to do.
+- **Render notes** — the practical traps, learned by failing.
+
+## Choosing a Format
+
+One distinguishing question each. Ask them in roughly this order and stop at the first yes.
+
+| Format | The question that selects it |
+|---|---|
+| **PointerPopups** | Do you already have footage of someone pointing at things? |
+| **TitledVideo** | Do you have a finished clip that just needs titles to be postable? |
+| **TalkingHead** | Is one person talking to camera the whole way through? |
+| **PipStory** | Is there a host, but the story keeps citing things worth showing? |
+| **Cinematic** | Is the point a feeling rather than an argument — cut to music, few words? |
+| **Explainer** | Is there a concept to explain, and no one on camera to explain it? |
+| **ProductLaunch** | Is there a product, three capabilities, and a name to land? |
+| **BrandOrigin** | Is it one from-here-to-there story about a real brand, ~30s? |
+| **TimelineExplainer** | Is the *list* the point — numbered beats the viewer counts along with? |
+| **Boil** | Can the subject not be photographed at all? |
+
+Two pairs are easy to confuse:
+
+- **BrandOrigin vs. TimelineExplainer** — BrandOrigin is one transformation carried by a recurring motif, ~30s. TimelineExplainer is a countable sequence, 6-10 numbered beats, and runs longer. If the viewer would be counting, it's the timeline.
+- **TalkingHead vs. PipStory** — the same host, but PipStory shrinks them into a corner whenever the narration names something concrete. If 25-50% of the beats cite a number, an object, or a place, it's PipStory.
+
+**Boil is the outlier.** It's the only format with no photography, no footage, and nothing licensed on screen. Reach for it when the subject is unreleased, abstract, or a service — or when stock would look borrowed.
+
+## Reading a Format File
+
+Load `references/formats/{name}.md` from this skill's own directory. File names are kebab-case: `pip-story.md`, `brand-origin.md`, `pointer-popups.md`, `timeline-explainer.md`, `product-launch.md`, `talking-head.md`, `titled-video.md`, plus `boil.md`, `cinematic.md`, `explainer.md`.
+
+The files share a vocabulary that comes from the storyboard structure they compile into. A **scene** holds `narration` and a stack of **layers**; a layer is a `source` (footage, a still, a generated clip), a `card` (live typography), or an `effect`. Terms you'll meet:
+
+- **`card`** — real typography rendered at composition time. Every exact word, number, name, year, and URL is a card. Never ask a generator for text; it invents letterforms.
+- **`ken`** — a slow Ken Burns drift over a still, so it reads as footage rather than a frozen frame. Alternate zoom direction and pan between consecutive scenes or the cuts all move identically.
+- **`rect`** — a layer's position as `[x, y, w, h]` in fractions of the frame. A corner inset is roughly `[0.58, 0.58, 0.42, 0.42]`.
+- **`atMs` / `untilMs` / `pop`** — a layer's visibility window inside its scene, with an optional pop-in.
+- **`broll` / `host` / `insert` / `main`** — conventional layer ids, not special types. The names carry intent between the format and whoever builds it.
+- **`plannedSeconds`** — an estimate. Measured narration length is the real clock.
+
+## Anti-patterns
+
+- **Two ideas in one scene.** Every grammar says this in its own words. If a beat needs two sentences, it's two beats.
+- **Card and narration saying the same words.** The card carries the short form, the voice carries the sentence. Doubling reads as a caption, not a design.
+- **Mixing formats mid-video.** A talking head that becomes a montage halfway through has no grammar; it has two halves.
+- **Choosing a format by look.** Formats are selected by what the material *is*. Look is a separate layer entirely — the same format can be dressed a dozen ways.
+
+## Adding an Eleventh Format
+
+Drop a new markdown file in `references/formats/`. Required sections, in order: `# Name — one-line description`, `## Composition`, `## Interview`, `## Slots`, `## Grammar`, `## Render notes`. Nothing else changes — the format list is the directory listing.
+
+Two rules worth honoring:
+
+1. **A format earns its file by recurring.** BrandOrigin was extracted after the same shape appeared four times in one reference gallery. Three or four independent uses is a format; one is a video.
+2. **The Grammar section must be able to say no.** A grammar that only describes what a video may contain isn't a grammar. Each of the ten forbids something specific — two marks on screen, a CTA on an editorial piece, an insert over the speaker's key line. If your new format forbids nothing, it's a mood board.
+
+## Toolchain Assumptions
+
+These grammars were extracted from a production pipeline, and several Render notes still name its scripts (`gen_boil.py`, `track_pointing.py`, `measure.py`, `styles.py`) and its per-clip costs. **Boil** and **PointerPopups** are the two that genuinely depend on a generator and a hand tracker — without those, read them as descriptions of a style rather than instructions you can follow. The other eight are pure structure: every Composition, Interview, Slots, and Grammar section stands on its own, whatever you build the video with.

--- a/skills/video-formats/references/formats/boil.md
+++ b/skills/video-formats/references/formats/boil.md
@@ -1,0 +1,80 @@
+# Boil — hand-drawn outlined motion graphics
+
+Wiggly single-weight vector line art over flat colour, with typography set
+directly on it. No photography, no generated video, no licence attached to
+anything on screen. Reach for it when the subject can't be photographed —
+an unreleased product, a service, an abstract idea — or when stock footage
+would look borrowed.
+
+## Composition
+16:9 1080p @30fps (9:16 works unchanged; art is centred by `--pos`). Five to
+seven scenes, 5-6s each. Every scene is a flat background with ONE drawn
+shape and at most one text block. Captions off — the type on screen is the
+type, and captions would double it.
+
+## Interview
+Round 1 — header "Subject": What is it, and what are the three things worth
+saying about it?
+Round 2 — header "Marks": For each beat, what object stands for it? Keep it
+iconic — a hand, a spark, a bridge, a lock. First run `gen_boil.py --list`.
+If the vocabulary is too rigid, create `boil_shapes.py` in the project and
+pass it with `--shape-file`; do not squeeze the idea into an unrelated built-in
+mark.
+Round 3 — header "Palette": Background and line colour per beat. Two colours
+per scene, no gradients. By default the card `fg` matches the line colour used
+for that scene's mark; only break this when the user explicitly asks for a
+contrast exception.
+Freeform: exact wording for the end card.
+
+## Slots
+`<scene>-still` boil clip, one `card` per beat, narration optional.
+
+## Grammar
+- **Hook** (5-6s): one abstract mark, no text. `rings` or `arrow`.
+- **Reveal** (5-6s): the subject named, on the inverted palette — if the deck
+  is dark, this beat is paper. The flip is what makes it land.
+- **Beats** (3 x 5-6s): one mark, one card, one idea. Mark right, text left
+  (or the reverse) — NEVER overlapping. See render notes.
+- **Landing** (5s): the quietest mark, name and one line.
+- One shape per scene. Two marks on screen reads as a diagram, not a beat.
+
+## Render notes
+- Generate art with `scripts/gen_boil.py`, one clip per scene. Match
+  `--seconds` to `plannedSeconds` EXACTLY: a short clip either loops
+  (visible seam) or freezes.
+- Custom marks live beside the storyboard, usually `project/boil_shapes.py`.
+  Define functions named `s_<name>(d, c, rng, w, p, cx, cy, s)` and call the
+  injected helpers `wob`, `circle`, and `box`. Then render with
+  `--shape-file project/boil_shapes.py --shape <name>`. Keep functions short:
+  one iconic outline, no fill, no text, no second object.
+  Example:
+
+  ```python
+  def s_heart(d, c, rng, w, p, cx, cy, s):
+      pts = []
+      for i in range(80):
+          t = math.tau * i / 79
+          x = 16 * math.sin(t) ** 3
+          y = -(13 * math.cos(t) - 5 * math.cos(2*t) - 2 * math.cos(3*t) - math.cos(4*t))
+          pulse = 1 + 0.04 * math.sin(p * math.tau)
+          pts.append((cx + x * s * 0.025 * pulse, cy + y * s * 0.025 * pulse))
+      wob(d, pts, c, rng, w, 2.8)
+  ```
+- `--hold 3` is the default and the right answer. Hold 1 is video noise;
+  hold 6+ reads as a stutter, not a drawing.
+- **Set every card `flat: true` and `bg: "transparent"`.** `flat` drops
+  the rounded corner and the drop shadow; without it a transparent card
+  still draws a floating grey panel. Do NOT match `bg` to the background
+  hex instead — the art is h264, so its background is only approximately
+  that value and an exact fill shows as a faint patch.
+- Check contrast per scene. The inverted reveal beat is where white type
+  gets set on paper and vanishes; the palette flips but card `fg` does not
+  follow automatically.
+- Match text and mark colour by default. For Boil, the card is part of the
+  same drawn poster as the mark, not a separate caption layer; mismatched text
+  and line colours read as accidental unless the user asked for that contrast.
+- Keep the mark and the card in different halves of the frame. The composer
+  will happily stack them, and a card over the drawing is the one thing that
+  makes this style look cheap.
+- Deterministic: same `--seed` gives the same jitter. Re-rendering a scene
+  after an edit will not reshuffle the boil.

--- a/skills/video-formats/references/formats/brand-origin.md
+++ b/skills/video-formats/references/formats/brand-origin.md
@@ -1,0 +1,47 @@
+# BrandOrigin — 30-second origin short
+
+How a brand or company got from what it was to what it is, in about 30
+seconds, vertical. Derived from a formula observed four times in a reference
+gallery: *"<Brand> origin short: How X went from A to B, with <visual motif>
+in 30 seconds."* Four uses of one shape is a format, not a one-off.
+
+## Composition
+Vertical 1080x1920 @30fps. Five to six scenes, 4-6s each. Every visual scene
+is a full-frame still carrying a `ken` drift — the era changes, the camera
+keeps moving. One recurring **motif** (an object, a shape, a material) appears
+in every era so the eye has a through-line. Captions on. One narrator voice.
+Era labels are composer `card` layers, never generated text.
+
+## Interview
+Round 1 — header "Subject": Which brand or company, and what's the one
+transformation the short is about? (from-X-to-Y in a sentence)
+Round 2 — header "Motif": What object recurs through every era? (the shoe,
+the chip, the cup — it's the visual spine)
+Round 3 — header "Eras": Three to four turning points, oldest first. What
+changed at each?
+Round A — header "Audio": Score (supply a file / generate / none)?
+Voice (built-in / supplied recording / none)? If generating the score, say
+which backend and its rights terms before they choose, not after.
+Round L — header "Look": Which caption/card preset — `styles.py --list`?
+Any look they describe should be saved with `styles.py --save`.
+Freeform: tone, and anything that must NOT be implied (endorsement, claims).
+
+## Slots
+`era-N` still per scene, `label-N` card (era + year), narration per scene.
+
+## Grammar
+- **Hook** (4-5s): the motif alone, present day, no context. Narration poses
+  the transformation as a question or a flat surprising fact.
+- **Era beats** (3-4 x 5-6s): oldest to newest. Each names its year on a card
+  and shows the motif *in that era's world*. Alternate `ken` zoom direction
+  and pan between consecutive scenes so cuts don't move identically.
+- **Landing** (5-6s): the motif today, narration closing the loop opened by
+  the hook. No CTA — this format is editorial, not an ad.
+- Keep it factual and attributable. State what happened; don't characterise
+  motives or imply the brand endorses the video.
+
+## Render notes
+Stills + `ken` is the whole visual language here, which makes it the cheapest
+format we have (~$0.02/scene generated, or free from stock). Generate video
+only if an era genuinely needs motion. Never ask the generator for logos,
+signage, or years — those are cards.

--- a/skills/video-formats/references/formats/cinematic.md
+++ b/skills/video-formats/references/formats/cinematic.md
@@ -1,0 +1,42 @@
+# Cinematic — mood-driven montage
+
+Atmospheric sequence cut to music: establishing shots, detail close-ups,
+slow motion, minimal or no narration. Carnival/sports/travel energy.
+
+## Composition
+Vertical 1080x1920 @30fps. Full-frame `broll` per scene, hard cuts (or
+brief cross-fades). A score is REQUIRED — supplied file or generated, either
+works. Captions off by default.
+
+## Interview
+Round A — header "Audio": ASK THIS FIRST, before mood or arc. Score: supply a
+file or generate one? If generating, name the backend and its rights terms
+BEFORE they choose — every cut point ends up shaped around whichever track
+arrives, so a rights problem discovered later means re-cutting the whole piece,
+not re-tagging it. Voice: usually none here, but ask rather than assume.
+Round 1 — header "Mood": What feeling? (tension/joy/awe/nostalgia) What's
+the subject?
+Round 2 — header "Arc": Build-up → peak → release: what is each, concretely?
+Round L — header "Look": Which caption/card preset — `styles.py --list`?
+Any look they describe should be saved with `styles.py --save`.
+Freeform: references, shots you already know you want.
+
+Do not ask the user where the drop is — MEASURE it. `scripts/measure.py --music`
+reports the real energy transitions. A remembered timestamp is off by enough to
+miss a cut, and a freshly generated track has no timestamps to remember.
+
+## Slots
+`broll` per scene (4-8 scenes), `music` file, optional 1-2 spoken lines.
+
+## Grammar
+Scenes shorten toward the peak (6s → 2-3s), longest scene right after the
+peak. Silent beats are silence (tts --silence), not filler narration. Cut
+timing should land near music beats — note the drop time from the interview
+and place the peak scene boundary there.
+
+## Render notes
+
+Every scene should carry a `ken` drift — alternate zoom in/out and pan
+direction between scenes so consecutive shots don't move identically.
+Slow-mo: request normal footage, play at 0.5x via composer playbackRate
+(add to Video.tsx when first needed).

--- a/skills/video-formats/references/formats/explainer.md
+++ b/skills/video-formats/references/formats/explainer.md
@@ -1,0 +1,38 @@
+# Explainer — narrated concept walkthrough
+
+Voiceover explains a concept over a sequence of illustrative visuals: b-roll
+cuts, text cards, big-number stat beats. No on-camera host. (Descends from
+showrunner's faceless-explainer, minus the LLM planner — the agent plans.)
+
+## Composition
+Vertical 1080x1920 @30fps (ask if landscape 1920x1080 wanted for YouTube).
+Scene types: full-frame `broll` layers, or text/stat beats built as
+placeholder layers with composer text (add TextCard/StatCard components as
+needed — see the composer's layer renderer). Captions on. One narrator voice.
+
+## Interview
+Round 1 — header "Topic": What concept? What's the one-sentence takeaway a
+viewer should leave with?
+Round 2 — header "Structure": Hook style (question / bold claim / statistic)?
+How long (30/45/60s)?
+Round 3 — header "Visuals": Illustrative footage (generate/find/supply) vs
+motion-graphics text beats — rough mix?
+Round A — header "Audio": Score (supply a file / generate / none)?
+Voice (built-in / supplied recording / none)? If generating the score, say
+which backend and its rights terms before they choose, not after.
+Round L — header "Look": Which caption/card preset — `styles.py --list`?
+Any look they describe should be saved with `styles.py --save`.
+Freeform: audience, tone, examples to include/avoid.
+
+## Slots
+`narration` per scene; visual per scene: `broll` source OR text-beat content
+(heading, stat, caption).
+
+## Grammar
+Hook ≤10 words spoken first. One idea per scene, 4-8s each. Every claim with
+a number gets a stat beat (composer text, pixel-perfect). Close with the
+takeaway restated + soft CTA.
+
+## Render notes
+Narration WAV durations are the clock. Stat/text beats: 3-4s minimum for
+readability.

--- a/skills/video-formats/references/formats/pip-story.md
+++ b/skills/video-formats/references/formats/pip-story.md
@@ -1,0 +1,39 @@
+# PipStory — shrinking-host narrative (script-driven)
+
+One continuous host presence: full-frame for direct-address beats, easing into
+a corner inset over supporting b-roll for concrete/numeric beats, easing back
+before every cut so scene changes land full-frame-to-full-frame. Proven
+grammar (taxonomy 5.1 + the coffee/phone/library/meal-prep demos).
+
+## Composition
+Vertical 1080x1920 @30fps. Layers per scene: optional `broll` (full-frame
+base) + `host` (rect `[0.58,0.58,0.42,0.42]`, enter/exit tweens 0.4s from/to
+full). Captions on. Voices: storyteller + short-reaction cohost.
+
+## Interview
+Round 1 — header "Script": Do you have a script, or should we write one
+together? (Have a file / Draft from a topic / Dictate now)
+Round 2 — header "Host": Use an existing host take pool, generate a new host
+look (describe them), or supply your own footage?
+Round 3 — header "Numbers": Which concrete facts/numbers must land on screen?
+(These become composer text overlays — never generation-prompt text.)
+Round A — header "Audio": Score (supply a file / generate / none)?
+Voice (built-in / supplied recording / none)? If generating the score, say
+which backend and its rights terms before they choose, not after.
+Round L — header "Look": Which caption/card preset — `styles.py --list`?
+Any look they describe should be saved with `styles.py --save`.
+Freeform: anything else about tone, pacing, platform?
+
+## Slots
+`host` (pool takes keyed by mood: talking/listening/surprised/smiling),
+`broll` per pip beat (object/scene shots, NO readable text), narration beats.
+
+## Grammar
+Segment script into 10-30-word beats. `pip` ONLY where narration cites
+something showable (number, bill, object, place); 25-50% of beats. Cohost
+lines ≥3 real words, never bare interjections. Exact figures render as
+composer overlays (StatCard-style), not in footage.
+
+## Render notes
+Host identity: same actual take files across all beats (pool), not repeated
+descriptors. B-roll durations: loop/trim in composer to measured narration.

--- a/skills/video-formats/references/formats/pointer-popups.md
+++ b/skills/video-formats/references/formats/pointer-popups.md
@@ -1,0 +1,53 @@
+# PointerPopups — analyzed footage with images pinned to pointing gestures
+
+The user's own footage (or generated footage) of a presenter pointing at
+empty space; hand-tracking analysis finds where and when they point, and
+popup images appear pinned beside those exact spots. Analysis-driven
+composition: the footage dictates the layout, not the storyboard.
+
+## Composition
+Match the source clip's orientation/dimensions (probe with
+`scripts/measure.py`). Base layer: the user's clip (with its own audio —
+set `muted: false`, no TTS unless they want VO added). Popup layers:
+image layers with `rect` from the tracker, `atMs`/`untilMs` windows,
+`pop: true`, `fit: contain`.
+
+## Interview
+Round 1 — header "Footage": Your pointing video: file path or URL? (This
+format needs real footage — generated pointing works but tracking quality
+follows footage quality.)
+Round 2 — header "Popups": The images to pop up, in pointing order: file
+paths / URLs / generate them? One per point, or should some repeat?
+Round 3 — header "Style": Popup size (small 0.22 / medium 0.30 / large
+0.40 of frame width)? Keep original audio, add VO, or both?
+Round A — header "Audio": Score (supply a file / generate / none)?
+Voice (built-in / supplied recording / none)? If generating the score, say
+which backend and its rights terms before they choose, not after.
+Round L — header "Look": Which caption/card preset — `styles.py --list`?
+Any look they describe should be saved with `styles.py --save`.
+Freeform: anything about timing, linger duration, or what each point means.
+
+## Slots
+`me` (the footage), `popup-N` images (assigned to pointing events in order).
+
+## Grammar / pipeline
+1. `uv run scripts/track_pointing.py analyze --in <clip> --out events.json`
+2. Review events with the user (count + timestamps) — if the tracker found
+   more/fewer points than they expect, show extracted frames at event
+   timestamps and reconcile before composing (extra events → drop by index;
+   missed events → hand-add from frame inspection).
+3. `uv run scripts/track_pointing.py layers --events events.json
+   --images a.png,b.png [--size 0.30]` → paste emitted layers into the
+   scene after the base layer.
+4. Scene `plannedSeconds` = clip duration (measure it); no TTS narration
+   unless requested (base layer keeps its own audio).
+
+## Render notes
+- Tracker assumes ONE pointing hand (max_num_hands=1); two-handed footage
+  needs a second pass with the flag raised.
+- Events under 350ms are dropped as jitter by design — a real "look here"
+  point holds. If the user's style is quick taps, lower MIN_EVENT_MS.
+- The popup rect auto-offsets toward frame center so it never covers the
+  finger; `--size` is the only knob usually worth touching.
+- Verify with extracted frames at each event midpoint before declaring
+  done — tracking confidence varies with lighting and hand size.

--- a/skills/video-formats/references/formats/product-launch.md
+++ b/skills/video-formats/references/formats/product-launch.md
@@ -1,0 +1,41 @@
+# ProductLaunch — 30-40 second launch spot
+
+Hero product, three capability beats, logo landing. The single most common
+archetype in the reference gallery (11 of 48) and the one with the shortest
+prompts, because the shape is so well established.
+
+## Composition
+16:9 1080p by default (ask; 9:16 for social-first). Five to seven scenes.
+Hero shots are stills with a slow `ken` push. Capability beats pair a still
+with a `card` naming the capability. End card is pure typography — product
+name, one line, URL. Captions on. One narrator voice, confident and dry.
+
+## Interview
+Round 1 — header "Product": What is it, and what does it let someone do that
+they couldn't before? (one sentence, no adjectives)
+Round 2 — header "Beats": The three capabilities worth 6 seconds each.
+Round 3 — header "Landing": Exact product name, closing line, and URL — these
+render as real typography, so give them to me exactly as they should appear.
+Round A — header "Audio": Score (supply a file / generate / none)?
+Voice (built-in / supplied recording / none)? If generating the score, say
+which backend and its rights terms before they choose, not after.
+Round L — header "Look": Which caption/card preset — `styles.py --list`?
+Any look they describe should be saved with `styles.py --save`.
+Freeform: brand colours, tone, anything to avoid.
+
+## Slots
+`hero` still, `beat-N` still + card (N=3), `endcard` card, narration.
+
+## Grammar
+- **Hook** (4-5s): the product, tight, unexplained. Narration states the
+  problem it removes — not the product's name.
+- **Reveal** (4-5s): wider, product named for the first time.
+- **Beats** (3 x 5-6s): one capability each. Card carries the capability in
+  <=4 words; narration carries the sentence. Never both saying the same words.
+- **Landing** (4-5s): typography only, held long enough to read twice.
+- One idea per scene. If a beat needs two sentences, it's two beats.
+
+## Render notes
+Real product? Use supplied photography (`file:`) — generators invent details
+and get logos wrong. Fictional product? Stills are fine. Product name and URL
+are ALWAYS cards; a generator will misspell them.

--- a/skills/video-formats/references/formats/talking-head.md
+++ b/skills/video-formats/references/formats/talking-head.md
@@ -1,0 +1,34 @@
+# TalkingHead — direct-to-camera monologue
+
+One person talks to camera throughout; optional lower-third labels and
+inset media moments. The base grammar behind storytime/confessional formats.
+
+## Composition
+Vertical 1080x1920 @30fps. Single `host` layer full-frame; optional brief
+`insert` layers (image/clip, rect `[0.06,0.55,0.88,0.33]`) for receipts/
+screenshots/moments. Captions on, karaoke style.
+
+## Interview
+Round 1 — header "Story": What's the story/message? Real footage of you, or
+a generated presenter?
+Round 2 — header "Beats": Where are the emotional turns? (These get
+expression changes / take changes.)
+Round 3 — header "Inserts": Any evidence moments (screenshots, photos,
+clips) to cut in? How sourced?
+Round A — header "Audio": Score (supply a file / generate / none)?
+Voice (built-in / supplied recording / none)? If generating the score, say
+which backend and its rights terms before they choose, not after.
+Round L — header "Look": Which caption/card preset — `styles.py --list`?
+Any look they describe should be saved with `styles.py --save`.
+Freeform: platform, length, energy level.
+
+## Slots
+`host` takes (pool by mood), optional `insert` media per beat, narration.
+
+## Grammar
+Open mid-story (no throat-clearing). Cut takes at emotional turns even if
+the setting is constant — take changes read as authenticity. Inserts ≤3s,
+never over the speaker's key lines.
+
+## Render notes
+If host is generated: pool takes, ping-pong loop for beats >6s (MiniMax cap).

--- a/skills/video-formats/references/formats/timeline-explainer.md
+++ b/skills/video-formats/references/formats/timeline-explainer.md
@@ -1,0 +1,42 @@
+# TimelineExplainer — numbered walk through a history
+
+A sequence of numbered beats moving through time: a discography, a
+leadership history, a company's decade. Distinct from BrandOrigin in that the
+*list* is the point — viewers are counting along — and it runs longer.
+
+## Composition
+16:9 1080p @30fps (9:16 works; cards get tighter). Six to ten scenes, 5-7s
+each. Each beat opens on its number as a `card`, then reveals a still. The
+number card is the format's signature — same position, same style, every
+beat, so the count is legible at a glance. Captions on.
+
+## Interview
+Round 1 — header "Subject": What history, and how many beats? (6-10; more
+than 10 wants a longer format)
+Round 2 — header "Beats": For each: the year/number, the one-line fact, and
+what we'd see.
+Round 3 — header "Arc": What's the through-line the last beat should land?
+Round A — header "Audio": Score (supply a file / generate / none)?
+Voice (built-in / supplied recording / none)? If generating the score, say
+which backend and its rights terms before they choose, not after.
+Round L — header "Look": Which caption/card preset — `styles.py --list`?
+Any look they describe should be saved with `styles.py --save`.
+Freeform: tone, and any claim that needs care.
+
+## Slots
+`num-N` card (number + year), `still-N` visual, narration per beat.
+
+## Grammar
+- **Cold open** (4s): the arc's end state as a question. No number.
+- **Beats** (6-10 x 5-7s): number card enters first (`atMs` ~0, `pop`), still
+  underneath with `ken`. Narration is one fact per beat — resist two.
+- **Landing** (5-6s): answers the cold open. Card, no still.
+- Numbers, years, and names are cards. Stills carry mood, not information.
+- Keep facts checkable and neutrally stated; this format invites strong claims
+  and shouldn't make them.
+
+## Render notes
+The most card-heavy format we have — good stress test of whether card layers
+can carry a video rather than accent one. If a still adds nothing to a beat,
+use a card alone on a flat background; an honest text beat beats a decorative
+image.

--- a/skills/video-formats/references/formats/titled-video.md
+++ b/skills/video-formats/references/formats/titled-video.md
@@ -1,0 +1,36 @@
+# TitledVideo — clip + typography package
+
+An existing (or generated) clip dressed with title/end cards and section
+labels — the "make this clip postable" format.
+
+## Composition
+Match source clip's orientation (probe with scripts/measure.py). Layers:
+`main` clip full-frame; title card scene first (2-3s, text on color or
+frame-grab background); optional corner section labels; end card with CTA.
+
+## Interview
+Round 1 — header "Source": The clip: supply file / URL / generate?
+Round 2 — header "Text": Exact title, section labels (if any), end-card CTA
+text. (Exact text — it renders as real typography.)
+Round 3 — header "Style": Color accent + font vibe (clean/bold/playful)?
+Round A — header "Audio": Score (supply a file / generate / none)?
+Voice (built-in / supplied recording / none)? If generating the score, say
+which backend and its rights terms before they choose, not after.
+Round L — header "Look": Which caption/card preset — `styles.py --list`?
+Any look they describe should be saved with `styles.py --save`.
+Freeform: platform, whether captions are wanted over the clip.
+
+## Slots
+`main` clip, `title`, optional `labels[]` with timestamps, `cta`.
+
+## Grammar
+Title card ≤6 words. Labels appear at content transitions (probe the clip's
+scene cuts if unsure — the quality check's scene detection can list them). End
+card holds 3s minimum.
+
+## Render notes
+
+If the source is a still (or a very short clip held long), give it a `ken`
+drift so it reads as footage rather than a frozen frame.
+This format is pure composition — usually zero generation cost. Good first
+demo of the studio preview loop.

--- a/skills/voice-matching/SKILL.md
+++ b/skills/voice-matching/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: voice-matching
-description: Use when writing in a creator's voice, analyzing a creator's style, or maintaining consistency across content.
+description: Use when writing in a creator's voice, analyzing a creator's style, or maintaining voice consistency across content.
 ---
 
 # Voice Matching

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SKILLS_DIR="$HOME/.claude/skills"
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_DIR="${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills}"
 
 count=0
 for link in "$SKILLS_DIR"/social-skills--*; do
-  [ -L "$link" ] || continue
-  rm "$link"
+  # Match symlinks and any leftover copies (broken links included).
+  [ -L "$link" ] || [ -e "$link" ] || continue
+  rm -rf "$link"
   count=$((count + 1))
 done
 
-# Clean up .root files
+# Clean up .root files written by older versions of install.sh.
 for skill_dir in "$REPO_DIR"/skills/*/; do
+  [ -d "$skill_dir" ] || continue
   rm -f "$skill_dir/.root"
 done
 
-echo "Removed $count social-skills symlinks."
+echo "Removed $count social-skills entr(ies) from $SKILLS_DIR."


### PR DESCRIPTION
Two changes that belong together: a fix to how skills resolve their references, and the first four skills migrated out of `video-studio`.

## The fix

Skills resolved shared references through a `.root` file written by `install.sh`. Installing via `npx skills add` **copies** the folder instead — no symlink, no `.root`, no `references/` — so skills silently fell back to a degraded path with no error. That is the route the public site advertises.

Every skill folder is now self-contained. Six `SKILL.md` files load references relative to their own directory; their prose is otherwise unchanged. `install.sh`/`uninstall.sh` no longer write `.root` and clean up stale ones and npx-left copies.

`scripts/verify-skills.sh` fails if any skill reaches outside its folder, names a reference it does not ship, ships one it never loads, has malformed frontmatter, or is missing from the README table. It was tested against deliberately broken fixtures, not just the happy path.

## The four skills

| Skill | What it is | Standalone? |
|---|---|---|
| `agent-interview` | The question protocol — ask one thing at a time, numbered options, numbered fallback | Yes |
| `video-formats` | Router plus the 10 format grammars, copied verbatim | 8 of 10 |
| `brand-kit` | Look presets reframed as saving a brand | Needs `styles.py` |
| `studio-setup` | Environment check and triage | Needs `doctor.py`/`setup.py` |

## What is deliberately *not* here

The Python and Remotion toolchain stays in `scrollmark/video-studio` (private). Skills invoke it and **declare** it — each has a `## Requires` block naming the script and what degrades without it.

Two reasons. `npx skills add` only copies markdown; it does not run `npm install`, `pip install`, or resolve `mediapipe` — so vendoring a toolchain recreates the exact bug this PR fixes, at a scale no verifier can catch. And the renderer is Remotion 4.x, which is source-available and needs a paid Company Licence above three people; vendoring it into a public repo hands that obligation to everyone who installs.

The seam is stated honestly rather than hidden: `boil` is ~40% inoperative without `gen_boil.py`, and `pointer-popups` has no usable grammar without `track_pointing.py`. The README says so.

## Worth a reviewer's eye

- **`SERVICES.md`** in `studio-setup` — every external service with cost, rights, and licence link. Two items were reworded for a public repo: a MiniMax music cell describing the service as usable unbilled and labelled internal-only, and an "internal stack" heading. Same warnings, external phrasing.
- **`brand-kit` documents something unbuilt.** The `brands/` bundle is fenced as **PROPOSED, NOT BUILT** — `styles.py` reads only `captions` and `cards` today and flags other keys as unknown.
- **Conflicts with `individual-installs`.** That branch also changes README, `install.sh`, and `uninstall.sh`. The changes are complementary — that one picks *which* skills install, this one changes *what* gets installed — so they should be folded together rather than one dropped.

## Known gaps

- Shared references are duplicated into each skill. An edit must touch the root copy and every skill copy in one commit; the verifier catches a missing file, not a stale one.
- `agent-interview` is 83 lines against a 45–80 target (warning, not failure).
- No test scenarios yet for the four new skills.
- The repo name and description no longer match its scope.

## Numbers

7 skills to 11. 29 files to 76 — though ~30 of those are the same 5 platform files copied into six skills, so hand-written new content is closer to 14 files.