### PR TITLE
The remaining video skills: acquisition, compositing, and editor handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ they describe is executed by the video-studio engine.
 |-------|----------|-------------|
 | `video-formats` | Planning, structuring, or critiquing a short-form video — choosing a format, laying out its scenes, or defining a new format. Covers ten scene grammars from talking-head to hand-drawn motion graphics. | Mostly — 8 of the 10 formats are pure structure. **Boil** and **PointerPopups** are not (see below). |
 | `brand-kit` | A user wants their videos to stay visually consistent — saving caption styling, card colours and geometry, title treatment, logos, fonts, voice and CTA copy once instead of redeciding them per video. | Deciding and recording a brand, yes. Applying it automatically at render time needs the engine. |
+| `media-acquisition` | Deciding where a shot's footage or stills should come from — public-domain archive, free stock, a paid generator, or a URL the user supplied — and when checking that what came back is actually usable before anything is built on it. | **No.** It is a selection rule wrapped around ten sourcing scripts; without them nothing searches, generates, or checks what arrived. |
+| `audio-acquisition` | A video needs narration, a music bed or sound effects — choosing a voice, deciding which music source is safe to publish with, timing a cut to a track, or fixing a render that came out quiet. | Partly. The rights tiering and mixing discipline read as a briefing; synthesis, measurement and licence filtering are the engine. |
+| `subject-compositing` | A filmed person has to appear somewhere they never were — dropping a subject over replacement footage, putting a drawn prop in front of them, driving the pair across frame, or pinning popup images to where they point on camera. | **No.** The segmentation, occlusion seam, arm punch-through and gesture timing are all engine scripts. What survives is knowing what footage to shoot. |
+| `edit-handoff` | A finished cut has to leave the pipeline and continue in a human editor — exporting a timeline to Premiere Pro, DaVinci Resolve, Final Cut Pro or CapCut, or answering what survives the trip and what an editor has to rebuild. | **No.** The exporters read the engine's timeline document; there is no degraded mode that still writes a file. The format judgement generalises. |
 
 ### Working method and toolchain
 
@@ -82,6 +86,25 @@ If you do not have access to video-studio, here is exactly what that costs you:
 - `brand-kit` lets you agree a brand with a user and hand-write the files. The preset
   mechanism — `--list`, `--show`, `--apply`, `--save` — is `styles.py`, and nothing expands
   a preset into a storyboard without it, so applying a brand becomes manual editing.
+- **`media-acquisition` does not work standalone.** The provider ladder, the shot-type
+  corollary and the landmine file are readable and will tell a human which library to
+  open — but the searching, generating, licence filtering and the five-way check on what
+  came back are all `source_clips.py`, the `stock_*` scripts, the `gen_*` scripts and
+  `verify_clips.py`. Without them it is a briefing document, not a workflow.
+- `audio-acquisition` keeps the part that matters commercially — which music source is
+  safe to publish with, and why the free one is not — plus the measure-don't-trust
+  discipline. Synthesis, loudness measurement and the per-sound licence filter are
+  `tts_kokoro.py`, `tts_eleven.py`, `gen_music.py`, `stock_freesound.py`, `measure.py`
+  and `normalize_audio.py`.
+- **`subject-compositing` is entirely engine-side.** `composite_subject.py` does the
+  segmentation, the feathered occlusion seam and the arm punch-through;
+  `track_pointing.py` does the gesture timing. Without them there is no shot. The one
+  part that survives is the footage brief — what a selfie segmenter needs from a take —
+  and it is worth having before anyone films.
+- **`edit-handoff` cannot produce a file without the engine.** `export_edit.py`,
+  `export_fcpxml.py` and `export_capcut.py` all read video-studio's per-project timeline
+  document. What generalises is the judgement: which format each application actually
+  imports, and that no interchange format carries effects.
 - `studio-setup` keeps its tooling inventory, but the single status report, the install
   plan and the auto/system/manual classification all come from `doctor.py` and `setup.py`.
   You can still check binaries by hand.

--- a/skills/audio-acquisition/SKILL.md
+++ b/skills/audio-acquisition/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: audio-acquisition
+description: Use when a video needs narration, a music bed or sound effects — choosing a voice, deciding which music source is safe to publish with, timing a cut to a track, or fixing a render that came out quiet.
+---
+
+# Audio Acquisition
+
+Audio is a question, never a leftover. Ask it every time, including for formats with no narration — a silent piece should be silent because somebody chose that, not because nobody raised it. Three decisions, and they have genuinely different answers.
+
+## Requires
+
+The audio scripts from **scrollmark/video-studio** (private): `tts_kokoro.py` (local voice plus word timings), `tts_eleven.py` (paid voice), `gen_music.py` (score), `stock_freesound.py` (effects, licence-filtered), `measure.py` (durations and a track's energy structure) and `normalize_audio.py` (loudness).
+
+Without them the rights tiering and the mixing discipline below still tell a human which service to buy and what to check — but nothing synthesises, nothing measures, and the licence filter that makes the effects tier safe lives in the script rather than in this prose. Treat it as a briefing, not a workflow.
+
+## Voice
+
+**The local voice is the default and it is free.** It runs offline, needs no key, and — the part that matters structurally — it returns **word timings**, which are what captions are driven by. A captioned format has no other option.
+
+Reach for the paid voice only when the read itself is the deliverable: a brand film, a client voice, anything where a flat delivery is the thing someone would complain about. It bills per character (~1,100 characters is a 90-second script) and it returns **no word timings**, so a captioned format still needs the local voice underneath.
+
+Both cache: identical text, voice and settings is a no-op reporting `cached: true`, so re-running every scene on a revision costs nothing and only the changed lines re-synthesise. **Do not force a re-render to "make sure it's fresh"** — a fresh synthesis can come back a few milliseconds different, and that shifts every cut after it.
+
+Narration is synthesised **first**, before footage, because measured narration duration is the scene clock. Never write an empty line to the synthesiser; ask it for measured silence instead, so downstream concatenation stays aligned.
+
+## Score — a rights decision before it is a taste decision
+
+This is the one category where the quality leader is the wrong answer, and the choice must be made **before** the cut is built around a track.
+
+- **If the piece will ever be published, use a licensed-catalogue generator.** The ElevenLabs music model trained on licensed catalogue with terms settled before launch, and commercial use starts around six dollars a month — so the rights caveat is a pricing decision rather than a constraint. It is also the only one that takes an exact length as a parameter.
+- **Lyria is clean under Google's terms** and shares the same key as the video and image generators, so it adds no account. Its free-tier quota is literally zero, which surfaces as a 429 that never clears.
+- **MiniMax music is free, unbilled, and its redistribution rights are unclear** — the training data is undisclosed and the terms do not clearly grant redistribution of generated output. Fine for internal and demo work, never under client work, and it should be reachable only by name rather than by an auto-pick.
+- **The best-sounding options are the ones to avoid.** Unresolved training-data litigation, and mostly no public API to automate against anyway.
+
+Costs and licence terms per service are tabulated in the `studio-setup` skill's `SERVICES.md` — read the rights column, not the price column, before publishing.
+
+**For a music-led format the score is the FIRST question of the interview, not the last.** Scene durations are cut to the track's energy envelope, so choosing it late means re-timing every scene. Get the track, map it, then set durations.
+
+## Effects
+
+Usually none. Offer them only when the format calls for them and the effects source is actually reachable. Freesound licences vary **per sound** — CC0, CC-BY, CC-BY-NC — so the default accepts CC0 only, nothing downstream carries an obligation, and widening to CC-BY means you must place the returned credit. Non-commercial licensed sound cannot go into client work at all.
+
+## Measure, Do Not Trust
+
+**Requested length is a hint, not a contract.** Most music generators take duration in the prompt and ignore it — one returned ~115 seconds for a 35-second ask. Only the licensed-catalogue one accepts a real length parameter. Measure every returned file; never write a planned duration into the timeline.
+
+**Cut to where the track actually changes.** `measure.py --music` reports a per-second loudness profile and the transitions — points where a window jumps or drops at least 3 dB against the trailing three seconds. Those are the drops and lifts, and they are the only defensible places to change section. Sections placed on a grid drift out of phase within about twenty seconds and read as arbitrary; a fade placed in the quiet bar before a final chorus sounds like the video was cut off, because it was.
+
+**Adding music silently costs 6 dB.** Tracks are summed by a mixer that divides by the number of inputs, so one music track turns 1 input into 2 and halves everything — narration included. Measured: voice at -17.3 dB without music and -23.5 dB with; the whole video -14.4 LUFS to -20.3 LUFS. Nothing looks wrong. The render succeeds, the balance is correct because both sources scaled equally, and the result is simply quiet — the one defect that survives every visual check. **Run `normalize_audio.py --in <render>` after any render with music**; it restores about -14 LUFS and preserves the balance. Generated music can also arrive peaking at 0 dBFS, so there is no headroom to lose.
+
+**Mix a bed by probing, not by guessing.** A bed generated at -15 LUFS with a -17 dB gain and an aggressive sidechain came out completely inaudible, and every level probe read within ±0.2 dB of the un-bedded mix — nothing in the logs said so. Verify by measuring RMS in a speech gap against RMS under loud speech: a bed should lift the gaps by roughly 6 dB and vanish under the loudest line.
+
+Voice-specific traps — how punctuation is stamped in the timing file, why a cached WAV has no timings, why a two-word line garbles — are in `references/voice-landmines.md`.
+
+## Anti-patterns
+
+- **Choosing a score by sound and discovering the rights afterwards.** A rights problem found after the edit means re-cutting, not re-tagging.
+- **Letting silence happen by omission.** Ask; then a silent piece is a choice.
+- **Writing planned durations into the timeline.** Measured audio is the clock. Planned durations desync audio, video and captions cumulatively.
+- **Declaring a mix done without measuring it.** Quiet and inaudible both render successfully and both look perfect on every frame you check.

--- a/skills/audio-acquisition/references/voice-landmines.md
+++ b/skills/audio-acquisition/references/voice-landmines.md
@@ -1,0 +1,64 @@
+# Voice and music landmines
+
+Failure modes recorded from production. All of them succeed loudly and fail
+quietly.
+
+## The local voice (Kokoro)
+
+- **Empty text raises "returned no audio".** For a deliberate quiet beat, ask
+  for measured silence instead — it writes real silence, so downstream audio
+  concatenation clocks stay aligned. A skipped file does not.
+- **Trailing punctuation is stamped at the NEXT word's start.** It arrives as
+  its own token, so unless punctuation-only tokens are merged onto the
+  preceding word, every caption page opens with a stray mark.
+- **Word timings exist only at synthesis time.** A resumed or cached WAV has
+  none. If you need timings for a file you did not just synthesise, fall back
+  to ASR or proportional estimation — and know that you have downgraded.
+- **Short interjection lines garble.** "Mhm." breaks both synthesis and the
+  downstream ASR check. Keep spoken lines to at least three real words.
+- Delivery is flat by design. That is a reason to buy a voice for a brand film,
+  not a reason to abandon it for a captioned format that needs the timings.
+
+## The paid voice
+
+- **No word timings at all.** Duration is measured off the returned file. A
+  captioned format still needs the local voice.
+- **Billed per character.** Check the account's own rate before a long batch;
+  a 90-second script is roughly 1,100 characters.
+- Caches on text + voice + settings exactly like the local one, so revisions
+  over unchanged scenes are free.
+
+## Music generators
+
+- **Duration is a prompt hint for most of them.** One returned ~115 seconds for
+  a 35-second request. Only the licensed-catalogue provider accepts a real
+  length parameter. Always measure what came back.
+- **A required field that reads as optional:** at least one provider requires a
+  lyrics field even for an instrumental, and omitting it returns a generic
+  "invalid params" error that names nothing. Pass an explicit instrumental
+  marker.
+- **A free tier whose quota is zero.** The resulting 429 is indistinguishable
+  from rate limiting and never clears, because there is no allowance to reset.
+  It is a billing gate.
+- **Generated music can arrive peaking at 0 dBFS**, leaving no headroom. This
+  is why normalising after render is real work rather than cosmetics.
+
+## The composer's mix
+
+- Music plays at a **fixed volume and does not duck under narration.** Balance
+  is set once, not per phrase — so a bed that competes with a loud line will
+  compete with it for the whole video.
+- Adding any music track halves everything (see the 6 dB note in the SKILL).
+  Normalise after every render that has music.
+
+## Loudness targets
+
+Platforms re-normalise on upload and can pump artefacts doing it, so a render
+far from about **-14 LUFS** is a defect even though it plays fine locally.
+Local synthesis is conservative, so renders trend quiet by default. Normalising
+stream-copies the video, so it is fast and lossless picture-side — there is no
+reason to skip it.
+
+Confirm both duration and loudness with a probe after the final render. Every
+shipped-broken audio mix in this pipeline's history would have been caught by
+one measurement.

--- a/skills/edit-handoff/SKILL.md
+++ b/skills/edit-handoff/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: edit-handoff
+description: Use when a finished cut has to leave the pipeline and continue in a human editor — exporting a timeline to Premiere Pro, DaVinci Resolve, Final Cut Pro or CapCut, or answering what survives the trip and what an editor has to rebuild.
+---
+
+# Edit Handoff
+
+"Can I finish this in Premiere?" is a handoff, not a render. The job is to move
+the tedious half of the edit — forty cuts on their true frames, each clip
+pointing at its real source, audio in sync — and to be exact about the half that
+does not move, because being vague there costs an editor an afternoon.
+
+## Requires
+
+`scripts/export_edit.py`, `scripts/export_fcpxml.py` and `scripts/export_capcut.py`
+from **scrollmark/video-studio** (private). They read that repo's per-project
+timeline document, so there is no degraded mode that still produces a file: no
+engine, no export. What survives without it is the judgement below — which
+format an editor should be asked for, and what to warn them about — which
+applies to any OTIO or FCPXML handoff, whoever writes it.
+
+## Which Export, Which Application
+
+| Target | Script | Route |
+|---|---|---|
+| Premiere Pro, DaVinci Resolve | `export_edit.py` | `.otio`, imported natively — no plugin |
+| Final Cut Pro | `export_fcpxml.py` | `.fcpxml` 1.9, opens as a real project |
+| CapCut | `export_capcut.py --install` | overwrites `draft_info.json` in an existing project |
+| Any of them, another machine | add `--bundle` | copies the media in beside the timeline |
+
+    uv run scripts/export_edit.py --project <dir>
+
+**Always pass `--project`.** It rebuilds that project's timeline first. The
+composer's props document is global, so exporting unbuilt silently emits
+whichever video was rendered last — a wrong file that looks entirely correct.
+
+There is no `.prproj` writer and there should not be one: Premiere's format is
+undocumented, versioned to the application, and a reverse-engineered writer
+breaks silently inside someone else's edit. Adobe's supported inbound paths are
+OTIO, FCP7 XML, AAF and EDL. FCPXML is the opposite case — Apple publishes it,
+which is why Final Cut gets a direct writer.
+
+## What Travels
+
+**Survives everywhere:** every cut at its true frame, each clip linked to its
+real source file, per-scene narration, music, and the captions as a sidecar
+`.srt` (Premiere imports it as a caption track).
+
+**Does not survive the generic path:** camera moves, fades, and the on-screen
+cards. This is not a gap in the exporter — the interchange formats carry no
+effects at all; OTIO's own matrix marks effects unsupported across EDL, FCP7
+XML, FCP X and AAF alike. So cards are written as **timeline markers carrying
+their text** at the frame where each appeared, and camera moves are marked the
+same way. The editor does not get the title; they get a labelled spot saying
+what belonged there.
+
+**Final Cut is the exception worth naming.** `export_fcpxml.py` writes cards as
+real `<title>` elements on Final Cut's Basic Title generator and camera moves as
+keyframed `<adjust-transform>`, both editable in the inspector. Measured on a
+real project, the generic OTIO→FCPX adapter emitted zero of each. If the cards
+matter and the editor is on Final Cut, use this path.
+
+## CapCut Wants an Empty Project First
+
+Ask the user to create one in CapCut itself (File > New Project, save, add
+nothing) and hand over the path. The script will not create the folder. A real
+project carries a dozen undocumented sibling files — `draft_meta_info.json`,
+`draft_settings`, `Resources/`, `matting/` — that only CapCut knows how to
+write, and a folder missing them appears in the drafts list and does nothing
+when clicked. Cards do not travel here either.
+
+## Anti-patterns
+
+- **Exporting without `--project`.** The failure is silent and ships the wrong video.
+- **Saying "it exports the whole video".** It exports the cut. Effects are rebuilt.
+- **Promising cards on the OTIO path.** They arrive as markers. Only FCPXML carries them.
+- **Claiming app-tested.** The FCPXML is validated by parsing its own output, not by
+  opening it in Final Cut. Say which one you mean.

--- a/skills/media-acquisition/SKILL.md
+++ b/skills/media-acquisition/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: media-acquisition
+description: Use when deciding where a shot's footage or stills should come from — public-domain archive, free stock, a paid generator, or a URL the user supplied — and when checking that what came back is actually usable before anything is built on it.
+---
+
+# Media Acquisition
+
+One shot, one source, decided by a rule rather than by which vendor sounds impressive. Apply it **per shot**, never per project — a single video routinely mixes all four tiers.
+
+## Requires
+
+The sourcing scripts from **scrollmark/video-studio** (private): `source_clips.py` (user URLs and licence-filtered search), `stock_archive.py`, `stock_pexels.py`, `stock_pixabay.py`, `stock_shutterstock.py` (stock), `gen_image.py`, `gen_veo.py`, `gen_minimax.py`, `gen_replicate.py` (generation), `verify_clips.py` (the return check) and `prekey.py` (keying a generated clip to alpha).
+
+**This skill is not usable standalone.** It is a selection rule wrapped around ten scripts. Without them you keep the ladder as a briefing document — it will tell a human which library to open and why — but nothing searches, nothing generates, nothing checks what arrived, and the licence filtering that makes the tiers safe is inside the scripts, not in this prose.
+
+## The Ladder
+
+    1. Does the subject exist in the real world?
+       NO  -> GENERATE (fictional product, invented scene, stylised abstraction)
+    2. Is it public, historical, scientific, civic or natural?
+       YES -> ARCHIVE  (free, no key: space, weather, wildlife, infrastructure, record)
+    3. Is it everyday or commercial — interiors, people at work, food, cities?
+       YES -> STOCK    (free with a key, modern catalogues)
+    4. Otherwise GENERATE. Then: does the MOTION carry meaning?
+       YES -> generate video    (a person acting, a process, a camera move)
+       NO  -> generate a STILL + camera drift  (~10x cheaper, and steadier)
+
+**Ordered by how likely the result is to be wrong, not by quality.** Every failure this pipeline has actually shipped came from generated footage — invented pseudo-text on a prop, an unplanned cut mid-clip, a presenter whose face changed between scenes. Real footage has none of those modes, costs nothing, and is already licensed. Generation is the fallback.
+
+**Archives go first among the free tiers** because they need no credential at all, which makes them the only sources guaranteed to work on a fresh machine. Their honest limit: deep on science, space, history and nature; thin to absent on staged modern subjects. Check what a query actually returns before promising a scene from them.
+
+**Tie-break on licence breadth, not catalogue size.** Prefer a source whose licence covers the whole catalogue over one that varies per item. An agent choosing hundreds of assets cannot do per-item rights reasoning reliably and one bad pick is a real liability — that is why Pexels outranks the mixed-licence libraries, and why the archive and effects scripts filter by licence rather than trusting search rank.
+
+## Shot Type Beats Subject
+
+The ladder keys on the subject, and that is not sufficient. A plastic toy brick is real, everyday and mass-produced, so step 3 says stock — and stock lost all four brick scenes to paid generation: a studio-lit isolated brick came back as a child with wooden cubes, a macro of the underside came back as a family on a rug.
+
+> **Stock is strong on subjects in context and a desert for objects in isolation.** A studio hero shot, a product macro or a mechanism close-up is a generation job even when the object is utterly ordinary.
+
+Generation's known weaknesses — faces, legible text, identity across shots — simply do not apply to a rigid unbranded object, which is why it wins there. Judge generation per shot, not per video.
+
+**Vocabulary is a sourcing decision.** "block" biases toward wooden cubes and Jenga; "plastic building brick" returns masonry. Search the term people tag with, then re-read the result against the shot you asked for.
+
+## Check What Came Back
+
+Search results are untrustworthy in five specific ways and none of them announce themselves. `verify_clips.py --project <dir>` catches all five — two queries returning the byte-identical clip, a monochrome clip in a colour piece, a clip shorter than its scene (it loops and the jump lands mid-shot), a silent score, narration text with no audio. **Nonzero means do not build.** Orientation mismatch is a warning, not a failure; a 4:3 archival clip in a vertical piece is often deliberate.
+
+Frame-check real footage for unwanted text the same way you would a generated frame. Pseudo-text reads as texture; the stock clip with "MAKE MONEY" burned into it reads as a statement.
+
+**Never regenerate an existing clip.** Cache by scene and layer id under the project directory. Re-fetching to "make sure it's fresh" costs money and can come back a few frames different, which shifts every cut after it.
+
+Provider-specific failure modes — duration limits that are silently rejected, errors delivered inside HTTP 200, endpoints that rot, billing gates that look like rate limits — are in `references/provider-landmines.md`. Read it before quoting a cost or planning a batch. Costs and rights per provider live in the `studio-setup` skill's `SERVICES.md`; check it before anything is published.
+
+## Anti-patterns
+
+- **Defaulting to generation because it always returns something.** It returns something wrong more often than the free tiers do, and it bills for it.
+- **Generating video for static b-roll.** A 6s clip is ~$0.36; a still is ~$0.03. If the motion carries no meaning, move the camera in the composer instead.
+- **Asking a generator for readable text.** It invents letterforms. Real text is composer typography, every time.
+- **Offering a source with no key.** It wastes the user's turn and makes the cost estimate wrong. Check availability before you offer.
+- **Treating a user-supplied URL as rights-cleared.** They own that call, but say so out loud when the URL is obviously third-party content.

--- a/skills/media-acquisition/references/provider-landmines.md
+++ b/skills/media-acquisition/references/provider-landmines.md
@@ -1,0 +1,100 @@
+# Provider landmines — footage and stills
+
+Every entry here was paid for in real money or in an afternoon. They share a
+shape: the call succeeds, or appears to, and the defect surfaces much later.
+
+## Errors that arrive looking like success
+
+- **MiniMax (Hailuo)** returns application errors *inside HTTP 200*. Check
+  `base_resp.status_code != 0` or you will poll a bogus task id for ten
+  minutes. `1008` is out of balance.
+- **Submitted MiniMax jobs bill even if you never download the result.** Do not
+  kill a poll loop mid-run to save money; the money is already spent.
+
+## Duration and aspect constraints that reject silently or late
+
+- **MiniMax 1080P generates 6s clips only.** Asking for 10s errors (2013). 768P
+  allows 10s. Output is landscape-only — vertical means a centre crop
+  downstream, so keep subjects centred in the prompt.
+- **Veo accepts durations {4, 6, 8} only.** The docs say "4 to 8 inclusive";
+  5 and 7 are rejected.
+- **Veo's `generate_audio` is refused on plain API-key auth** (enterprise only).
+  Irrelevant here anyway — we supply our own voice and music, so paying the
+  8x audio-inclusive tier buys something we discard.
+- **Veo shares the text API key but has a separate, much smaller video quota.**
+  Probe with one 4s clip before planning a batch.
+
+## Generated footage caps below scene length
+
+Generated video caps around 6s while narration-driven scenes often run longer,
+so a clip shorter than its scene is the common case, not the exotic one. In the
+composer this freezes on the last frame rather than looping — the video element
+has no loop property and passing one is silently ignored. The props builder
+probes source length so the layer can be wrapped in a loop; if that probe is
+skipped the freeze ships.
+
+## Endpoints rot, and nothing tells you
+
+The image script targeted an endpoint that began answering `404 ... no longer
+available to new users` for every model in the family — fast, standard and
+ultra alike. Nothing had called it in weeks, so nobody knew. Two durable
+lessons:
+
+- A model listed by the provider's own model-list call may still be uncallable.
+- Published cURL examples can be wrong for your API version. One documented
+  field name took an enum and rejected every string form; the working field had
+  a different name entirely.
+
+**Treat the first call of any provider script in a session as a smoke test**,
+not a guarantee.
+
+## A 429 is not always a rate limit
+
+Gemini image models have **no free tier**. The quota metrics report no limit at
+all, and a full day's wait changes nothing — it is a billing gate wearing a
+rate-limit costume, made more convincing by text models on the same key
+answering fine. Never tell someone to wait for the reset.
+
+Related: **Lyria's free-tier quota is literally zero** for the same reason.
+
+## Anonymous access that is really a cache hit
+
+Pexels needs a key from request one. A handful of popular queries answer
+without one, which looks like a free anonymous tier; they are CDN cache hits —
+`query=sky` came back `cf-cache-status: HIT`, `age: 17118`, a nearly five-hour
+old copy of somebody else's authenticated request. Any query that actually
+reaches the API 401s.
+
+**Shutterstock splits search from download.** Search works on the free tier at
+100 requests/hour — and one video consumed ~50 searches including replacements,
+so a couple of videos an hour is the ceiling. Downloading needs a paid
+subscription on top of API access; there is no free download path.
+
+**Pixabay requires results to be cached for 24 hours.** Store them; do not
+re-query per render.
+
+## Single-provider categories are a trap
+
+Generated images had exactly one wired provider. When it turned out to be
+billing-gated the whole category went to zero with no fallback. Categories with
+a keyless free floor (archives) or two independent sources (stock) degraded
+gracefully. When a category has one provider, say so before it is relied on.
+
+## Content rules for generation
+
+- **No readable text in prompts.** Models render pseudo-text; garbled signage
+  was the single largest QC error class across three rounds. Exact digits are
+  especially unreliable — a request for $260 rendered as "250/month".
+- **Unprompted background text still appears** on storefronts and labels. Catch
+  it on a frame check and regenerate that clip only.
+- **Identity across scenes:** repeating descriptors verbatim reduces drift but
+  does not eliminate it. Separate generations of the same descriptor produced a
+  visibly different person roughly one time in four. The only guarantee is
+  reusing the same actual footage.
+
+## Keying a generated clip
+
+Generated "green screens" are never studio green — a real MiniMax key sampled
+at ~0x28680C. Sample the clip's own corner rather than assuming a value at
+prompt-writing time, and key with a hard cutoff: any soft blend leaves dark
+hair semi-transparent against a dark desaturated key.

--- a/skills/subject-compositing/SKILL.md
+++ b/skills/subject-compositing/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: subject-compositing
+description: Use when a filmed person has to appear somewhere they never were — dropping a subject over replacement footage, putting a drawn prop in front of them, driving the pair across frame, or pinning popup images to where they point on camera.
+---
+
+# Subject Compositing
+
+For shots nobody can film and no generator produces convincingly: him in a spaceship,
+in a clown car, on the moon. A real take is segmented out of its real surroundings and
+laid over replacement footage, with a prop in front. It lives or dies on the source
+take — settle the footage before you promise the shot.
+
+## Requires
+
+`scripts/composite_subject.py` and `scripts/track_pointing.py` from
+**scrollmark/video-studio** (private). Both run MediaPipe — selfie segmentation and
+pose landmarks for the composite, hand landmarks for the gestures. Without them
+nothing here executes: no matte, no feathered occlusion seam, no arm punch-through, no
+gesture timing. What still holds is the footage guidance below — it tells the user
+what to shoot, and is worth giving before they shoot rather than after. The pointing
+format's scene grammar lives in `video-formats`.
+
+## What the Segmenter Needs From the Take
+
+This decides whether the shot works, and it is decided on set, not in post. The model
+is a **selfie segmenter** — one person, front-facing, upper body, at conversational
+distance. Everything it fails at follows from that.
+
+- **One person, near arm visible.** Pose landmarks pick whichever wrist the segmenter
+  can see. A second person in frame, or an arm crossing out of shot, breaks free-arm.
+- **Tonal separation from the background.** Hair, dark clothing on a dark wall, or a
+  subject the same value as what is behind them gives a matte that chews the
+  silhouette. It does not error; it just looks cheap.
+- **Flat even light, no motion blur.** Fast pans and hard shadow edges leave the matte
+  flickering frame to frame, which reads instantly as fake. Lock the camera off and
+  let the subject move instead.
+- **Frame wide enough to cut.** `--occlude-below` slices the subject at the prop's top
+  edge with a feathered seam — it sells "inside it" and hides the real chair they were
+  sitting on, but it needs body below the cut line to work with.
+- **Short takes.** Every frame goes through the segmenter one at a time; a couple of
+  seconds is the working unit. This is a shot, not a sequence.
+
+## The Composite
+
+    scripts/composite_subject.py out.mp4 --in take.mp4 --ss 39.9 --t 2.5 \
+        --bg crowd.webm --bg-crop 405:600:430:15 --bg-eq eq=contrast=1.9:saturation=0 \
+        --fg art/car.png --occlude-below 1215 --free-arm --travel -330 430 --flip-h
+
+Layering is background → subject → prop → the gesturing forearm punched back through
+the prop. `--free-arm` intersects a capsule around elbow/wrist/hand with the real
+mask, so only body pixels come forward; without that intersection a drifting pose
+estimate cuts a person-shaped hole of background through the prop. `--travel`,
+`--flip-h` and `--flip-v` move subject and prop as one object over a static background,
+and mirroring happens *before* travel — flip afterwards and the flip reverses the
+travel direction too. `--scale` anchors on the subject, not the frame origin.
+
+**Draw the prop crudely, with an alpha channel.** Wobbly hand-drawn art forgives
+the matte's soft edges; clean vector art makes it look broken beside them. A PNG
+without alpha is rejected outright. And **check the background crop before compositing
+into it** — a tight crop of soft archival footage becomes grey mush, and stadium
+footage is full of legible third-party advertising you have just put in a brand video.
+
+## Pointing
+
+`track_pointing.py analyze` emits events — windows where an extended index finger
+holds a stable position — with the pointed-*at* location extrapolated past the
+fingertip, as canvas fractions. `layers` turns those into storyboard layers offset
+toward frame centre so the popup never covers the hand. Here the footage dictates the
+layout and the storyboard does not, so **reconcile the event list with the user before
+composing**: pull frames at each timestamp and check the count. Holds under half a
+second are dropped as jitter by design, and only one hand is tracked — quick tappers
+and two-handed presenters both come back short, and it reads as a broken tracker
+rather than a threshold working.
+
+## Anti-patterns
+
+- **Promising the shot before seeing the take.** Background contrast and camera motion
+  decide it, and neither is fixable in post.
+- **A clean vector prop.** It makes the matte look broken; crude art hides it.
+- **Trusting the event list.** Extract frames and reconcile the count with the user.


### PR DESCRIPTION
Wave 2 of the video-studio split. Four skills, taking the repo from 11 to 15. Same basis as #4: prose lives here, the toolchain stays in `scrollmark/video-studio` and is declared rather than vendored.

| Skill | Trigger | Standalone? |
|---|---|---|
| `media-acquisition` | Sourcing footage or stills for a shot | No — 11 scripts |
| `audio-acquisition` | Voice, score, or effects for a cut | No — 6 scripts |
| `edit-handoff` | A finished cut going to a human editor | No — 3 exporters |
| `subject-compositing` | Putting a filmed person somewhere they never were | No — 2 scripts |

## These two were a different kind of work

`media-acquisition` and `audio-acquisition` had **no section to lift**. Unlike the four in #4, their content was woven through the Workflow narrative, so this is untangling rather than extraction. What was deliberately left behind for the orchestrator is recorded in the extraction notes — step-0 doctor gating including the sequencing rule, the storyboard recording convention, the fixed-clips path contract, cost quoting, the rebuild-before-every-render rule, and the render-side Remotion landmines.

The content that came out is judgment, not tool documentation:

- **`media-acquisition`** is a per-shot ladder — real? → archive → stock → generate — **ordered by likelihood of failure, not by quality**, with the corollary that *shot type beats subject* (stock is a desert for objects in isolation).
- **`audio-acquisition`** frames score as **a rights decision before a taste decision**, and notes local voice is the default because it returns word timings where paid voice does not. It links `studio-setup/SERVICES.md` rather than duplicating the licence table.

## Needs a human eye

**`subject-compositing`'s segmentation prerequisites are inferred.** The section on what the selfie segmenter demands of a take — one person front-facing, near arm visible, tonal separation, flat light, locked-off camera, body below the occlusion line — had **no source document**. It is reconstructed from the model choice and the code's own workarounds, then framed as shooting guidance. It is the most useful part of that skill and the part most likely to be wrong. Please check it against what you actually know works.

Also: `track_pointing.py` is now referenced by both `video-formats` and `subject-compositing`, split by angle — format grammar there, gesture capture here — rather than duplicated.

## Still open after this

The orchestrator (`video-studio` itself) is the ninth and last skill, and is deliberately not here: it is the residue, so every prior cut shrinks it. And none of the eight new skills carry the repo's `tests/scenarios/` convention yet.

Verifier: 15 skills self-contained, one pre-existing warning (`agent-interview` at 83 lines).