### PR TITLE
verify-skills: fail when a shared reference drifts from its canonical copy

### DIFF
--- a/scripts/verify-skills.sh
+++ b/scripts/verify-skills.sh
@@ -106,6 +106,24 @@ for skill_dir in "$SKILLS_ROOT"/*/; do
   fi
 done
 
+# 5. A shared reference duplicated into a skill must match the canonical copy at
+#    the repo root. Duplication is the price of self-containment; drift is not.
+#    This is the check that catches an edit applied to references/ but not to the
+#    copies — the failure mode that silently ships stale guidance.
+if [ -d "$REPO_DIR/references" ]; then
+  while IFS= read -r copy; do
+    rel="${copy#*/references/}"
+    canonical="$REPO_DIR/references/$rel"
+    # A skill may own references nothing else shares (no root copy). That is
+    # fine — only files that ALSO exist at the root are shared, and only those
+    # can drift.
+    [ -f "$canonical" ] || continue
+    if ! cmp -s "$copy" "$canonical"; then
+      err "${copy#$REPO_DIR/} has drifted from references/$rel (edit both, in the same commit)"
+    fi
+  done < <(find "$SKILLS_ROOT" -path '*/references/*' -type f -name '*.md' 2>/dev/null)
+fi
+
 if [ "$skill_count" -eq 0 ]; then
   echo "FAIL: no skills with a SKILL.md found under skills/" >&2
   exit 1


### PR DESCRIPTION
The one gap left open by the self-containment work, now closed.

## The problem

Self-containment traded a single shared `references/` for duplicated copies — five platform files now live in six skills each. `verify-skills.sh` catches a reference a skill *names but does not ship*. It did not catch one that is **present but stale**.

So an edit applied to `references/platforms/x.md` alone would pass verification while shipping five stale duplicates, and every consumer of those five skills would silently read outdated guidance. `CONTRIBUTING.md` documents the rule ("edit the root copy and every skill copy in the same commit") but nothing enforced it.

This is not hypothetical. PR #1 does exactly this — edits the root copy only — and GitHub reports it `MERGEABLE / CLEAN`. It would merge green and leave six copies behind.

## The check

Any file under `skills/*/references/` that also exists at the repo root must match it byte for byte, or verification fails with the path and the instruction.

Skill-owned references that have no root copy — `provider-landmines.md`, `voice-landmines.md`, the ten format files — are ignored, because there is nothing for them to drift from. That distinction is what makes the check usable rather than noisy.

## Verified

Corrupted a duplicate, confirmed the failure names the right file, restored, confirmed clean. Passes against the current repo.

## Not in this PR

An earlier version bundled the X source-evidence guidance from #1 and the gated trend check from #2. Both are third-party contributions and are being held pending a decision on the vendor integration, so they are split out. #1 and #2 remain open and untouched.