### PR TITLE
Port the showrunner gaps: music ducking, catalogued music, captions, presets

### DIFF
--- a/MIGRATION-NOTES.md
+++ b/MIGRATION-NOTES.md
@@ -6,6 +6,8 @@ Two structural migrations are recorded here, oldest first:
    `references/`, and what to do about an old install.
 2. **[The video-studio split](#migration-the-video-studio-split)** — why this repo holds
    prose only, and where the video toolchain went.
+3. **[Retiring showrunner](#migration-retiring-showrunner)** — what was carried across from
+   the second engine, what was deliberately dropped, and why its skill did not move.
 
 ---
 
@@ -273,3 +275,67 @@ gives worse answers, and nobody finds out.
 - The README is grouped rather than flat. Seven social-media skills, two video-production
   skills, two working-method/toolchain skills — the split is visible in the table of
   contents, not buried.
+
+
+---
+
+<a id="migration-retiring-showrunner"></a>
+
+## Migration: retiring showrunner
+
+`scrollmark/showrunner` was the other half of the video toolchain: 11,550 lines
+across `src/showrunner/`, a `showrunner` console script, and four video formats
+registered through entry points. It is being retired in favour of the skills in
+this repo plus `video-studio-engine`. This records what crossed over and what
+did not, so the decision does not have to be re-derived from an empty directory
+later.
+
+### What was ported
+
+| from | to | why it was a gap |
+|---|---|---|
+| `music/ducking.py` | `audio/duck_music.py` | Nothing here ducked music. A grep for "duck" across `src/video_studio/` returned zero hits: the bed played at one volume through the narration. |
+| `music/catalog.py`, `music/picker.py` | `audio/music_catalog.py` | `gen_music` *generates* a bed; there was no way to use music the user already owned, and no deterministic pick, so a re-render could change the score. |
+| `captions/generate.py` (whisper path) | `audio/gen_captions.py` | `tts_kokoro` emits word timings for what it speaks. Narration it did not speak — a recorded read, a client-supplied track — had no timings at all and rendered uncaptioned. |
+| `captions/ass.py`, `captions/pages.py` | `export/burn_captions.py` | Captions reached the screen only through Remotion props. Anything cut in ffmpeg had no captions. |
+| `styles/presets/*.json` (11) | `video_studio/styles/*.md` | `styles.py` shipped the mechanism with **no presets at all**. Translated to this repo's caption/card vocabulary; the type scale, spacing scale and motion curves were dropped rather than faked, because nothing here reads them. |
+| `costs.py` pricing tables | `references/generation-costs.md` | The lifecycle (estimate → reserve → reconcile) only worked with `Pipeline`. The numbers were worth keeping; the machinery was not. |
+
+The presets carry two keys `styles.py` itself ignores — `music.moods` and
+`rhythm.bpm` — so `music_catalog --pick --style <name>` derives a bed from the
+same preset that sets the look. The mood vocabulary already matched.
+
+### What was deliberately dropped
+
+- **`cloud/`** (1,704 lines) — a client for the platform drafts API: multipart
+  upload with a client-minted idempotency id, analysis polling, Firebase auth.
+  That surface is reachable through the platform's own connector; a second
+  bespoke OAuth client is not worth carrying.
+- **`pipeline.py`, `formats/`, `events.py`, `checkpoints.py`, `plan.py`**
+  (~2,950 lines) — the embedded pipeline with an LLM planner. This is the thing
+  being deprecated, not a casualty of it: in this repo the agent plans, and the
+  programs are what it drives.
+- **`exporters/otio.py`** — already covered. `export/export_edit.py` declares
+  `opentimelineio` and the FCPX adapter directly.
+- **`providers/tts/kokoro.py`, `providers/video/{minimax,gemini}.py`** — already
+  covered by `audio/tts_kokoro.py` and `generate/gen_{minimax,veo}.py`.
+
+Net: roughly 600 lines carried, roughly 10,800 dropped.
+
+### Why the showrunner skill did not move
+
+`skills/showrunner/SKILL.md` (354 lines) is a driving guide for the
+`showrunner` CLI: `init`, `create`, `refine`, `export`, `analyze`, and a
+troubleshooting table keyed to that CLI's errors. Sections 1–8 and 10 document
+commands that are going away. Section 9's frame-extraction quality pass is
+already covered here by `showwatcher` (see `setup.py`, step `qc`), which the
+workflow degrades gracefully without.
+
+So it is **superseded, not moved** — importing a guide to an archived tool would
+have made this repo's skill count go up and its accuracy go down. `video-formats`
+and `video-production` carry the parts that outlive the CLI.
+
+One thing it did prove: line 35 of that skill still reads `pip install
+showrunner`, which installs an unrelated project of the same name. PR #75 fixed
+that across four files in the showrunner repo and missed the skill — worth
+checking before the repo is archived, since the skill is what an agent reads.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ skill is missing from it.
 
 The engine used to live in a separate private repo, `scrollmark/video-studio`, and no
 skill here could touch it. That split is gone: the engine is in this repo now, and the
-31 programs behind these skills land in one of three places.
+35 programs behind these skills land in one of three places.
 
 **1. Bundled inside a skill — nothing to install.** Five programs are pure standard
 library and take their input on the command line, so they ship in the skill folder that
@@ -87,7 +87,7 @@ programs are bundled in two skills each; each skill carries its own copy, becaus
 may never reach outside its own folder. `./scripts/verify-skills.sh` fails if those copies
 drift apart, or if a `SKILL.md` names a bundled script that is not there.
 
-**2. The `video-studio-engine` package — one `pip install`.** The other 26 programs
+**2. The `video-studio-engine` package — one `pip install`.** The other 30 programs
 either carry third-party dependencies or read a project's state (a props document, a
 composer directory, a styles tree), which makes them unfit to sit in a skill folder as a
 lone file. They are built from `src/video_studio/` in this repo and run as
@@ -98,6 +98,7 @@ lone file. They are built from `src/video_studio/` in this repo and run as
     pip install 'video-studio-engine[audio]'     # + tts_kokoro, gen_music
     pip install 'video-studio-engine[generate]'  # + gen_veo, gen_boil
     pip install 'video-studio-engine[vision]'    # + composite_subject, track_pointing
+    pip install 'video-studio-engine[captions]'  # + gen_captions (whisper word timings)
     pip install 'video-studio-engine[export]'    # + export_edit (OpenTimelineIO)
     pip install 'video-studio-engine[all]'       # everything
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ audio = [
   "numpy>=1.26",
 ]
 
+# Word timings for narration this studio did not synthesise. Optional because
+# it pulls a ~200MB CTranslate2 inference runtime that only gen_captions needs;
+# tts_kokoro already emits timings for anything it speaks itself.
+captions = ["faster-whisper>=1.0"]
+
 # Hosted image/video/music models, plus the procedural boil renderer's PNG path.
 generate = [
   "google-genai>=0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ export = [
 ]
 
 all = [
-  "video-studio-engine[sourcing,audio,generate,vision,export]",
+  "video-studio-engine[sourcing,audio,captions,generate,vision,export]",
 ]
 
 [project.scripts]

--- a/references/generation-costs.md
+++ b/references/generation-costs.md
@@ -1,0 +1,66 @@
+# What a generated second costs
+
+Order-of-magnitude list prices in USD, for deciding *what to generate* before
+you generate it. Not billing truth: no provider here returns a price with the
+asset, so every figure is a published rate or an observed one, and every one of
+them drifts. Treat them as an upper bound for planning, then read your invoice.
+
+Consolidated from the figures already embedded in the programs
+(`gen_veo`, `gen_minimax`, `gen_image`) plus the two TTS rates, so a format
+document can quote one source instead of each program quoting its own.
+
+## Generated video — the dominant cost
+
+| provider | program | rate | 6s clip |
+|---|---|---|---|
+| Veo 3.1 (Gemini) | `gen_veo` | ~$0.40/s | ~$2.40 |
+| MiniMax Hailuo 02 | `gen_minimax` | ~$0.06/s | ~$0.36 |
+| Replicate | `gen_replicate` | varies by model — tens of cents for video | — |
+
+Veo is roughly **seven times** MiniMax per second. That ratio, not the absolute
+number, is the thing to plan around: a format that wants eight generated scenes
+costs about $19 on Veo and about $3 on MiniMax.
+
+⚠️ MiniMax's training-data position is not established. It is fine for internal
+and experimental work; it does not go under client deliverables. The same
+rights note governs `gen_music` — see the provider notes in that program.
+
+## Generated stills
+
+| model | rate |
+|---|---|
+| `gemini-3.1-flash-lite-image` | ~$0.01 |
+| `gemini-3.1-flash-image` (default) | ~$0.03 |
+| `gemini-2.5-flash-image` | ~$0.04 |
+| `gemini-3-pro-image` | ~$0.13 |
+
+A still is one to two orders of magnitude cheaper than a clip of the same
+subject. A 6s Veo clip is ~$2.40; the same image held with a slow push is ~$0.03.
+Most scenes that "need video" need motion, and motion can come from the
+composition rather than from the generator — see `gen_boil` for the case where
+the motion is drawn instead of generated, at zero marginal cost.
+
+## Narration
+
+| provider | program | rate |
+|---|---|---|
+| Kokoro | `tts_kokoro` | free — runs locally |
+| ElevenLabs | — | ~$0.15 per 1,000 characters |
+
+Narration runs about **15 characters per spoken second** at ~150 wpm, so a
+60-second read is ~900 characters: free on Kokoro, ~$0.14 on ElevenLabs.
+Narration is never the line item that matters.
+
+## What is free
+
+Stock footage under its own licence, `gen_boil` (drawn, deterministic, no API),
+every export path, and all composition. A format built from stock plus boil plus
+composition costs nothing per render, which is why `titled-video` and the
+stock-sourced half of `brand-origin` can be iterated on without a budget
+conversation.
+
+## Where these live in code
+
+`gen_minimax.COST_PER_SECOND`, `gen_image.COST_USD`, and the note at the top of
+`gen_veo`. If a rate moves, change it there — those constants are what the
+programs actually report in their JSON output — and update this table to match.

--- a/src/video_studio/audio/duck_music.py
+++ b/src/video_studio/audio/duck_music.py
@@ -1,0 +1,238 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Duck the music bed under the narration. A post-pass over built props.
+
+Usage:
+  uv run scripts/duck_music.py --composer composer/ --project projects/foo
+  uv run scripts/duck_music.py --composer composer/ --project projects/foo \
+      --base 0.16 --depth 0.65          # louder bed / deeper dip
+  uv run scripts/duck_music.py ... --dry-run    # report, write nothing
+
+RUN THIS AFTER build_props AND BEFORE rendering. It reads the props file that
+build_props wrote, adds a per-frame volume envelope to `props.music`, and writes
+the file back. build_props is the authority on the clock, so re-running it
+overwrites the envelope — duck again afterwards. Running duck twice is
+harmless; the envelope is recomputed from the narration, never from itself.
+
+Why derive from props rather than from the storyboard: build_props snaps scene
+boundaries on the CUMULATIVE total, not per scene, precisely so rounding error
+cannot accumulate down the timeline. Re-deriving that arithmetic here would be
+a second implementation of the clock, free to drift from the first — and an
+envelope that drifts is worse than no envelope, because it ducks the music
+around speech that is no longer there.
+
+THE ALGORITHM:
+  1. One RMS energy reading per video frame, per narration WAV.
+  2. Normalise against the loudest moment across ALL narrations, not per file,
+     so a consistently quiet scene is not spuriously boosted into ducking.
+  3. Map energy to gain: silence keeps `--base`, peak narration lands at
+     `base × (1 − depth)`.
+  4. Smooth asymmetrically — dip fast, recover slow — so the bed does not
+     pump on every phoneme.
+
+Defaults assume a commercially mastered bed (peaks near 0 dBFS) under TTS
+narration (~-20 dBFS RMS): the bed sits at ~-16 dBFS and drops ~9 dB under
+narration peaks, landing near -25 dBFS during speech. Voice leads by 5-8 dB
+and the music still reads as music rather than as a rumour of music.
+
+Prints JSON: {"props", "frames", "ducked", "floor", "base"}.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import struct
+import wave
+from pathlib import Path
+
+from video_studio.paths import studio_root
+
+#: Volume with no narration over it.
+DEFAULT_BASE = 0.16
+#: Fraction of the base to remove under the loudest narration.
+DEFAULT_DEPTH = 0.65
+#: Frames to dip / recover. Attack is deliberately ~3x faster than release.
+DEFAULT_ATTACK = 6
+DEFAULT_RELEASE = 18
+
+
+def slugify(project: Path) -> str:
+    """Match build_props' slug so we find the props file it wrote."""
+    return project.resolve().name
+
+
+def decode_pcm(raw: bytes, *, sampwidth: int, channels: int) -> list[float]:
+    """16- or 8-bit PCM to mono floats in [-1, 1]. Stereo is averaged."""
+    if sampwidth == 2:
+        max_amp = 32768.0
+        if channels == 1:
+            return [s / max_amp for (s,) in struct.iter_unpack("<h", raw)]
+        fmt = "<" + "h" * channels
+        usable = len(raw) - (len(raw) % (2 * channels))
+        return [sum(v) / (channels * max_amp)
+                for v in struct.iter_unpack(fmt, raw[:usable])]
+    if sampwidth == 1:
+        # 8-bit PCM is unsigned, centred on 128.
+        if channels == 1:
+            return [(b - 128) / 128.0 for b in raw]
+        out: list[float] = []
+        for i in range(0, len(raw) - channels + 1, channels):
+            out.append(sum(b - 128 for b in raw[i:i + channels]) / (channels * 128.0))
+        return out
+    # 24- and 32-bit are not decoded here. Returning empty makes the envelope
+    # flat for this scene, which is audibly wrong but not silently wrong — the
+    # summary reports how many narrations contributed.
+    return []
+
+
+def rms_per_frame(audio_path: Path, *, fps: int) -> list[float]:
+    """One RMS reading per video frame, across the file's full duration.
+
+    stdlib `wave` only: every TTS path in this repo emits WAV, and pulling in
+    numpy for one array of means would put a compiled dependency behind a
+    feature most users run once per render.
+    """
+    if not audio_path.exists():
+        return []
+    try:
+        with wave.open(str(audio_path), "rb") as w:
+            channels, sampwidth = w.getnchannels(), w.getsampwidth()
+            framerate, nframes = w.getframerate(), w.getnframes()
+            raw = w.readframes(nframes)
+    except (wave.Error, OSError):
+        return []
+
+    samples = decode_pcm(raw, sampwidth=sampwidth, channels=channels)
+    if not samples:
+        return []
+    per_frame = int(framerate / fps)
+    if per_frame <= 0:
+        return []
+
+    out: list[float] = []
+    for start in range(0, len(samples), per_frame):
+        window = samples[start:start + per_frame]
+        if not window:
+            break
+        out.append(math.sqrt(sum(s * s for s in window) / len(window)))
+    return out
+
+
+def asymmetric_smooth(values: list[float], base: float,
+                      attack: int, release: int) -> list[float]:
+    """One-pole filter with separate dip and recover time constants."""
+    if attack <= 0 and release <= 0:
+        return list(values)
+    alpha_attack = 1.0 / max(attack, 1)
+    alpha_release = 1.0 / max(release, 1)
+    out = list(values)
+    current = base
+    for i, target in enumerate(out):
+        alpha = alpha_attack if target < current else alpha_release
+        current += (target - current) * alpha
+        out[i] = current
+    return out
+
+
+def compute_envelope(narrations: list[tuple[int, list[float]]], *,
+                     total_frames: int, base: float, depth: float,
+                     attack: int, release: int) -> list[float]:
+    """Per-frame music volume for the whole composition."""
+    peak = max((max(rms) for _, rms in narrations if rms), default=0.0) or 1e-9
+    raw = [base] * total_frames
+    for start_frame, rms in narrations:
+        for i, energy in enumerate(rms):
+            f = start_frame + i
+            if 0 <= f < total_frames:
+                target = base * (1.0 - depth * min(energy / peak, 1.0))
+                # MIN across overlapping narrations: the louder source wins.
+                raw[f] = min(raw[f], target)
+    return asymmetric_smooth(raw, base, attack, release)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--composer", default=str(studio_root() / "composer"))
+    ap.add_argument("--base", type=float, default=DEFAULT_BASE)
+    ap.add_argument("--depth", type=float, default=DEFAULT_DEPTH)
+    ap.add_argument("--attack", type=int, default=DEFAULT_ATTACK)
+    ap.add_argument("--release", type=int, default=DEFAULT_RELEASE)
+    ap.add_argument("--dry-run", action="store_true")
+    a = ap.parse_args()
+
+    if not 0.0 < a.base <= 1.0:
+        raise SystemExit("--base must be in (0, 1]")
+    if not 0.0 <= a.depth <= 1.0:
+        raise SystemExit("--depth must be in [0, 1]")
+
+    composer = Path(a.composer).expanduser().resolve()
+    project = Path(a.project).expanduser().resolve()
+    slug = slugify(project)
+    props_path = composer / "props" / f"{slug}.json"
+    if not props_path.exists():
+        raise SystemExit(
+            f"no props at {props_path} — run build_props for this project first."
+        )
+
+    props = json.loads(props_path.read_text())
+    if "music" not in props:
+        raise SystemExit(
+            "these props carry no music track, so there is nothing to duck. "
+            "Add `music` to the storyboard and re-run build_props."
+        )
+
+    fps = int(props.get("fps", 30))
+    public = composer / "public"
+
+    narrations: list[tuple[int, list[float]]] = []
+    frame = 0
+    missing: list[str] = []
+    for scene in props["scenes"]:
+        if scene.get("audio"):
+            wav = public / scene["audio"]
+            rms = rms_per_frame(wav, fps=fps)
+            if rms:
+                narrations.append((frame, rms))
+            else:
+                missing.append(scene["id"])
+        frame += int(scene["durationInFrames"])
+    total_frames = frame
+
+    if not narrations:
+        raise SystemExit(
+            "no readable narration audio in these props — every scene is silent, "
+            "so ducking would be a no-op. Nothing written."
+        )
+
+    envelope = compute_envelope(narrations, total_frames=total_frames,
+                                base=a.base, depth=a.depth,
+                                attack=a.attack, release=a.release)
+    floor = min(envelope) if envelope else a.base
+
+    if missing:
+        print(f"warning: unreadable or non-PCM narration in {len(missing)} scene(s): "
+              f"{', '.join(missing)} — the bed stays at full volume under them.")
+
+    if not a.dry_run:
+        props["music"]["baseVolume"] = a.base
+        props["music"]["envelope"] = [round(v, 4) for v in envelope]
+        props_path.write_text(json.dumps(props, indent=2) + "\n")
+
+    print(json.dumps({
+        "props": str(props_path),
+        "frames": total_frames,
+        "seconds": round(total_frames / fps, 3),
+        "ducked": len(narrations),
+        "silent": len(missing),
+        "base": a.base,
+        "floor": round(floor, 4),
+        "dryRun": a.dry_run,
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/video_studio/audio/gen_captions.py
+++ b/src/video_studio/audio/gen_captions.py
@@ -1,0 +1,210 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["faster-whisper>=1.0"]
+# ///
+"""Word timings for narration this studio did not synthesise.
+
+Usage:
+  uv run scripts/gen_captions.py --audio projects/x/audio/hook.wav
+  uv run scripts/gen_captions.py --audio projects/x/audio/hook.wav \
+      --timings-out projects/x/audio/hook.timings.json
+  uv run scripts/gen_captions.py --project projects/x        # every scene WAV
+  uv run scripts/gen_captions.py --project projects/x --force # redo existing
+
+Why this exists: tts_kokoro already emits `<scene>.timings.json` beside every
+WAV it synthesises, and build_props turns that into on-screen captions. Any
+narration that did NOT come from Kokoro therefore has no timings at all — a
+recorded voice, a client-supplied read, a track pulled off a camera. Those
+scenes render silently uncaptioned, which is the failure this closes.
+
+It writes EXACTLY the format tts_kokoro writes — a flat, scene-relative
+`[{"text", "startMs", "endMs"}, ...]` — so build_props consumes the output of
+either producer without knowing which one ran.
+
+TRANSCRIPTION IS A GUESS. Kokoro knows what it was asked to say; whisper is
+inferring words from audio, and it will mis-hear names, jargon and anything
+said over music. Read what comes back before shipping it. Pass --text with the
+known script to check the transcript against it — mismatches are reported, not
+silently corrected, because deciding which one is wrong is a human's call.
+
+The model runs LOCALLY (faster-whisper, CTranslate2). Nothing is uploaded.
+First run downloads weights to ~/.cache/huggingface; `base` is ~150MB.
+
+Prints JSON: {"audio", "timings", "words", "seconds", "model"}.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+#: Whisper sizes, smallest first. `base` is the default: on narration-grade
+#: audio the accuracy gain from `small` is mostly on accents and noise, and
+#: this runs on a laptop CPU.
+MODELS = ("tiny", "base", "small", "medium", "large-v3")
+DEFAULT_MODEL = "base"
+
+
+def measured_seconds(path: Path) -> float | None:
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=noprint_wrappers=1:nokey=1", str(path)],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        return round(float(out), 3)
+    except (OSError, subprocess.CalledProcessError, ValueError):
+        return None
+
+
+def merge_punctuation(timings: list[dict]) -> list[dict]:
+    """Fold punctuation-only tokens onto the previous word.
+
+    Same rule tts_kokoro applies. A lone "," rendered as its own caption is a
+    frame of visible garbage, and whisper emits them more often than Kokoro.
+    """
+    out: list[dict] = []
+    for t in timings:
+        word = (t.get("text") or "").strip()
+        if not word:
+            continue
+        if out and not any(c.isalnum() for c in word):
+            out[-1]["text"] += word
+            out[-1]["endMs"] = max(out[-1]["endMs"], t["endMs"])
+            continue
+        out.append({"text": word, "startMs": t["startMs"], "endMs": t["endMs"]})
+    return out
+
+
+def transcribe(audio: Path, model_name: str, language: str | None) -> list[dict]:
+    """Word-level timings, scene-relative, in tts_kokoro's format."""
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError:
+        raise SystemExit(
+            "faster-whisper is not installed. Install the extra:\n"
+            "  pip install 'video-studio-engine[captions]'\n"
+            "It is optional because it pulls a ~200MB inference runtime that "
+            "only this program needs."
+        )
+
+    # int8 on CPU is the portable choice; it is what makes `base` usable on a
+    # laptop without a GPU, and caption timing does not need float precision.
+    model = WhisperModel(model_name, device="cpu", compute_type="int8")
+    segments, _info = model.transcribe(
+        str(audio), word_timestamps=True, language=language, vad_filter=True,
+    )
+
+    timings: list[dict] = []
+    for segment in segments:
+        for word in (segment.words or []):
+            text = (word.word or "").strip()
+            if not text:
+                continue
+            timings.append({
+                "text": text,
+                "startMs": max(0, round(word.start * 1000)),
+                "endMs": max(0, round(word.end * 1000)),
+            })
+    return merge_punctuation(timings)
+
+
+def compare_to_script(timings: list[dict], script: str) -> dict | None:
+    """Report divergence between the transcript and a known script.
+
+    Deliberately reports rather than corrects: aligning a mis-heard word to an
+    intended one is a judgement about which is right, and getting that wrong
+    silently is worse than saying they differ.
+    """
+    def norm(s: str) -> list[str]:
+        return ["".join(c for c in w.lower() if c.isalnum())
+                for w in s.split() if any(c.isalnum() for c in w)]
+
+    heard, intended = norm(" ".join(t["text"] for t in timings)), norm(script)
+    if heard == intended:
+        return None
+    only_heard = [w for w in heard if w not in set(intended)]
+    only_script = [w for w in intended if w not in set(heard)]
+    return {
+        "heardWords": len(heard), "scriptWords": len(intended),
+        "notInScript": only_heard[:12], "notHeard": only_script[:12],
+    }
+
+
+def run_one(audio: Path, timings_out: Path, model: str, language: str | None,
+            script: str | None, force: bool) -> dict:
+    if timings_out.exists() and not force:
+        return {"audio": str(audio), "timings": str(timings_out),
+                "skipped": "timings already exist — pass --force to redo"}
+    if not audio.exists():
+        raise SystemExit(f"no such audio: {audio}")
+
+    timings = transcribe(audio, model, language)
+    if not timings:
+        raise SystemExit(
+            f"whisper found no speech in {audio}. If the scene is meant to be "
+            f"silent it needs no timings; if it is not, check the file is "
+            f"narration and not music."
+        )
+
+    timings_out.parent.mkdir(parents=True, exist_ok=True)
+    timings_out.write_text(json.dumps(timings, indent=2) + "\n")
+
+    result = {
+        "audio": str(audio), "timings": str(timings_out),
+        "words": len(timings), "seconds": measured_seconds(audio), "model": model,
+    }
+    if script:
+        divergence = compare_to_script(timings, script)
+        if divergence:
+            result["divergesFromScript"] = divergence
+            print(f"warning: transcript differs from --text for {audio.name} "
+                  f"— read {timings_out.name} before shipping.", file=sys.stderr)
+    return result
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--audio", help="one WAV to transcribe")
+    ap.add_argument("--project", help="transcribe every audio/*.wav in a project")
+    ap.add_argument("--timings-out", help="explicit output path (with --audio)")
+    ap.add_argument("--model", default=DEFAULT_MODEL, choices=MODELS)
+    ap.add_argument("--language", help="ISO code, e.g. en. Omit to auto-detect.")
+    ap.add_argument("--text", help="the known script, to check the transcript against")
+    ap.add_argument("--force", action="store_true",
+                    help="overwrite timings that already exist")
+    a = ap.parse_args()
+
+    if bool(a.audio) == bool(a.project):
+        raise SystemExit("pass exactly one of --audio or --project")
+
+    if a.audio:
+        audio = Path(a.audio).expanduser().resolve()
+        out = (Path(a.timings_out).expanduser().resolve() if a.timings_out
+               else audio.with_suffix(".timings.json"))
+        print(json.dumps(run_one(audio, out, a.model, a.language, a.text, a.force),
+                         indent=2))
+        return
+
+    project = Path(a.project).expanduser().resolve()
+    audio_dir = project / "audio"
+    wavs = sorted(audio_dir.glob("*.wav"))
+    if not wavs:
+        raise SystemExit(f"no WAVs in {audio_dir}")
+    # --text describes one read, so it cannot be checked against a whole
+    # directory of different scenes.
+    results = [run_one(w, w.with_suffix(".timings.json"), a.model, a.language,
+                       None, a.force) for w in wavs]
+    print(json.dumps({
+        "project": str(project),
+        "transcribed": sum(1 for r in results if "words" in r),
+        "skipped": sum(1 for r in results if "skipped" in r),
+        "scenes": results,
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/video_studio/audio/music_catalog.py
+++ b/src/video_studio/audio/music_catalog.py
@@ -1,0 +1,341 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""The tracks you are licensed to use, and a deterministic way to pick one.
+
+Usage:
+  uv run scripts/music_catalog.py --where                  # where the catalog lives
+  uv run scripts/music_catalog.py --list                   # every track
+  uv run scripts/music_catalog.py --list --mood editorial  # filtered
+  uv run scripts/music_catalog.py --show warm-keys-01      # one track, resolved
+  uv run scripts/music_catalog.py --add path/to/track.mp3 --id warm-keys-01 \
+      --moods editorial,warm --bpm 96 --license "Artlist, invoice 4471"
+  uv run scripts/music_catalog.py --remove warm-keys-01
+  uv run scripts/music_catalog.py --pick --moods editorial,warm --bpm 96 \
+      --seed brand-origin-brick
+
+Why this exists: `gen_music` makes a bed from nothing, which is the right answer
+when no bed exists and the wrong answer when the user already owns music they
+have cleared. Generated beds also drift — ask twice, get two different pieces —
+so a series that wants one recognisable theme cannot be built out of them.
+
+NOTHING IS SHIPPED HERE. The catalog is a pointer file: every entry names a
+track the user provisioned under their own licence, and records that licence as
+a string so there is a paper trail if provenance is ever questioned. Deleting a
+catalog entry does not delete audio.
+
+WHERE THE CATALOG LIVES, highest precedence first:
+
+  $VIDEO_STUDIO_MUSIC_DIR/catalog.json     wherever the user points it
+  ~/.config/video-studio/music/catalog.json the user's own, across every project
+
+Same reasoning as styles.py: a catalog kept inside a checkout dies with the
+checkout. Music is a thing a user has, not a thing a project has.
+
+PICKING is deterministic. Same moods, same bpm, same seed — same track, every
+re-render, so a video does not change its score because it was rebuilt. Scoring
+is mood overlap (double weighted; it is the primary selector) plus bpm
+closeness, then a seeded sample from the top quarter of the field. Sampling
+rather than always taking the winner keeps one track from becoming the only
+track a mood ever resolves to.
+
+Prints JSON on every path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+CATALOG_VERSION = 1
+
+ENV_VAR = "VIDEO_STUDIO_MUSIC_DIR"
+
+#: A soft vocabulary, not a validator. Users invent their own moods and
+#: reference them from a style preset's `music.moods`; these are here so that
+#: independently-tagged catalogs have some chance of sharing a word.
+SUGGESTED_MOODS = (
+    "editorial", "lifestyle", "contemplative", "energetic", "cinematic",
+    "corporate", "ambient", "playful", "tense", "warm", "dark",
+    "uplifting", "mellow", "aggressive", "gentle",
+)
+
+#: Score every candidate, then sample from the top fraction. All-best is
+#: boring (one track per mood forever); all-random is unpredictable.
+SHORTLIST_FRACTION = 0.25
+SHORTLIST_MIN = 3
+
+#: bpm scoring reaches zero this far from the target.
+BPM_TOLERANCE = 20.0
+
+
+def catalog_dir() -> Path:
+    override = os.environ.get(ENV_VAR)
+    if override:
+        return Path(override).expanduser().resolve()
+    return Path.home() / ".config" / "video-studio" / "music"
+
+
+def catalog_file() -> Path:
+    return catalog_dir() / "catalog.json"
+
+
+def load() -> dict:
+    """The catalog, or an empty one. Never raises for a missing file."""
+    path = catalog_file()
+    if not path.exists():
+        return {"version": CATALOG_VERSION, "tracks": []}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    version = int(data.get("version", CATALOG_VERSION))
+    if version > CATALOG_VERSION:
+        raise SystemExit(
+            f"catalog at {path} is version {version}; this build reads up to "
+            f"{CATALOG_VERSION}. Upgrade video-studio-engine."
+        )
+    data.setdefault("tracks", [])
+    return data
+
+
+def save(data: dict) -> Path:
+    path = catalog_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def resolve_audio(track: dict) -> Path:
+    """Absolute path to a track's audio.
+
+    Relative paths resolve against the catalog directory, so moving the whole
+    directory to another machine keeps every entry valid.
+    """
+    p = Path(track["path"]).expanduser()
+    return p if p.is_absolute() else (catalog_dir() / p).resolve()
+
+
+def measured_seconds(path: Path) -> float | None:
+    """Duration via ffprobe, or None if ffprobe is absent or the file is not
+    readable as media. Never fatal — duration is a convenience field."""
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=noprint_wrappers=1:nokey=1", str(path)],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        return round(float(out), 2)
+    except (OSError, subprocess.CalledProcessError, ValueError):
+        return None
+
+
+# ── picking ──────────────────────────────────────────────────────────────
+
+def _mood_overlap(track: dict, wanted: tuple[str, ...]) -> float:
+    if not wanted:
+        return 0.0
+    return len(set(track.get("moods", [])) & set(wanted)) / len(wanted)
+
+
+def _bpm_closeness(track_bpm: float | None, wanted: float | None) -> float:
+    if track_bpm is None or wanted is None:
+        return 0.0
+    return max(0.0, 1.0 - abs(track_bpm - wanted) / BPM_TOLERANCE)
+
+
+def _score(track: dict, moods: tuple[str, ...], bpm: float | None) -> float:
+    return 2.0 * _mood_overlap(track, moods) + _bpm_closeness(track.get("bpm"), bpm)
+
+
+def _rng(seed: str) -> random.Random:
+    # Hashing only normalises an arbitrary string into an int; nothing here
+    # depends on the hash being cryptographic.
+    digest = hashlib.sha256(seed.encode("utf-8")).digest()
+    return random.Random(int.from_bytes(digest[:8], "big"))
+
+
+def pick(tracks: list[dict], moods: tuple[str, ...], bpm: float | None,
+         seed: str) -> dict | None:
+    """The chosen track, or None if the catalog is empty."""
+    candidates = [t for t in tracks if set(t.get("moods", [])) & set(moods)] if moods else list(tracks)
+    if not candidates:
+        # A mood filter that matches nothing is too strict to be useful —
+        # fall back to the whole catalog rather than returning silence.
+        candidates = list(tracks)
+    if not candidates:
+        return None
+    scored = sorted(candidates, key=lambda t: _score(t, moods, bpm), reverse=True)
+    shortlist = scored[:max(SHORTLIST_MIN, int(len(scored) * SHORTLIST_FRACTION))]
+    return _rng(seed).choice(shortlist)
+
+
+def pick_for_preset(tracks: list[dict], preset: dict, seed: str) -> dict | None:
+    """Derive moods and bpm from a style preset's `music.moods` / `rhythm.bpm`.
+
+    This is the join between styles.py and this module: a preset carries the
+    look AND the mood of the bed, so choosing a style chooses the music.
+    """
+    music_cfg = (preset or {}).get("music") or {}
+    rhythm = (preset or {}).get("rhythm") or {}
+    return pick(tracks, tuple(music_cfg.get("moods", [])), rhythm.get("bpm"), seed)
+
+
+def load_preset(name: str) -> dict:
+    """Read a styles.py preset by name — the same four tiers, same order.
+
+    A preset carries `music.moods` and `rhythm.bpm` alongside the look, so
+    choosing a style can choose the bed. Those keys are inert to styles.py
+    itself, which reads only `captions` and `cards`.
+    """
+    import re
+    roots: list[Path] = []
+    env = os.environ.get("VIDEO_STUDIO_STYLES")
+    if env:
+        roots.append(Path(env).expanduser())
+    roots += [
+        Path.home() / ".config" / "video-studio" / "styles",
+        Path(__file__).resolve().parent.parent / "styles",
+    ]
+    for root in roots:
+        candidate = root / f"{name}.md"
+        if candidate.exists():
+            block = re.search(r"```json\s*(.*?)```", candidate.read_text(), re.S)
+            if not block:
+                raise SystemExit(f"preset {candidate} has no ```json block")
+            return json.loads(block.group(1))
+    raise SystemExit(
+        f"no style preset named {name!r}. List them with: video-studio styles --list"
+    )
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--where", action="store_true", help="print the catalog path")
+    ap.add_argument("--list", action="store_true")
+    ap.add_argument("--show", metavar="ID")
+    ap.add_argument("--add", metavar="AUDIO")
+    ap.add_argument("--remove", metavar="ID")
+    ap.add_argument("--pick", action="store_true")
+    ap.add_argument("--id", help="track id for --add")
+    ap.add_argument("--moods", default="", help="comma-separated")
+    ap.add_argument("--mood", help="filter --list by one mood")
+    ap.add_argument("--bpm", type=float)
+    ap.add_argument("--key", help='musical key, e.g. "Am"')
+    ap.add_argument("--license", dest="license_str",
+                    help="the licence you hold — recorded verbatim")
+    ap.add_argument("--source", help="where it came from")
+    ap.add_argument("--notes")
+    ap.add_argument("--seed", default="", help="stable input for --pick")
+    ap.add_argument("--style", metavar="NAME",
+                    help="take moods and bpm from a styles.py preset")
+    ap.add_argument("--copy", action="store_true",
+                    help="copy the audio into the catalog directory on --add")
+    a = ap.parse_args()
+
+    moods = tuple(m.strip() for m in a.moods.split(",") if m.strip())
+
+    if a.where:
+        print(json.dumps({"dir": str(catalog_dir()), "catalog": str(catalog_file()),
+                          "exists": catalog_file().exists()}))
+        return
+
+    data = load()
+    tracks: list[dict] = data["tracks"]
+
+    if a.add:
+        src = Path(a.add).expanduser().resolve()
+        if not src.exists():
+            raise SystemExit(f"no such audio file: {src}")
+        track_id = a.id or src.stem
+        if any(t["id"] == track_id for t in tracks):
+            raise SystemExit(f"catalog already has a track with id '{track_id}' "
+                             f"— pick another --id, or --remove it first")
+        if a.copy:
+            catalog_dir().mkdir(parents=True, exist_ok=True)
+            dest = catalog_dir() / src.name
+            shutil.copy2(src, dest)
+            stored = src.name
+        else:
+            stored = str(src)
+        entry = {"id": track_id, "path": stored}
+        if moods:
+            entry["moods"] = list(moods)
+        for field, value in (("bpm", a.bpm), ("key", a.key),
+                             ("license", a.license_str), ("source", a.source),
+                             ("notes", a.notes)):
+            if value is not None:
+                entry[field] = value
+        seconds = measured_seconds(src)
+        if seconds is not None:
+            entry["durationSeconds"] = seconds
+        if not a.license_str:
+            print("warning: no --license recorded. The catalog is the paper "
+                  "trail; an entry without one cannot prove provenance.",
+                  file=sys.stderr)
+        tracks.append(entry)
+        save(data)
+        print(json.dumps({"added": entry, "catalog": str(catalog_file())}, indent=2))
+        return
+
+    if a.remove:
+        before = len(tracks)
+        data["tracks"] = [t for t in tracks if t["id"] != a.remove]
+        if len(data["tracks"]) == before:
+            raise SystemExit(f"no track with id '{a.remove}'")
+        save(data)
+        print(json.dumps({"removed": a.remove, "remaining": len(data["tracks"])}))
+        return
+
+    if a.show:
+        track = next((t for t in tracks if t["id"] == a.show), None)
+        if track is None:
+            raise SystemExit(f"no track with id '{a.show}'")
+        audio = resolve_audio(track)
+        print(json.dumps({**track, "resolvedPath": str(audio),
+                          "audioExists": audio.exists()}, indent=2))
+        return
+
+    if a.pick:
+        if a.style:
+            preset = load_preset(a.style)
+            # Explicit flags still win: --style is a starting point, the same
+            # way styles.py treats a preset when applying it to a storyboard.
+            derived = (preset.get("music") or {}).get("moods", [])
+            moods = moods or tuple(derived)
+            if a.bpm is None:
+                a.bpm = (preset.get("rhythm") or {}).get("bpm")
+        chosen = pick(tracks, moods, a.bpm, a.seed)
+        if chosen is None:
+            raise SystemExit(
+                "the catalog is empty — add a track you are licensed to use "
+                "with --add, or generate a bed with gen_music instead."
+            )
+        audio = resolve_audio(chosen)
+        if not audio.exists():
+            print(f"warning: {chosen['id']} points at {audio}, which is missing",
+                  file=sys.stderr)
+        print(json.dumps({"id": chosen["id"], "path": str(audio),
+                          "moods": chosen.get("moods", []), "bpm": chosen.get("bpm"),
+                          "license": chosen.get("license"), "seed": a.seed}, indent=2))
+        return
+
+    # --list, and the bare no-flag case.
+    shown = [t for t in tracks if a.mood in t.get("moods", [])] if a.mood else tracks
+    print(json.dumps({
+        "catalog": str(catalog_file()),
+        "count": len(shown),
+        "suggestedMoods": list(SUGGESTED_MOODS),
+        "tracks": [{"id": t["id"], "moods": t.get("moods", []), "bpm": t.get("bpm"),
+                    "license": t.get("license")} for t in shown],
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/video_studio/cli.py
+++ b/src/video_studio/cli.py
@@ -34,7 +34,10 @@ COMMANDS: dict[str, str] = {
     "stock_shutterstock": "video_studio.sourcing.stock_shutterstock",
     "verify_clips": "video_studio.sourcing.verify_clips",
     # audio
+    "duck_music": "video_studio.audio.duck_music",
+    "gen_captions": "video_studio.audio.gen_captions",
     "gen_music": "video_studio.audio.gen_music",
+    "music_catalog": "video_studio.audio.music_catalog",
     "tts_kokoro": "video_studio.audio.tts_kokoro",
     # generation
     "gen_boil": "video_studio.generate.gen_boil",
@@ -46,6 +49,7 @@ COMMANDS: dict[str, str] = {
     "composite_subject": "video_studio.vision.composite_subject",
     "track_pointing": "video_studio.vision.track_pointing",
     # export
+    "burn_captions": "video_studio.export.burn_captions",
     "export_capcut": "video_studio.export.export_capcut",
     "export_edit": "video_studio.export.export_edit",
     "export_fcpxml": "video_studio.export.export_fcpxml",
@@ -61,10 +65,10 @@ COMMANDS: dict[str, str] = {
 
 GROUPS = [
     ("sourcing", "stock APIs, downloads, and verifying what came back"),
-    ("audio", "voice synthesis and generated music"),
+    ("audio", "voice, word timings, and the music bed"),
     ("generate", "generated images, video and procedural motion"),
     ("vision", "segmentation, compositing, hand tracking"),
-    ("export", "CapCut / Final Cut / OTIO handoff"),
+    ("export", "burnt-in captions, CapCut / Final Cut / OTIO handoff"),
     ("project", "props, preflight, editor, looks, tutorials, digest"),
 ]
 
@@ -111,7 +115,11 @@ def main(argv: list[str] | None = None) -> int:
         # own rule instead: None is 0, an int is the code, anything else prints
         # to stderr and exits 1.
         if exc.code is None:
-        
+            return 0
+        if isinstance(exc.code, int):
+            return exc.code
+        print(exc.code, file=sys.stderr)
+        return 1
     return 0
 
 

--- a/src/video_studio/cli.py
+++ b/src/video_studio/cli.py
@@ -103,7 +103,15 @@ def main(argv: list[str] | None = None) -> int:
     try:
         runpy.run_module(module, run_name="__main__", alter_sys=True)
     except SystemExit as exc:  # scripts call sys.exit(); honour their code
-        return int(exc.code or 0)
+        # `raise SystemExit("message")` is the house style for a fatal error in
+        # these scripts, and its code is that STRING, not a number. Coercing it
+        # with int() raised ValueError and buried the message under a traceback
+        # — but only when invoked as `video-studio <cmd>`, never when the file
+        # was run directly, which is why it survived. Follow the interpreter's
+        # own rule instead: None is 0, an int is the code, anything else prints
+        # to stderr and exits 1.
+        if exc.code is None:
+        
     return 0
 
 

--- a/src/video_studio/export/burn_captions.py
+++ b/src/video_studio/export/burn_captions.py
@@ -1,0 +1,299 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Captions for the ffmpeg path: word timings → ASS, optionally burnt in.
+
+Usage:
+  # one scene, subtitle file only
+  uv run scripts/burn_captions.py --timings projects/x/audio/hook.timings.json \
+      --out projects/x/subs/hook.ass
+
+  # burn onto a clip
+  uv run scripts/burn_captions.py --timings projects/x/audio/hook.timings.json \
+      --video projects/x/clips/hook.mp4 --out projects/x/clips/hook-capped.mp4
+
+  # a whole project, one .ass per scene, offset onto the project timeline
+  uv run scripts/burn_captions.py --project projects/x --out projects/x/subs/
+
+  # take the look from a style preset
+  uv run scripts/burn_captions.py --timings ... --out ... --style tourism
+
+Why this exists: captions currently reach the screen ONE way — build_props
+folds `<scene>.timings.json` into composer props and Remotion draws them. Every
+route that does not end in Remotion therefore ends with no captions: a clip cut
+straight in ffmpeg, a stock-footage supercut, anything handed to an editor as
+finished video. This gives that route the same word-level highlight.
+
+STYLING speaks the same vocabulary as styles.py, so a preset drives both
+renderers. Keys honoured here: color, highlight, fontFamily, fontSize, stroke,
+strokeWidth, bottom, wordsPerPage, uppercase. Keys that are Remotion-only —
+bounce, wiggle, palette, wordGap — are reported as ignored rather than dropped
+in silence, because a preset that visibly differs between the two paths should
+say why.
+
+Burn-in is DESTRUCTIVE: captions become pixels. Keep the clean master. The .ass
+file is written either way, so an editor can re-time or restyle downstream.
+
+Prints JSON: {"ass", "pages", "words", "video"?, "ignoredStyleKeys"}.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from video_studio.paths import studio_root
+
+#: Style keys this renderer understands, mapped from styles.py's CAPTION_KEYS.
+HONOURED = ("color", "highlight", "fontFamily", "fontSize", "stroke",
+            "strokeWidth", "bottom", "wordsPerPage", "uppercase")
+#: Recognised by styles.py but meaningless in ASS — motion and per-word spacing
+#: have no representation in the subtitle format.
+REMOTION_ONLY = ("bounce", "wiggle", "palette", "wordGap")
+
+DEFAULTS = {
+    "color": "#ffffff", "highlight": "#facc15", "fontFamily": "Inter",
+    "fontSize": 56, "stroke": "#000000", "strokeWidth": 3,
+    "bottom": 0.12, "wordsPerPage": 4, "uppercase": False,
+}
+
+#: A page also breaks on a long silence or a long run, not only on word count.
+MAX_PAGE_MS = 1800
+MAX_GAP_MS = 600
+
+HEADER = """[Script Info]
+Title: video-studio captions
+ScriptType: v4.00+
+PlayResX: {width}
+PlayResY: {height}
+WrapStyle: 0
+ScaledBorderAndShadow: yes
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Caption,{font_family},{font_size},{highlight},{color},{stroke},&H80000000,-1,0,0,0,100,100,0,0,1,{stroke_width},1,2,60,60,{margin_v},1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+
+
+def ass_color(hex_color: str) -> str:
+    """'#RRGGBB' → ASS '&H00BBGGRR'. ASS is BGR with a leading alpha byte."""
+    value = (hex_color or "").lstrip("#")
+    if len(value) != 6 or any(c not in "0123456789abcdefABCDEF" for c in value):
+        value = "ffffff"
+    r, g, b = value[0:2], value[2:4], value[4:6]
+    return f"&H00{b}{g}{r}".upper()
+
+
+def ass_time(ms: int) -> str:
+    """Milliseconds → 'h:mm:ss.cc'. ASS resolution is a centisecond."""
+    cs = round(max(int(ms), 0) / 10)
+    s, cs = divmod(cs, 100)
+    m, s = divmod(s, 60)
+    h, m = divmod(m, 60)
+    return f"{h}:{m:02d}:{s:02d}.{cs:02d}"
+
+
+def escape(text: str) -> str:
+    # Braces delimit override blocks in ASS; a literal brace in narration would
+    # silently swallow the rest of the line as a malformed tag.
+    return text.replace("\\", "\\\\").replace("{", "(").replace("}", ")").replace("\n", " ")
+
+
+def paginate(timings: list[dict], *, offset_ms: int, words_per_page: int) -> list[dict]:
+    """Group flat word timings into pages shown one at a time."""
+    pages: list[dict] = []
+    current: dict | None = None
+    for t in timings:
+        start = int(t["startMs"]) + offset_ms
+        end = max(int(t["endMs"]) + offset_ms, start)
+        if (current is None
+                or len(current["tokens"]) >= words_per_page
+                or (end - current["startMs"]) > MAX_PAGE_MS
+                or (start - current["tokens"][-1]["toMs"]) > MAX_GAP_MS):
+            if current is not None:
+                pages.append(current)
+            current = {"startMs": start, "endMs": end, "tokens": []}
+        current["tokens"].append({"text": t["text"], "fromMs": start, "toMs": end})
+        current["endMs"] = end
+    if current is not None:
+        pages.append(current)
+    return pages
+
+
+def render_ass(pages: list[dict], style: dict, width: int, height: int) -> str:
+    lines = [HEADER.format(
+        width=width, height=height,
+        font_family=style["fontFamily"], font_size=int(style["fontSize"]),
+        # Karaoke fills SecondaryColour → PrimaryColour, so the HIGHLIGHT is
+        # primary and the resting text colour is secondary. Swapping these is
+        # the classic way to get captions that highlight backwards.
+        highlight=ass_color(style["highlight"]), color=ass_color(style["color"]),
+        stroke=ass_color(style["stroke"]), stroke_width=int(style["strokeWidth"]),
+        margin_v=int(height * float(style["bottom"])),
+    )]
+    for page in pages:
+        if not page["tokens"]:
+            continue
+        parts: list[str] = []
+        cursor = page["startMs"]
+        for token in page["tokens"]:
+            # Absorb the silence before a word into a k-tag of its own, so the
+            # highlight lands on the word rather than drifting early.
+            gap_cs = max(round((token["fromMs"] - cursor) / 10), 0)
+            if gap_cs:
+                parts.append(f"{{\\k{gap_cs}}}")
+            dur_cs = max(round((token["toMs"] - token["fromMs"]) / 10), 1)
+            text = token["text"].upper() if style["uppercase"] else token["text"]
+            parts.append(f"{{\\k{dur_cs}}}{escape(text)} ")
+            cursor = max(token["toMs"], cursor)
+        lines.append(
+            f"Dialogue: 0,{ass_time(page['startMs'])},{ass_time(page['endMs'])},"
+            f"Caption,,0,0,0,,{''.join(parts).rstrip()}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def load_style(name: str | None, overrides: dict) -> tuple[dict, list[str]]:
+    """Merge defaults, an optional named preset, then explicit flags."""
+    style = dict(DEFAULTS)
+    ignored: list[str] = []
+    if name:
+        preset = find_preset(name)
+        captions = preset.get("captions", preset)
+        for key, value in captions.items():
+            if key in HONOURED:
+                style[key] = value
+            elif key in REMOTION_ONLY:
+                ignored.append(key)
+    style.update({k: v for k, v in overrides.items() if v is not None})
+    return style, ignored
+
+
+def find_preset(name: str) -> dict:
+    """Read a styles.py preset: markdown with one fenced ```json block.
+
+    Searches the same places styles.py does, minus the project-local tier —
+    this program is given a project only sometimes.
+    """
+    import os
+    import re
+    roots = []
+    env = os.environ.get("VIDEO_STUDIO_STYLES")
+    if env:
+        roots.append(Path(env).expanduser())
+    roots += [Path.home() / ".config" / "video-studio" / "styles",
+              studio_root() / "styles"]
+    for root in roots:
+        candidate = root / f"{name}.md"
+        if candidate.exists():
+            block = re.search(r"```json\s*(.*?)```", candidate.read_text(), re.S)
+            if not block:
+                raise SystemExit(f"preset {candidate} has no ```json block")
+            return json.loads(block.group(1))
+    raise SystemExit(
+        f"no style preset named {name!r}. Looked in: "
+        + ", ".join(str(r) for r in roots)
+        + "\nList what exists with: video-studio styles --list"
+    )
+
+
+def burn(video: Path, ass: Path, out: Path) -> None:
+    """Burn subtitles into a copy of the video. Audio is stream-copied."""
+    out.parent.mkdir(parents=True, exist_ok=True)
+    # The subtitles filter takes a path in its own mini-syntax, where ':' and
+    # '\' are separators — escape them rather than hope the path is plain.
+    escaped = str(ass).replace("\\", "\\\\").replace(":", r"\:").replace("'", r"\'")
+    cmd = ["ffmpeg", "-y", "-i", str(video), "-vf", f"subtitles='{escaped}'",
+           "-c:a", "copy", str(out)]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except FileNotFoundError:
+        raise SystemExit("ffmpeg not found — install it, or drop --video to "
+                         "write the .ass file only.")
+    except subprocess.CalledProcessError as exc:
+        tail = (exc.stderr or "").strip().splitlines()[-6:]
+        raise SystemExit("ffmpeg failed to burn captions:\n  " + "\n  ".join(tail))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--timings", help="one <scene>.timings.json")
+    ap.add_argument("--project", help="every audio/*.timings.json in a project")
+    ap.add_argument("--video", help="burn onto this clip (with --timings)")
+    ap.add_argument("--out", required=True, help="file, or directory with --project")
+    ap.add_argument("--style", help="named preset from styles.py")
+    ap.add_argument("--width", type=int, default=1080)
+    ap.add_argument("--height", type=int, default=1920)
+    ap.add_argument("--color"); ap.add_argument("--highlight")
+    ap.add_argument("--font-family", dest="fontFamily")
+    ap.add_argument("--font-size", dest="fontSize", type=int)
+    ap.add_argument("--words-per-page", dest="wordsPerPage", type=int)
+    ap.add_argument("--uppercase", action="store_true", default=None)
+    a = ap.parse_args()
+
+    if bool(a.timings) == bool(a.project):
+        raise SystemExit("pass exactly one of --timings or --project")
+    if a.video and not a.timings:
+        raise SystemExit("--video burns one clip, so it needs --timings, not --project")
+
+    style, ignored = load_style(a.style, {
+        "color": a.color, "highlight": a.highlight, "fontFamily": a.fontFamily,
+        "fontSize": a.fontSize, "wordsPerPage": a.wordsPerPage,
+        "uppercase": a.uppercase,
+    })
+    if ignored:
+        print(f"note: preset keys with no ASS equivalent were ignored: "
+              f"{', '.join(sorted(set(ignored)))} — the burnt captions will differ "
+              f"from the Remotion render in motion, not in wording.", file=sys.stderr)
+
+    if a.timings:
+        timings = json.loads(Path(a.timings).expanduser().read_text())
+        if not timings:
+            raise SystemExit(f"{a.timings} is empty — nothing to caption.")
+        pages = paginate(timings, offset_ms=0,
+                         words_per_page=int(style["wordsPerPage"]))
+        out = Path(a.out).expanduser().resolve()
+        ass_path = out if out.suffix == ".ass" else out.with_suffix(".ass")
+        ass_path.parent.mkdir(parents=True, exist_ok=True)
+        ass_path.write_text(render_ass(pages, style, a.width, a.height))
+        result = {"ass": str(ass_path), "pages": len(pages), "words": len(timings),
+                  "ignoredStyleKeys": sorted(set(ignored))}
+        if a.video:
+            burn(Path(a.video).expanduser().resolve(), ass_path, out)
+            result["video"] = str(out)
+        print(json.dumps(result, indent=2))
+        return
+
+    project = Path(a.project).expanduser().resolve()
+    out_dir = Path(a.out).expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    files = sorted((project / "audio").glob("*.timings.json"))
+    if not files:
+        raise SystemExit(
+            f"no timings in {project / 'audio'} — run tts_kokoro (synthesised "
+            f"narration) or gen_captions (recorded narration) first."
+        )
+    written = []
+    for timings_file in files:
+        timings = json.loads(timings_file.read_text())
+        if not timings:
+            continue
+        pages = paginate(timings, offset_ms=0,
+                         words_per_page=int(style["wordsPerPage"]))
+        scene = timings_file.name.removesuffix(".timings.json")
+        target = out_dir / f"{scene}.ass"
+        target.write_text(render_ass(pages, style, a.width, a.height))
+        written.append({"scene": scene, "ass": str(target), "pages": len(pages)})
+    print(json.dumps({"project": str(project), "written": len(written),
+                      "ignoredStyleKeys": sorted(set(ignored)),
+                      "scenes": written}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/video_studio/project/styles.py
+++ b/src/video_studio/project/styles.py
@@ -58,6 +58,11 @@ CARD_KEYS = {"bg", "fg", "tracking", "fontSize", "align", "size"}
 PLACEMENT_KEYS = {"rect", "pop", "fade", "atMs", "untilMs", "enter", "exit"}
 
 
+#: Presets shipped inside the installed package. Lowest precedence of all, so
+#: every other tier can shadow one by name.
+PACKAGE_STYLES = Path(__file__).resolve().parent.parent / "styles"
+
+
 def style_roots(project: Path | None) -> list[Path]:
     roots = []
     if project:
@@ -66,6 +71,13 @@ def style_roots(project: Path | None) -> list[Path]:
         roots.append(Path(os.environ["VIDEO_STUDIO_STYLES"]))
     roots.append(USER_STYLES)
     roots.append(SKILL_ROOT / "styles")
+    # SKILL_ROOT is the studio tree, which an installed copy does not have: with
+    # no marker directory to find, studio_root() falls back to the cwd, so the
+    # tier above resolves to <wherever you happen to be>/styles. That is present
+    # for a developer standing in the checkout and absent for everyone who ran
+    # `pip install` — the shipped presets would simply never appear for them.
+    # This tier travels with the package instead.
+    roots.append(PACKAGE_STYLES)
     return roots
 
 

--- a/src/video_studio/styles/3b1b-dark.md
+++ b/src/video_studio/styles/3b1b-dark.md
@@ -1,0 +1,63 @@
+---
+name: 3b1b-dark
+description: Navy/blue/gold, math education inspired by 3Blue1Brown
+---
+
+# 3b1b-dark
+
+Navy/blue/gold, math education inspired by 3Blue1Brown. Ported from the showrunner style set, which described a whole design
+system — a six-step type scale, a spacing scale, motion curves. Only the parts
+this studio renders survived the translation: caption styling, three card roles,
+and the music mood so `music_catalog --pick` can choose a bed that matches.
+
+Motion curves and the spacing scale were dropped rather than faked; nothing here
+reads them, and a value nothing reads is a value that drifts.
+
+```json
+{
+  "captions": {
+    "color": "#ffffff",
+    "highlight": "#facc15",
+    "fontFamily": "Inter",
+    "fontSize": 28,
+    "stroke": "#1c1c2e",
+    "strokeWidth": 3,
+    "bottom": 0.12,
+    "wordsPerPage": 4
+  },
+  "cards": {
+    "title": {
+      "bg": "#1c1c2e",
+      "fg": "#ffffff",
+      "fontSize": 84,
+      "align": "left",
+      "tracking": -0.02
+    },
+    "label": {
+      "bg": "#3b82f6",
+      "fg": "#ffffff",
+      "fontSize": 22,
+      "align": "left",
+      "tracking": 0.08
+    },
+    "stat": {
+      "bg": "#facc15",
+      "fg": "#1c1c2e",
+      "fontSize": 128,
+      "align": "center",
+      "tracking": -0.03
+    }
+  },
+  "music": {
+    "moods": [
+      "contemplative",
+      "ambient",
+      "gentle"
+    ]
+  },
+  "rhythm": {
+    "bpm": 96,
+    "fps": 30
+  }
+}
+```

--- a/src/video_studio/styles/bold-neon.md
+++ b/src/video_studio/styles/bold-neon.md
@@ -1,0 +1,63 @@
+---
+name: bold-neon
+description: Black/cyan/pink, gaming and tech energy
+---
+
+# bold-neon
+
+Black/cyan/pink, gaming and tech energy. Ported from the showrunner style set, which described a whole design
+system — a six-step type scale, a spacing scale, motion curves. Only the parts
+this studio renders survived the translation: caption styling, three card roles,
+and the music mood so `music_catalog --pick` can choose a bed that matches.
+
+Motion curves and the spacing scale were dropped rather than faked; nothing here
+reads them, and a value nothing reads is a value that drifts.
+
+```json
+{
+  "captions": {
+    "color": "#ffffff",
+    "highlight": "#e11d48",
+    "fontFamily": "Inter",
+    "fontSize": 28,
+    "stroke": "#0a0a0a",
+    "strokeWidth": 3,
+    "bottom": 0.12,
+    "wordsPerPage": 4
+  },
+  "cards": {
+    "title": {
+      "bg": "#0a0a0a",
+      "fg": "#ffffff",
+      "fontSize": 88,
+      "align": "left",
+      "tracking": -0.03
+    },
+    "label": {
+      "bg": "#06b6d4",
+      "fg": "#ffffff",
+      "fontSize": 22,
+      "align": "left",
+      "tracking": 0.1
+    },
+    "stat": {
+      "bg": "#e11d48",
+      "fg": "#0a0a0a",
+      "fontSize": 140,
+      "align": "center",
+      "tracking": -0.04
+    }
+  },
+  "music": {
+    "moods": [
+      "energetic",
+      "aggressive",
+      "uplifting"
+    ]
+  },
+  "rhythm": {
+    "bpm": 140,
+    "fps": 30
+  }
+}
+```

--- a/src/video_studio/styles/clean-corporate.md
+++ b/src/video_studio/styles/clean-corporate.md
@@ -1,0 +1,63 @@
+---
+name: clean-corporate
+description: White/blue, professional business presentations
+---
+
+# clean-corporate
+
+White/blue, professional business presentations. Ported from the showrunner style set, which described a whole design
+system — a six-step type scale, a spacing scale, motion curves. Only the parts
+this studio renders survived the translation: caption styling, three card roles,
+and the music mood so `music_catalog --pick` can choose a bed that matches.
+
+Motion curves and the spacing scale were dropped rather than faked; nothing here
+reads them, and a value nothing reads is a value that drifts.
+
+```json
+{
+  "captions": {
+    "color": "#1e293b",
+    "highlight": "#059669",
+    "fontFamily": "Inter",
+    "fontSize": 28,
+    "stroke": "#ffffff",
+    "strokeWidth": 3,
+    "bottom": 0.12,
+    "wordsPerPage": 4
+  },
+  "cards": {
+    "title": {
+      "bg": "#ffffff",
+      "fg": "#1e293b",
+      "fontSize": 84,
+      "align": "left",
+      "tracking": -0.03
+    },
+    "label": {
+      "bg": "#2563eb",
+      "fg": "#1e293b",
+      "fontSize": 22,
+      "align": "left",
+      "tracking": 0.08
+    },
+    "stat": {
+      "bg": "#059669",
+      "fg": "#ffffff",
+      "fontSize": 128,
+      "align": "center",
+      "tracking": -0.04
+    }
+  },
+  "music": {
+    "moods": [
+      "corporate",
+      "warm",
+      "uplifting"
+    ]
+  },
+  "rhythm": {
+    "bpm": 112,
+    "fps": 30
+  }
+}
+```

--- a/src/video_studio/styles/dramatic-story.md
+++ b/src/video_studio/styles/dramatic-story.md
@@ -1,0 +1,63 @@
+---
+name: dramatic-story
+description: Black/gold/red, cinematic storytelling
+---
+
+# dramatic-story
+
+Black/gold/red, cinematic storytelling. Ported from the showrunner style set, which described a whole design
+system — a six-step type scale, a spacing scale, motion curves. Only the parts
+this studio renders survived the translation: caption styling, three card roles,
+and the music mood so `music_catalog --pick` can choose a bed that matches.
+
+Motion curves and the spacing scale were dropped rather than faked; nothing here
+reads them, and a value nothing reads is a value that drifts.
+
+```json
+{
+  "captions": {
+    "color": "#f8fafc",
+    "highlight": "#dc2626",
+    "fontFamily": "Inter",
+    "fontSize": 28,
+    "stroke": "#0f172a",
+    "strokeWidth": 3,
+    "bottom": 0.12,
+    "wordsPerPage": 4
+  },
+  "cards": {
+    "title": {
+      "bg": "#0f172a",
+      "fg": "#f8fafc",
+      "fontSize": 96,
+      "align": "left",
+      "tracking": -0.02
+    },
+    "label": {
+      "bg": "#f59e0b",
+      "fg": "#f8fafc",
+      "fontSize": 22,
+      "align": "left",
+      "tracking": 0.15
+    },
+    "stat": {
+      "bg": "#dc2626",
+      "fg": "#0f172a",
+      "fontSize": 144,
+      "align": "center",
+      "tracking": -0.03
+    }
+  },
+  "music": {
+    "moods": [
+      "cinematic",
+      "tense",
+      "dark"
+    ]
+  },
+  "rhythm": {
+    "bpm": 72,
+    "fps": 30
+  }
+}
+```

--- a/src/video_studio/styles/forest-breath.md
+++ b/src/video_studio/styles/forest-breath.md
@@ -1,0 +1,64 @@
+---
+name: forest-breath
+description: Sage green + off-white, grounded and calm
+---
+
+# forest-breath
+
+Sage green + off-white, grounded and calm. Ported from the showrunner style set, which described a whole design
+system — a six-step type scale, a spacing scale, motion curves. Only the parts
+this studio renders survived the translation: caption styling, three card roles,
+and the music mood so `music_catalog --pick` can choose a bed that matches.
+
+Motion curves and the spacing scale were dropped rather than faked; nothing here
+reads them, and a value nothing reads is a value that drifts.
+
+```json
+{
+  "captions": {
+    "color": "#1a2e1f",
+    "highlight": "#c19a6b",
+    "fontFamily": "Inter",
+    "fontSize": 28,
+    "stroke": "#f5f5f0",
+    "strokeWidth": 3,
+    "bottom": 0.12,
+    "wordsPerPage": 4
+  },
+  "cards": {
+    "title": {
+      "bg": "#f5f5f0",
+      "fg": "#1a2e1f",
+      "fontSize": 80,
+      "align": "left",
+      "tracking": -0.01
+    },
+    "label": {
+      "bg": "#4a7c59",
+      "fg": "#1a2e1f",
+      "fontSize": 22,
+      "align": "left",
+      "tracking": 0.14
+    },
+    "stat": {
+      "bg": "#c19a6b",
+      "fg": "#f5f5f0",
+      "fontSize": 132,
+      "align": "center",
+      "tracking": -0.02
+    }
+  },
+  "music": {
+    "moods": [
+      "gentle",
+      "ambient",
+      "warm",
+      "contemplative"
+    ]
+  },
+  "rhythm": {
+    "bpm": 80,
+    "fps": 30
+  }
+}
+```

--- a/src/video_studio/styles/minty-fresh.md
+++ b/src/video_studio/styles/minty-fresh.md
@@ -1,0 +1,63 @@
+---
+name: minty-fresh
+description: Mint green + cream, cheerful product marketing
+---
+
+# minty-fresh
+
+Mint green + cream, cheerful product marketing. Ported from the showrunner style set, which described a whole design
+system — a six-step type scale, a spacing scale, motion curves. Only the parts
+this studio renders survived the translation: caption styling, three card roles,
+and the music mood so `music_catalog --pick` can choose a bed that matches.
+
+Motion curves and the spacing scale were dropped rather than faked; nothing here
+reads them, and a value nothing reads is a value that drifts.
+
+```json
+{
+  "captions": {
+    "color": "#064e3b",
+    "highlight": "#f59e0b",
+    "fontFamily": "Inter",
+    "fontSize": 28,
+    "stroke": "#f4faf5",
+    "strokeWidth": 3,
+    "bottom": 0.12,
+    "wordsPerPage": 4
+  },
+  "cards": {
+    "title": {
+      "bg": "#f4faf5",
+      "fg": "#064e3b",
+      "fontSize": 84,
+      "align": "left",
+      "tracking": -0.02
+    },
+    "label": {
+      "bg": "#10b981",
+      "fg": "#064e3b",
+      "fontSize": 22,
+      "align": "left",
+      "tracking": 0.1
+    },
+    "stat": {
+      "bg": "#f59e0b",
+      "fg": "#f4faf5",
+      "fontSize": 132,
+      "align": "center",
+      "tracking": -0.03
+    }
+  },
+  "music": {
+    "moods": [
+      "uplifting",
+      "playful",
+      "gentle"
+    ]
+  },
+  "rhythm": {
+    "bpm": 118,
+    "fps": 30
+  }
+}
+```

--- a/src/video_studio/styles/paper-press.md
+++ b/src/video_studio/styles/paper-press.md
@@ -1,0 +1,63 @@
+---
+name: paper-press
+description: Cream + black + red, newspaper editorial
+---
+
+# paper-press
+
+Cream + black + red, newspaper editorial. Ported from the showrunner style set, which described a whole design
+system — a six-step type scale, a spacing scale, motion curves. Only the parts
+this studio renders survived the translation: caption styling, three card roles,
+and the music mood so `music_catalog --pick` can choose a bed that matches.
+
+Motion curves and the spacing scale were dropped rather than faked; nothing here
+reads them, and a value nothing reads is a value that drifts.
+
+```json
+{
+  "captions": {
+    "color": "#0a0a0a",
+    "highlight": "#b91c1c",
+    "fontFamily": "Inter",
+    "fontSize": 28,
+    "stroke": "#f8f4ed",
+    "strokeWidth": 3,
+    "bottom": 0.12,
+    "wordsPerPage": 4
+  },
+  "cards": {
+    "title": {
+      "bg": "#f8f4ed",
+      "fg": "#0a0a0a",
+      "fontSize": 92,
+      "align": "left",
+      "tracking": -0.03
+    },
+    "label": {
+      "bg": "#111111",
+      "fg": "#0a0a0a",
+      "fontSize": 22,
+      "align": "left",
+      "tracking": 0.18
+    },
+    "stat": {
+      "bg": "#b91c1c",
+      "fg": "#f8f4ed",
+      "fontSize": 150,
+      "align": "center",
+      "tracking": -0.04
+    }
+  },
+  "music": {
+    "moods": [
+      "editorial",
+      "warm",
+      "contemplative"
+    ]
+  },
+  "rhythm": {
+    "bpm": 108,
+    "fps": 30
+  }
+}
+```

--- a/src/video_studio/styles/pastel-gradient.md
+++ b/src/video_studio/styles/pastel-gradient.md
@@ -1,0 +1,63 @@
+---
+name: pastel-gradient
+description: Lavender/purple, wellness and lifestyle
+---
+
+# pastel-gradient
+
+Lavender/purple, wellness and lifestyle. Ported from the showrunner style set, which described a whole design
+system — a six-step type scale, a spacing scale, motion curves. Only the parts
+this studio renders survived the translation: caption styling, three card roles,
+and the music mood so `music_catalog --pick` can choose a bed that matches.
+
+Motion curves and the spacing scale were dropped rather than faked; nothing here
+reads them, and a value nothing reads is a value that drifts.
+
+```json
+{
+  "captions": {
+    "color": "#1e1b4b",
+    "highlight": "#ec4899",
+    "fontFamily": "Inter",
+    "fontSize": 28,
+    "stroke": "#f5f0ff",
+    "strokeWidth": 3,
+    "bottom": 0.12,
+    "wordsPerPage": 4
+  },
+  "cards": {
+    "title": {
+      "bg": "#f5f0ff",
+      "fg": "#1e1b4b",
+      "fontSize": 84,
+      "align": "left",
+      "tracking": -0.01
+    },
+    "label": {
+      "bg": "#8b5cf6",
+      "fg": "#1e1b4b",
+      "fontSize": 22,
+      "align": "left",
+      "tracking": 0.12
+    },
+    "stat": {
+      "bg": "#ec4899",
+      "fg": "#f5f0ff",
+      "fontSize": 128,
+      "align": "center",
+      "tracking": -0.02
+    }
+  },
+  "music": {
+    "moods": [
+      "gentle",
+      "ambient",
+      "warm"
+    ]
+  },
+  "rhythm": {
+    "bpm": 88,
+    "fps": 30
+  }
+}
+```

--- a/src/video_studio/styles/sunny-editorial.md
+++ b/src/video_studio/styles/sunny-editorial.md
@@ -1,0 +1,63 @@
+---
+name: sunny-editorial
+description: Warm yellow + cream + charcoal, inviting long-form content
+---
+
+# sunny-editorial
+
+Warm yellow + cream + charcoal, inviting long-form content. Ported from the showrunner style set, which described a whole design
+system — a six-step type scale, a spacing scale, motion curves. Only the parts
+this studio renders survived the translation: caption styling, three card roles,
+and the music mood so `music_catalog --pick` can choose a bed that matches.
+
+Motion curves and the spacing scale were dropped rather than faked; nothing here
+reads them, and a value nothing reads is a value that drifts.
+
+```json
+{
+  "captions": {
+    "color": "#1c1917",
+    "highlight": "#ea580c",
+    "fontFamily": "Fraunces",
+    "fontSize": 28,
+    "stroke": "#fefae0",
+    "strokeWidth": 3,
+    "bottom": 0.12,
+    "wordsPerPage": 4
+  },
+  "cards": {
+    "title": {
+      "bg": "#fefae0",
+      "fg": "#1c1917",
+      "fontSize": 84,
+      "align": "left",
+      "tracking": -0.02
+    },
+    "label": {
+      "bg": "#d97706",
+      "fg": "#1c1917",
+      "fontSize": 22,
+      "align": "left",
+      "tracking": 0.12
+    },
+    "stat": {
+      "bg": "#ea580c",
+      "fg": "#fefae0",
+      "fontSize": 140,
+      "align": "center",
+      "tracking": -0.03
+    }
+  },
+  "music": {
+    "moods": [
+      "warm",
+      "uplifting",
+      "editorial"
+    ]
+  },
+  "rhythm": {
+    "bpm": 98,
+    "fps": 30
+  }
+}
+```

--- a/src/video_studio/styles/tech-startup.md
+++ b/src/video_studio/styles/tech-startup.md
@@ -1,0 +1,63 @@
+---
+name: tech-startup
+description: Dark/indigo/pink, modern SaaS aesthetic
+---
+
+# tech-startup
+
+Dark/indigo/pink, modern SaaS aesthetic. Ported from the showrunner style set, which described a whole design
+system — a six-step type scale, a spacing scale, motion curves. Only the parts
+this studio renders survived the translation: caption styling, three card roles,
+and the music mood so `music_catalog --pick` can choose a bed that matches.
+
+Motion curves and the spacing scale were dropped rather than faked; nothing here
+reads them, and a value nothing reads is a value that drifts.
+
+```json
+{
+  "captions": {
+    "color": "#fafafa",
+    "highlight": "#ec4899",
+    "fontFamily": "Inter",
+    "fontSize": 28,
+    "stroke": "#18181b",
+    "strokeWidth": 3,
+    "bottom": 0.12,
+    "wordsPerPage": 4
+  },
+  "cards": {
+    "title": {
+      "bg": "#18181b",
+      "fg": "#fafafa",
+      "fontSize": 84,
+      "align": "left",
+      "tracking": -0.03
+    },
+    "label": {
+      "bg": "#6366f1",
+      "fg": "#fafafa",
+      "fontSize": 22,
+      "align": "left",
+      "tracking": 0.08
+    },
+    "stat": {
+      "bg": "#ec4899",
+      "fg": "#18181b",
+      "fontSize": 132,
+      "align": "center",
+      "tracking": -0.04
+    }
+  },
+  "music": {
+    "moods": [
+      "energetic",
+      "corporate",
+      "uplifting"
+    ]
+  },
+  "rhythm": {
+    "bpm": 124,
+    "fps": 30
+  }
+}
+```

--- a/src/video_studio/styles/warm-minimal.md
+++ b/src/video_studio/styles/warm-minimal.md
@@ -1,0 +1,63 @@
+---
+name: warm-minimal
+description: Cream/brown, lifestyle and editorial
+---
+
+# warm-minimal
+
+Cream/brown, lifestyle and editorial. Ported from the showrunner style set, which described a whole design
+system — a six-step type scale, a spacing scale, motion curves. Only the parts
+this studio renders survived the translation: caption styling, three card roles,
+and the music mood so `music_catalog --pick` can choose a bed that matches.
+
+Motion curves and the spacing scale were dropped rather than faked; nothing here
+reads them, and a value nothing reads is a value that drifts.
+
+```json
+{
+  "captions": {
+    "color": "#292524",
+    "highlight": "#d97706",
+    "fontFamily": "Fraunces",
+    "fontSize": 28,
+    "stroke": "#faf5f0",
+    "strokeWidth": 3,
+    "bottom": 0.12,
+    "wordsPerPage": 4
+  },
+  "cards": {
+    "title": {
+      "bg": "#faf5f0",
+      "fg": "#292524",
+      "fontSize": 84,
+      "align": "left",
+      "tracking": -0.02
+    },
+    "label": {
+      "bg": "#b45309",
+      "fg": "#292524",
+      "fontSize": 22,
+      "align": "left",
+      "tracking": 0.12
+    },
+    "stat": {
+      "bg": "#d97706",
+      "fg": "#faf5f0",
+      "fontSize": 132,
+      "align": "center",
+      "tracking": -0.03
+    }
+  },
+  "music": {
+    "moods": [
+      "editorial",
+      "warm",
+      "contemplative"
+    ]
+  },
+  "rhythm": {
+    "bpm": 92,
+    "fps": 30
+  }
+}
+```


### PR DESCRIPTION
Closes the four capability gaps that stood between `showrunner` and retirement, so the repo can be archived. Roughly **600 lines carried, ~10,800 dropped** — the full accounting is in `MIGRATION-NOTES.md`.

## What was actually missing

| gap | why it was one |
|---|---|
| `duck_music` | A grep for "duck" across `src/video_studio/` returned **zero hits**. The bed played at one volume straight through the narration. |
| `music_catalog` | `gen_music` generates a bed; there was no way to use music the user already owns, and no deterministic pick — a re-render could change the score. |
| `gen_captions` | `tts_kokoro` emits timings for what it speaks. Recorded narration had none and rendered uncaptioned. |
| `burn_captions` | Captions reached the screen only via Remotion props. Anything cut in ffmpeg had none. |
| 11 style presets | `styles.py` shipped the mechanism and **zero presets**. |

## Two bugs found on the way

**`cli.py` swallowed every error message** (first commit, isolated for review). `raise SystemExit("message")` is the house style here and its `.code` is a *string*; the dispatcher did `int(exc.code or 0)`, so all 15 programs that raise one printed a `ValueError` traceback instead. Only via `video-studio <cmd>` — running the file directly was always fine, which is why it survived, and `video-studio <cmd>` is what the skills' prose says to use. Same shape as the `.root` bug: correct for whoever developed it, broken for whoever installed it.

**The shipped-styles tier could never resolve.** `SKILL_ROOT / "styles"` goes through `studio_root()`, which finds no marker directory here and falls back to the cwd — so it meant `<wherever you're standing>/styles`. Added a tier that travels with the package; confirmed against a real built wheel (11 presets + 4 programs present).

## Design notes worth a reviewer's eye

- `duck_music` reads the props `build_props` already wrote rather than re-deriving scene starts. build_props snaps boundaries on the *cumulative* total specifically so rounding can't accumulate; a second implementation would be free to drift, and an envelope that drifts ducks around speech that has moved. It must therefore run **after** `build_props` — documented, idempotent.
- Presets carry `music.moods` and `rhythm.bpm`, which `styles.py` ignores, so `music_catalog --pick --style <name>` derives a bed from the preset that sets the look. The mood vocabularies already matched.
- The type scale, spacing scale and motion curves were **dropped, not translated** — nothing here reads them, and a value nothing reads is a value that drifts.

## Verification

- `duck_music` on a two-scene fixture: floor 0.056 under loud narration, asymptotic recovery to 0.16 in silence, attack faster than release, idempotent.
- `burn_captions`: `\k` tags sum exactly to each page duration; burned a real clip and inspected frames — the spoken word highlights while upcoming words stay in the text colour.
- Picker: same seed → same track across runs; different seeds vary; explicit `--moods` overrides `--style`.
- `verify-skills.sh` passes (one pre-existing unrelated warning). Wheel builds clean.

New dependencies: **none** for music (stdlib only); `faster-whisper` behind an optional `[captions]` extra.

## Not in this PR

`skills/showrunner/SKILL.md` is superseded rather than moved, with the reasoning recorded. Its line 35 still reads `pip install showrunner` — the unrelated PyPI project. **PR #75 fixed that across four files and missed the skill**, which is the file an agent actually reads. Worth fixing before the repo is archived.