### PR TITLE
Fold individual-skill installs onto the self-contained installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,25 @@ so edits in your clone take effect immediately. It is idempotent — re-run it a
 including after pulling new skills — and it prunes links whose skill no longer exists.
 Set `CLAUDE_SKILLS_DIR` to install somewhere other than `~/.claude/skills`.
 
+Install a subset by naming the skills, which is worth doing if you only want the
+social-media half or only the video half:
+
+```bash
+./install.sh trend-radar hook-anatomy    # just these two
+./install.sh --list                      # what is available
+```
+
+An unknown name is an error rather than a silent no-op, and a partial install never
+prunes skills it was not asked about.
+
 Either way, skills become available in your next Claude Code session. Neither route
 installs, downloads, or requires video-studio.
 
 ## Uninstall
 
 ```bash
-./uninstall.sh
+./uninstall.sh              # everything
+./uninstall.sh trend-radar  # just one
 ```
 
 Removes every `social-skills--*` entry from your skills directory (symlinks and copies

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Development install: symlink each skill folder into ~/.claude/skills/.
+# Development install: symlink skill folders into ~/.claude/skills/.
 # Each skill folder is self-contained — it carries its own references/ —
 # so a symlinked install and a copied install (npx skills add) behave identically.
+#
+#   ./install.sh                      install every skill
+#   ./install.sh trend-radar          install just one
+#   ./install.sh brand-kit video-formats
+#   ./install.sh --list               show what is available
 #
 # Regular users do not need this script:
 #   npx skills add scrollmark/social-skills
@@ -11,11 +16,52 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills}"
 
-mkdir -p "$SKILLS_DIR"
+available() {
+  for d in "$REPO_DIR"/skills/*/; do
+    [ -f "$d/SKILL.md" ] && basename "$d"
+  done
+}
 
-installed=0
-for skill_dir in "$REPO_DIR"/skills/*/; do
-  [ -f "$skill_dir/SKILL.md" ] || continue
+usage() {
+  cat <<EOF
+Usage: ./install.sh [skill ...]
+
+With no arguments, installs every skill. Named skills install only those.
+
+Available:
+$(available | sed 's/^/  /')
+
+Options:
+  --list, -l    list available skills and exit
+  --help, -h    show this message
+EOF
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  -l|--list) available; exit 0 ;;
+esac
+
+# Resolve the requested set, failing loudly on a name that does not exist —
+# a typo should not look like a successful install of nothing.
+requested=("$@")
+if [ ${#requested[@]} -gt 0 ]; then
+  unknown=()
+  for name in "${requested[@]}"; do
+    [ -f "$REPO_DIR/skills/$name/SKILL.md" ] || unknown+=("$name")
+  done
+  if [ ${#unknown[@]} -gt 0 ]; then
+    echo "Unknown skill(s): ${unknown[*]}" >&2
+    echo "" >&2
+    echo "Available:" >&2
+    available | sed 's/^/  /' >&2
+    exit 1
+  fi
+fi
+
+install_one() {
+  local skill_dir="${1%/}"
+  local name target
   name="$(basename "$skill_dir")"
   target="$SKILLS_DIR/social-skills--$name"
 
@@ -26,19 +72,37 @@ for skill_dir in "$REPO_DIR"/skills/*/; do
   if [ -L "$target" ] || [ -e "$target" ]; then
     rm -rf "$target"
   fi
-  ln -s "${skill_dir%/}" "$target"
-  installed=$((installed + 1))
+  ln -s "$skill_dir" "$target"
   echo "  installed: social-skills--$name"
-done
+}
 
-# Remove links for skills that no longer exist in this repo.
-for link in "$SKILLS_DIR"/social-skills--*; do
-  [ -L "$link" ] || continue
-  if [ ! -e "$link" ]; then
-    rm -f "$link"
-    echo "  pruned (stale): $(basename "$link")"
-  fi
-done
+mkdir -p "$SKILLS_DIR"
+
+installed=0
+if [ ${#requested[@]} -gt 0 ]; then
+  for name in "${requested[@]}"; do
+    install_one "$REPO_DIR/skills/$name"
+    installed=$((installed + 1))
+  done
+else
+  for skill_dir in "$REPO_DIR"/skills/*/; do
+    [ -f "$skill_dir/SKILL.md" ] || continue
+    install_one "$skill_dir"
+    installed=$((installed + 1))
+  done
+fi
+
+# Remove links for skills that no longer exist in this repo. Only safe on a
+# full install — a partial install must not prune skills it was not asked about.
+if [ ${#requested[@]} -eq 0 ]; then
+  for link in "$SKILLS_DIR"/social-skills--*; do
+    [ -L "$link" ] || continue
+    if [ ! -e "$link" ]; then
+      rm -f "$link"
+      echo "  pruned (stale): $(basename "$link")"
+    fi
+  done
+fi
 
 echo ""
 echo "Done. $installed skill(s) installed into $SKILLS_DIR."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,21 +1,72 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Remove skills installed by ./install.sh.
+#
+#   ./uninstall.sh                    remove every social-skills entry
+#   ./uninstall.sh trend-radar        remove just one
+#   ./uninstall.sh brand-kit video-formats
+
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills}"
 
-count=0
-for link in "$SKILLS_DIR"/social-skills--*; do
+installed_entries() {
+  for link in "$SKILLS_DIR"/social-skills--*; do
+    [ -L "$link" ] || [ -e "$link" ] || continue
+    basename "$link" | sed 's/^social-skills--//'
+  done
+}
+
+usage() {
+  cat <<EOF
+Usage: ./uninstall.sh [skill ...]
+
+With no arguments, removes every social-skills entry. Named skills remove
+only those.
+
+Currently installed:
+$(installed_entries | sed 's/^/  /')
+EOF
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+remove_one() {
+  local name="$1"
+  local target="$SKILLS_DIR/social-skills--$name"
   # Match symlinks and any leftover copies (broken links included).
-  [ -L "$link" ] || [ -e "$link" ] || continue
-  rm -rf "$link"
-  count=$((count + 1))
-done
+  if [ -L "$target" ] || [ -e "$target" ]; then
+    rm -rf "$target"
+    echo "  removed: social-skills--$name"
+    return 0
+  fi
+  echo "  not installed: social-skills--$name" >&2
+  return 1
+}
 
-# Clean up .root files written by older versions of install.sh.
-for skill_dir in "$REPO_DIR"/skills/*/; do
-  [ -d "$skill_dir" ] || continue
-  rm -f "$skill_dir/.root"
-done
+count=0
+if [ $# -gt 0 ]; then
+  for name in "$@"; do
+    remove_one "$name" && count=$((count + 1)) || true
+  done
+else
+  for link in "$SKILLS_DIR"/social-skills--*; do
+    [ -L "$link" ] || [ -e "$link" ] || continue
+    rm -rf "$link"
+    count=$((count + 1))
+  done
+fi
 
+# Clean up .root files written by older versions of install.sh. Only on a full
+# uninstall — a partial one should leave the rest of the repo alone.
+if [ $# -eq 0 ]; then
+  for skill_dir in "$REPO_DIR"/skills/*/; do
+    [ -d "$skill_dir" ] || continue
+    rm -f "$skill_dir/.root"
+  done
+fi
+
+echo ""
 echo "Removed $count social-skills entr(ies) from $SKILLS_DIR."


### PR DESCRIPTION
Supersedes #3.

#3 adds a genuinely useful feature — install one skill instead of all of them — but it branched before the `.root` removal in #4. Merging it directly would revert the self-containment fix, because it rewrites the same three files against the old versions.

So this reapplies the feature on top of the current installers rather than merging the branch.

## What you get

```bash
./install.sh                          # everything, as before
./install.sh trend-radar hook-anatomy # a subset
./install.sh --list                   # what is available
./uninstall.sh trend-radar            # remove one
```

Useful now that the repo spans two domains — you can take the social-media skills without the video ones, or the reverse.

## Behaviour worth reviewing

- **An unknown name exits 1** and prints the available list, rather than reporting a successful install of nothing. That was the failure mode most likely to bite.
- **A partial install does not prune.** Pruning stale links is correct on a full install and wrong on a partial one, which has no idea what the other skills are for.
- **A partial uninstall leaves `.root` cleanup alone**, for the same reason.

## Tested

Full install, single install, multi install, `--list`, unknown name, partial-install-does-not-prune, single uninstall, full uninstall — against a scratch `CLAUDE_SKILLS_DIR`. Verifier passes: 11 skills, one pre-existing warning.

## Note on #3

Close #3 in favour of this. The feature and the authorship are John's; this is the same idea rebased onto the fix.