### PR TITLE
video-production: the pipeline that calls the other eight

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ they describe is executed by the video-studio engine.
 | `audio-acquisition` | A video needs narration, a music bed or sound effects — choosing a voice, deciding which music source is safe to publish with, timing a cut to a track, or fixing a render that came out quiet. | Partly. The rights tiering and mixing discipline read as a briefing; synthesis, measurement and licence filtering are the engine. |
 | `subject-compositing` | A filmed person has to appear somewhere they never were — dropping a subject over replacement footage, putting a drawn prop in front of them, driving the pair across frame, or pinning popup images to where they point on camera. | **No.** The segmentation, occlusion seam, arm punch-through and gesture timing are all engine scripts. What survives is knowing what footage to shoot. |
 | `edit-handoff` | A finished cut has to leave the pipeline and continue in a human editor — exporting a timeline to Premiere Pro, DaVinci Resolve, Final Cut Pro or CapCut, or answering what survives the trip and what an editor has to rebuild. | **No.** The exporters read the engine's timeline document; there is no degraded mode that still writes a file. The format judgement generalises. |
+| `video-production` | Actually producing a short-form video end to end — running the interview, storyboarding, sourcing, previewing, rendering and quality-checking in order — or when a run has stalled and you need to know which step comes next and who owns it. | **No.** It drives the whole engine: without the private repo there is no props document, no preview, no renderer and no preflight. The step order and the hard rules still read as a production discipline. |
 
 ### Working method and toolchain
 
@@ -105,6 +106,11 @@ If you do not have access to video-studio, here is exactly what that costs you:
   `export_fcpxml.py` and `export_capcut.py` all read video-studio's per-project timeline
   document. What generalises is the judgement: which format each application actually
   imports, and that no interchange format carries effects.
+- **`video-production` is the one skill that is purely the engine's driver.** It sequences
+  `setup.py`, `build_props.py`, `studio.py`, `preflight.py`, the Remotion renderer,
+  `normalize_audio.py` and `poster.py`; with none of those present there is nothing to sequence.
+  What survives is the shape of a production run — which decision must precede which, where money
+  enters, and the `references/hard-rules.md` list of things that already went wrong once.
 - `studio-setup` keeps its tooling inventory, but the single status report, the install
   plan and the auto/system/manual classification all come from `doctor.py` and `setup.py`.
   You can still check binaries by hand.

--- a/skills/video-production/SKILL.md
+++ b/skills/video-production/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: video-production
+description: Use when actually producing a short-form video end to end — running the interview, storyboarding, sourcing, previewing, rendering and quality-checking in order — or when a run has stalled and you need to know which step comes next and who owns it.
+---
+
+# Video Production
+
+**You are the pipeline.** There are no stages, checkpoints or event streams: you sequence the scripts, ask the user at decision points, and gate the output. Every other video skill owns one step; this one owns the order they run in, and the rules that only make sense across a whole run.
+
+## Requires
+
+The orchestration scripts from **scrollmark/video-studio** (private): `setup.py` / `doctor.py` (step 0), `build_props.py` (steps 5 and 7), `studio.py` (the editor), `preflight.py` (the render gate), the composer's `npx remotion render`, `normalize_audio.py` and `poster.py`. Sourcing, voice and export scripts belong to the step skills named below.
+
+**This skill is not standalone — it drives the whole engine.** Without that repo there is no props document, no preview, no renderer and no preflight, so the sequence has nothing to sequence. What survives is the shape: which decision must precede which, and where money and silence enter a run.
+
+## The Pipeline
+
+| # | Step | Owned by |
+|---|---|---|
+| 0 | Check the machine; offer to fix it; **ask before installing** | `studio-setup` |
+| 1 | Enumerate `formats/*.md`, present as a choice, load only the chosen one | `video-formats` |
+| 2 | Run that format's interview, ≤4 questions a round | `agent-interview` |
+| 3 | Elicit sourcing — **footage and audio in the same round** | `media-acquisition`, `audio-acquisition` |
+| 4 | Build the storyboard from the format's grammar | `video-formats` |
+| 5 | `build_props.py --placeholders`, open the editor, re-read `props.json` | here |
+| 6 | Resolve sources — TTS first, then footage; then `verify_clips.py` | `audio-acquisition`, `media-acquisition` |
+| 7 | `build_props.py` (no flag) → `preflight.py` → render → `normalize_audio.py` | here |
+| 8 | Quality gate: pull frames, confirm duration and loudness | `studio-setup` |
+| 9 | `poster.py` — pick the thumbnail, and **open the candidate sheet** | here |
+
+A brand kit (`brand-kit`) is applied at step 4. An export to a human editor (`edit-handoff`) and a composited subject (`subject-compositing`) are branches off steps 7 and 6, not extra steps. Per-step mechanics and the exact invocations are in `references/run-mechanics.md`.
+
+## Sequencing Rules
+
+- **`doctor.py` runs before sourcing is offered, at step 3.** Offering a source with no key wastes the user's turn *and* makes the cost estimate wrong.
+- **Placeholder preview is the default before any spend.** Step 5 is free and catches layout mistakes while they still are. `--placeholders` appears there and nowhere else in the run. The user's edits to `props.json` are authoritative — re-read it after they finish.
+- **Quote total cost before the first paid call and again after the last.**
+- **Rebuild props immediately before every render**, and never skip preflight.
+- **Never declare a render done without viewing frames from it.** "It rendered" and "it is correct" are different claims; only one of them is in the log.
+
+## The Two Contracts
+
+**Sources.** Record the chosen source per layer in the storyboard as `prompt:` (generate) / `find:` (licensed search) / `url:` (user link) / `file:` (user path). A single video routinely mixes all four.
+
+**Paths.** Each of those resolves from exactly one place — `project/clips/<sceneId>-<layerId>.<ext>` — the only path `build_props` reads, and it copies into `composer/public/` itself. Hand-placing a file into `composer/public/clips/` does **not** work; build_props never looks there and will placeholder or error.
+
+## One Machine, Several Agents
+
+Projects cannot collide on content — each owns its props file, its media directory, and registers its own composition. They *do* share a port. **Always open the editor with `studio.py --project <dir>`, never directly**, or a second agent silently attaches to the first agent's editor and both then see one project. Hand the user the printed `url` **verbatim**: it ends in the composition id, and a bare `localhost:<port>` opens whichever composition the generated registry lists first — alphabetically, so the same one every time. Claim, `--status` and `--release --port` mechanics are in `references/run-mechanics.md`.
+
+## Read Before Rendering
+
+`references/hard-rules.md` — the rules learned the expensive way: the placeholder-render trap, the clock rule, the cost table, and the render-side composer landmines. Do not start step 7 without it.
+
+## Anti-patterns
+
+- **Sourcing before layout is approved.** Step 5 is free and step 6 is not.
+- **Rendering a placeholdered build.** It looks finished. It is coloured boxes.
+- **Skipping preflight because the last build was fine.** It is checking a global file that another project may have overwritten since.
+- **Narrating a clean bill of health at step 0.** If nothing is missing, say nothing and get on with it.
+- **Reporting a regression as a footnote.** A worse result than the previous version is a finding. Offer one fix-and-rerender loop, then stop.

--- a/skills/video-production/references/hard-rules.md
+++ b/skills/video-production/references/hard-rules.md
@@ -1,0 +1,106 @@
+# Hard rules
+
+Learned the expensive way — in real money or in afternoons. None of these are
+preferences. Every one of them describes something that already went wrong.
+
+## The placeholder trap
+
+**`--placeholders` is for layout preview only. Never render a build made with
+it.** Unresolved sources become solid coloured boxes, and a placeholdered build
+is not a *failed* build to the naked eye — it is a finished-looking video of
+coloured rectangles. Check `readyToRender` in the `build_props` summary and run
+`preflight.py` before every render.
+
+A nonzero `preflight.py` means **do not render** — fix and rebuild. It exits
+nonzero if any layer would render as a placeholder, if props reference a file
+missing from `public/`, or if a narration track is silent.
+
+## props.json is global
+
+`props.json` belongs to the composer, not to a project. **Always rebuild it
+immediately before rendering** — otherwise a second project's props silently
+render into the first project's output filename, and only the duration gives it
+away. The same applies to any timeline export: pass `--project` so it rebuilds
+first.
+
+## Clocks — the number one systemic bug class
+
+- **Scene duration = MEASURED narration WAV duration.** The plan's estimate is a
+  hint, never the clock. Using planned durations desyncs audio, video and
+  captions cumulatively: 20–30 findings per video before the fix, 0–6 after.
+- Empty narration → `tts_kokoro.py --silence <seconds>`; never synthesize `""`.
+  `--silence` is for beats that are **meant** to be quiet. Never use it to paper
+  over a voice backend that failed: the silent WAV becomes the scene clock and
+  the render ships with no narration and no captions while every log line still
+  reads as success. If the voice is broken, fix it or stop and tell the user.
+- **Music generators ignore the length you ask for.** Observed in one session:
+  22s requested returned 128s, 128s returned 148s, 140s returned 25s and then
+  66s. Never plan a cut against the requested length — generate, MEASURE the
+  file, then design to what you actually got. If it comes back too short to
+  cover the video, re-roll rather than looping; a loop seam in a scored piece is
+  audible in a way a slightly different arrangement is not.
+- **End on the track's own resolution, not on a fade you imposed.** Map the
+  energy envelope and find where the piece actually finishes. Fading out
+  mid-phrase — especially in the dip before a final chorus — reads to a listener
+  as the video being cut off, because it is. If the track must be shortened, cut
+  at a real section boundary and let its own decay end it.
+
+## Generation
+
+- MiniMax 1080P generates **only** 6s clips; request 6, trim in the composer.
+- Veo accepts durations {4, 6, 8} only; quota-check with a 4s probe first.
+- **Never put readable text in generation prompts** — models render pseudo-text.
+  Real text and numbers are composer overlays (TextCard / StatCard), and those
+  are pixel-perfect.
+- Identity across scenes: reuse the same actual footage (a "pool" of takes,
+  `file:` sources). Repeated prompt descriptors only *reduce* drift.
+
+## The clips path
+
+`url:` / `find:` / `prompt:` sources resolve from exactly one location:
+`project/clips/<sceneId>-<layerId>.<ext>`. Use `source_clips.py` or the `gen_*`
+scripts to put them there — `build_props` copies them into `composer/public/`
+itself. Hand-placing files into `composer/public/clips/` does **not** work;
+`build_props` never looks there and will placeholder or error.
+
+## Render-side composer landmines (Remotion 4.0.x)
+
+- `<OffthreadVideo>` has **no** `loop` prop — passing one is silently ignored, so
+  a clip shorter than its scene freezes on its last frame. Wrap it in `<Loop
+  durationInFrames={srcFrames}>`; `build_props` probes the source length into
+  `srcDurationInFrames`. This is the common case, not the exotic one: generated
+  footage caps at 6s while narration-driven scenes often run longer.
+- **Ken Burns headroom.** A `translate(%)` inside `scale()` shifts by scale ×
+  percent, while the hidden overflow per side is only (scale−1)/2. A fixed shift
+  therefore outgrows its margin exactly when `zoom:"out"` returns the scale to 1,
+  exposing a background sliver at the frame edge. Derive the shift from the live
+  headroom — (scale−1)/(2·scale) — not from a constant reserve. Motion is eased,
+  not linear; the quality check flags constant-velocity drift as mechanical.
+- **JPEG intermediates tag the output `yuvj420p`** (full range), which the
+  quality check flags as a platform-compatibility risk. `--pixel-format` does NOT
+  override it; `Config.setVideoImageFormat("png")` does. PNG frames render a
+  little slower and produce a smaller file here.
+
+## Verification
+
+Never declare a render done without viewing frames from it. Pull 4–6 frames
+across the timeline (`ffmpeg -ss <t> -i <mp4> -frames:v 1 f<t>.png`) and actually
+look at them; confirm duration and loudness with `ffprobe`. Every shipped-broken
+render in this pipeline's history would have been caught by opening a single
+frame.
+
+## Cost table
+
+Update when observed. Amounts are written without a currency symbol because
+dollar-prefixed digit tokens get clobbered by argument substitution.
+
+| Item | Rate |
+|---|---|
+| MiniMax | ~0.36 USD per 6s clip |
+| Veo preview | ~0.40 USD/s |
+| Imagen Fast | ~0.02 USD/still |
+| Local voice | free |
+| Placeholder previews | free |
+
+Quote the total **before the first paid call and again after the last**, and only
+after `doctor.py` has said which providers are actually reachable.

--- a/skills/video-production/references/run-mechanics.md
+++ b/skills/video-production/references/run-mechanics.md
@@ -1,0 +1,129 @@
+# Run mechanics
+
+The per-step detail behind the pipeline table. Each step names the skill that
+owns the *judgement*; what is here is the *sequencing* — what must have happened
+before the step starts, and what the step leaves behind for the next one.
+
+## 0 — Can this machine do the job?
+
+`setup.py` reports only; it changes nothing without `--yes`. Everything present:
+say nothing and go to step 1 — narrating a clean bill of health is noise.
+Something missing: name it in the user's terms ("the renderer isn't installed"),
+say whether you can fix it, and **ask before running anything, every time, even
+the safe ones** — `--yes` also runs package-manager installs that touch the whole
+system. Some items a machine simply cannot do (getting a key, enabling billing,
+accepting terms); hand those over with the specific link and never dress one up
+as a command.
+
+**A missing key is not a blocker.** Archives need no key and the voice runs
+locally, so a fresh machine can still make a complete video. Say that rather than
+stopping.
+
+**Network access is part of step 0.** Some agent hosts sandbox with the network
+off by default, and every stock lookup and generation call needs it. Resolve it
+before sourcing starts — the failure mode is a dozen provider timeouts that each
+look like a different problem.
+
+## 1–2 — Format, then interview
+
+Enumerate the format definitions, present them as a **choice question** (name +
+first line), and load **only** the chosen file: it defines the interview, the
+scene grammar, the slots and the composition settings. Then run that format's
+interview. Keep rounds to ≤4 questions and always include a freeform "anything
+else?" option.
+
+## 3 — Sourcing, one round, both halves
+
+Run `doctor.py` **first** and only offer sources that are actually available.
+Footage and audio are elicited in the **same round**, and the offer is phrased as
+a choice question.
+
+**Audio is a question, never a leftover** — ask it even for formats with no
+narration, so that a silent piece is silent because somebody chose it. For a
+music-led format the score is the *first* question of the whole interview, since
+scene durations are cut to its energy envelope.
+
+Record the outcome per layer in the storyboard as `prompt:` / `find:` / `url:` /
+`file:`. A single video routinely mixes all four.
+
+## 4 — Storyboard
+
+Apply the format's grammar mechanically: descriptors repeated verbatim, durations
+computed from narration word count (~2.4 words/sec, clamped 3–10s) as a *hint*
+only. The storyboard is a JSON document with a published schema in the engine
+repo (`references/storyboard.schema.json` there): `title` + `scenes`, each scene
+carrying `id`, `narration`, `voice`, `plannedSeconds` and `layers`; each layer
+carrying `id`, `source`, `rect`, `enter`/`exit`, `fit`, `ken`, and optionally a
+live-typography `card` instead of a source.
+
+## 5 — Placeholder preview
+
+    build_props.py --placeholders     # every unresolved source becomes a labelled coloured shape
+    studio.py --project <dir>         # NEVER launch the editor directly
+
+The editor hot-reloads `props.json`, so the user can adjust rects, timing and
+tweens visually at zero cost. **Re-read `props.json` when they finish — their
+edits are authoritative.** This flag is for this step only and never appears
+again in the run.
+
+## 6 — Resolve sources
+
+TTS first (narration timing drives everything), then footage per the sourcing
+choices. Everything lands at `project/clips/<sceneId>-<layerId>.<ext>`. Never
+regenerate an existing clip; never pass `--force` to "make sure it's fresh".
+Narration caches itself and reports `"cached": true`, so on a revision just re-run
+every scene and let the unchanged ones skip. Then `verify_clips.py --project
+<dir>` — **nonzero means do not build.**
+
+Quote the running total cost before the first paid call and again after the last.
+
+## 7 — Final props, gate, render, normalise
+
+    build_props.py            # no --placeholders; measured narration becomes the clock
+    preflight.py              # nonzero = do not render
+    npx remotion render       # in the composer directory
+    normalize_audio.py --in <mp4>
+
+Rebuild props immediately before **each** render. See `hard-rules.md` for why.
+
+## 8 — Quality gate
+
+If the automated check is available, report its errors and warnings honestly; a
+regression against a prior version is a finding, not a footnote. **If it is
+absent, say so plainly and verify by hand — never skip verification silently.**
+Either way, pull 4–6 frames across the timeline and look at them, and confirm
+duration and loudness. Offer one fix-and-rerender loop before declaring done.
+
+## 9 — Poster frame
+
+`poster.py --in <mp4>` writes a ranked shortlist and a labelled candidate sheet.
+**Open the sheet.** The score measures colour and contrast, so it knows nothing
+about subject matter — on its first real run it ranked an underwater reef above a
+marigold market for a Mexico spot. Pass `--at <seconds>` once you have looked. A
+feed reads as coherent because its thumbnails do; this is part of the look, not
+an upload-time afterthought. The default alternative is frame one, which here is
+a title card fading up from black.
+
+## Concurrency and studio claims
+
+Each project owns its own props file and media directory and registers its own
+composition, so two agents on two projects cannot collide on content: separate
+media, separate document, separate composition. Render and preflight both take
+the project name.
+
+Still shared: the composer's `node_modules` (read-only in practice) and **the
+port**. Always open the editor with `studio.py --project <dir>`, which picks a
+free port and claims the shared props file. The default port is shared, so a
+second agent launching directly *attaches* to the first agent's editor and both
+then see one project.
+
+**Give the user the `url` that script prints, verbatim.** It ends in the
+composition id and that part is load-bearing: a bare `http://localhost:<port>`
+opens whichever composition the generated registry lists first — which is
+alphabetical, so it is the same project every time no matter whose editor it is.
+This is not only a multi-agent problem; one agent alone hits it too.
+
+`--status` lists every studio running on the machine, one entry per agent. When
+you are done, `--release --port <port>` drops only yours — releasing without a
+port discards other agents' records without stopping their servers, leaving a
+live editor nobody can find.


### PR DESCRIPTION
The ninth and final skill of the video-studio split. 15 skills to 16.

This one is **residue, not extraction** — what remained of the 541-line `SKILL.md` once the other eight were carved out. Its job is connective tissue.

## Naming

`video-production`, not `video-studio`. That name belongs to the private engine repo, and a public skill sharing it would blur exactly the boundary this split exists to draw.

## Shape

`SKILL.md` is a router: a ten-step table naming which skill owns each step.

| Step | Owner |
|---|---|
| 0 machine check | `studio-setup` |
| 1 format pick | `video-formats` |
| 2 interview | `agent-interview` |
| 3 sourcing (footage + audio, one round) | `media-acquisition` + `audio-acquisition` |
| 4 storyboard | `video-formats` (+ `brand-kit` applies here) |
| 5 placeholder preview + editor | here |
| 6 resolve + verify | acquisition pair |
| 7 build → preflight → render → normalize | here |
| 8 quality gate | `studio-setup` |
| 9 poster | here |

`edit-handoff` and `subject-compositing` are branches off steps 7 and 6, not steps in the line.

What stays in `SKILL.md` is only what spans a whole run: doctor-before-sourcing, placeholder-before-spend, cost quoted before the first and after the last paid call, rebuild-props-before-every-render, the `prompt:`/`find:`/`url:`/`file:` recording convention, the fixed `clips/<sceneId>-<layerId>` path, and the shared-port `studio.py --project` hazard.

`references/hard-rules.md` keeps the measured specifics rather than smoothing them into advice — the Ken Burns `(scale-1)/(2*scale)` headroom derivation, `yuvj420p`, the global `props.json` constraint, the music-length observations. That section is labelled in the source as learned the expensive way, and it reads like it.

## What the split did *not* home

The extraction log lists what now belongs to no skill. **Nothing in Workflow steps 0–9 is unhomed** — the pipeline is fully covered. The residue is ops and repo cartography: host/skill-loader install paths, the engine repo's layout map, `tutorials/` and `tutor.py`, card `lines:` and per-scene `captionStyle` rationale, the storyboard schema's `atMs`/`untilMs`/`pop`/`chromakey` fields, and a git landmine about backticks in commit messages.

One of those is a policy rather than a mechanism and needs a decision rather than an extraction: **the Daily loop, including the standing "distribution is a human step" rule.** It has no home now.

Verifier: 16 skills self-contained, one pre-existing warning.