### PR TITLE
Port the showwatcher QC engine, minus its host

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,25 @@ audio = [
   "numpy>=1.26",
 ]
 
+# Checking a render against the plan it was built from: decoded frames, motion,
+# audio structure, composition. Ported from the showwatcher analyzer. No models
+# here — the model-backed checks live behind the qc-* extras below, so this one
+# stays installable on a laptop.
+qc = [
+  "numpy>=1.26",
+  "opencv-python-headless>=4.9",
+  "scenedetect>=0.6.4",
+  "rapidfuzz>=3.9",
+  "scipy>=1.14,<1.18",
+]
+
+# Model-backed QC, one extra per model so no single install drags in every one.
+# Each maps to detectors the engine skips cleanly when the extra is absent.
+qc-ocr = ["video-studio-engine[qc]", "easyocr>=1.7"]        # caption_sync, layout
+qc-yolo = ["video-studio-engine[qc]", "ultralytics>=8.2"]   # objects, entity_tracking
+qc-face = ["video-studio-engine[qc]", "mediapipe>=0.10"]    # lip_sync's real backend
+qc-clip = ["video-studio-engine[qc]", "fastembed>=0.3"]     # prompt_visual
+
 # Word timings for narration this studio did not synthesise. Optional because
 # it pulls a ~200MB CTranslate2 inference runtime that only gen_captions needs;
 # tts_kokoro already emits timings for anything it speaks itself.
@@ -76,7 +95,7 @@ export = [
 ]
 
 all = [
-  "video-studio-engine[sourcing,audio,captions,generate,vision,export]",
+  "video-studio-engine[sourcing,audio,captions,generate,vision,export,qc]",
 ]
 
 [project.scripts]

--- a/src/video_studio/cli.py
+++ b/src/video_studio/cli.py
@@ -48,6 +48,8 @@ COMMANDS: dict[str, str] = {
     # vision
     "composite_subject": "video_studio.vision.composite_subject",
     "track_pointing": "video_studio.vision.track_pointing",
+    # qc
+    "qc_analyze": "video_studio.qc.qc_analyze",
     # export
     "burn_captions": "video_studio.export.burn_captions",
     "export_capcut": "video_studio.export.export_capcut",
@@ -68,6 +70,7 @@ GROUPS = [
     ("audio", "voice, word timings, and the music bed"),
     ("generate", "generated images, video and procedural motion"),
     ("vision", "segmentation, compositing, hand tracking"),
+    ("qc", "checking a render against the plan it was built from"),
     ("export", "burnt-in captions, CapCut / Final Cut / OTIO handoff"),
     ("project", "props, preflight, editor, looks, tutorials, digest"),
 ]

--- a/src/video_studio/qc/__init__.py
+++ b/src/video_studio/qc/__init__.py
@@ -1,0 +1,23 @@
+"""Checking a render against the plan it was built from.
+
+Ported from `showwatcher`, an internal analyzer that was documented as this
+pipeline's step-8 quality gate for a year and never installed anywhere. The
+detectors and the decode layer were independent of that tool's host; the only
+coupling was where the ground truth came from, which is now `ground_truth.py`
+reading this repo's `plan.json` instead of a showrunner work_dir.
+
+Three of these checks — container, timeline, black_freeze — also ship as the
+bundled `qc_render.py` in the video-production skill, which needs no install at
+all. This package is the rest: everything that needs decoded frames, and behind
+further extras, everything that needs a model.
+"""
+
+__version__ = "0.1.0"
+
+#: Report schema this package emits.
+SCHEMA_VERSION = 2
+
+#: The shape v1 wrote. Kept so reports produced before the port still load.
+LEGACY_SCHEMA_VERSION = 1
+
+__all__ = ["LEGACY_SCHEMA_VERSION", "SCHEMA_VERSION", "__version__"]

--- a/src/video_studio/qc/analysis/align.py
+++ b/src/video_studio/qc/analysis/align.py
@@ -1,0 +1,243 @@
+"""Shared alignment primitives for the sync detectors.
+
+Port of analyzer/align.py with `envelope_offset_ms` vectorized. The naive
+per-lag Python loop is retained as `_envelope_offset_ms_naive` and serves as
+the oracle in tests — the vectorized path must pick the SAME lag on every
+input, including deliberately periodic ones.
+
+The behavior that must not regress: among lags scoring within EPSILON of the
+best, prefer the one closest to the expected position. Periodic content
+(music beats, repeated jingles) produces multiple near-equal correlation
+peaks, and float noise must not decide which repetition wins.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+
+import numpy as np
+
+ENVELOPE_RATE_HZ = 100  # 10 ms hop
+EPSILON = 0.02  # near-tie window for the expected-position tie-break
+
+
+def decode_pcm(path: str, sample_rate: int = 16_000) -> np.ndarray:
+    """Decode any audio (or a video's audio track) to mono float32 PCM."""
+    result = subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            path,
+            "-map",
+            "0:a:0",
+            "-ac",
+            "1",
+            "-ar",
+            str(sample_rate),
+            "-f",
+            "f32le",
+            "-",
+        ],
+        capture_output=True,
+        check=True,
+    )
+    return np.frombuffer(result.stdout, dtype=np.float32)
+
+
+def rms_envelope(
+    pcm: np.ndarray, sample_rate: int = 16_000, rate_hz: int = ENVELOPE_RATE_HZ
+) -> np.ndarray:
+    """RMS envelope at rate_hz frames/sec (default 10 ms hop)."""
+    hop = sample_rate // rate_hz
+    n = len(pcm) // hop
+    if n == 0:
+        return np.zeros(0, dtype=np.float32)
+    frames = pcm[: n * hop].reshape(n, hop)
+    out: np.ndarray = np.sqrt(np.mean(frames.astype(np.float64) ** 2, axis=1)).astype(np.float32)
+    return out
+
+
+def _tie_break(
+    scores: np.ndarray,
+    valid: np.ndarray,
+    lo: int,
+    expected_index: int,
+) -> int | None:
+    """Among valid lags within EPSILON of the best score, pick the one closest
+    to the expected position. Equal distances resolve to the lowest position —
+    the same order the naive loop's `min()` produced."""
+    if not valid.any():
+        return None
+    best_score = scores[valid].max()
+    candidate_mask = valid & (scores >= best_score - EPSILON)
+    positions = np.nonzero(candidate_mask)[0]
+    distances = np.abs(lo + positions - expected_index)
+    return int(positions[np.argmin(distances)])
+
+
+def envelope_offset_ms(
+    needle: np.ndarray,
+    haystack: np.ndarray,
+    expected_index: int,
+    search_radius: int,
+    rate_hz: int = ENVELOPE_RATE_HZ,
+) -> tuple[float, float] | None:
+    """Locate `needle` (a scene's envelope head) inside `haystack` (the mix
+    envelope) near expected_index. Returns (offset_ms, confidence) where
+    offset > 0 means the scene audio starts LATER than planned; confidence
+    is the normalized correlation peak in [0, 1]. None when there is no
+    usable signal (silent needle or empty search window).
+
+    Vectorized: per-lag means and norms come from cumulative sums, giving the
+    identical mean-subtracted normalized correlation the naive loop computes
+    (dot(n, seg - seg.mean()) == dot(n, seg) because sum(n) == 0).
+    """
+    if len(needle) < rate_hz // 4:  # < 250 ms of envelope: nothing to lock onto
+        return None
+    lo = max(0, expected_index - search_radius)
+    hi = min(len(haystack), expected_index + search_radius + len(needle))
+    window = haystack[lo:hi].astype(np.float64)
+    m = len(needle)
+    if len(window) < m:
+        return None
+
+    n = needle.astype(np.float64) - float(needle.mean())
+    n_norm = float(np.linalg.norm(n))
+    if n_norm < 1e-6:
+        return None  # flat/silent needle
+
+    # Sliding dot product of the mean-subtracted needle against every segment.
+    corr = np.correlate(window, n, mode="valid")
+
+    # Per-segment norms after mean subtraction, via cumulative sums:
+    #   sum(seg^2) - m * mean(seg)^2
+    csum = np.concatenate(([0.0], np.cumsum(window)))
+    csum2 = np.concatenate(([0.0], np.cumsum(window**2)))
+    seg_sums = csum[m:] - csum[:-m]
+    seg_sums2 = csum2[m:] - csum2[:-m]
+    seg_var = np.maximum(seg_sums2 - seg_sums**2 / m, 0.0)
+    seg_norms = np.sqrt(seg_var)
+
+    # The naive loop `continue`s on s_norm < 1e-9 — mask identically, or a
+    # flat window region becomes a spurious near-tie candidate.
+    valid = seg_norms >= 1e-9
+    scores = np.zeros_like(corr)
+    scores[valid] = corr[valid] / (n_norm * seg_norms[valid])
+
+    best_pos = _tie_break(scores, valid, lo, expected_index)
+    if best_pos is None:
+        return None
+    best_score = float(scores[valid].max())
+
+    found_index = lo + best_pos
+    offset_ms = (found_index - expected_index) * (1000.0 / rate_hz)
+    return offset_ms, max(0.0, best_score)
+
+
+def _envelope_offset_ms_naive(
+    needle: np.ndarray,
+    haystack: np.ndarray,
+    expected_index: int,
+    search_radius: int,
+    rate_hz: int = ENVELOPE_RATE_HZ,
+) -> tuple[float, float] | None:
+    """The v1 per-lag loop, kept verbatim as the oracle for the vectorized path."""
+    if len(needle) < rate_hz // 4:
+        return None
+    lo = max(0, expected_index - search_radius)
+    hi = min(len(haystack), expected_index + search_radius + len(needle))
+    window = haystack[lo:hi]
+    if len(window) < len(needle):
+        return None
+
+    n = needle - needle.mean()
+    n_norm = np.linalg.norm(n)
+    if n_norm < 1e-6:
+        return None
+
+    scores: list[tuple[int, float]] = []
+    for pos in range(0, len(window) - len(needle) + 1):
+        seg = window[pos : pos + len(needle)]
+        s = seg - seg.mean()
+        s_norm = np.linalg.norm(s)
+        if s_norm < 1e-9:
+            continue
+        scores.append((pos, float(np.dot(n, s) / (n_norm * s_norm))))
+    if not scores:
+        return None
+
+    best_score = max(score for _, score in scores)
+    candidates = [pos for pos, score in scores if score >= best_score - EPSILON]
+    best_pos = min(candidates, key=lambda pos: abs(lo + pos - expected_index))
+
+    found_index = lo + best_pos
+    offset_ms = (found_index - expected_index) * (1000.0 / rate_hz)
+    return offset_ms, max(0.0, best_score)
+
+
+@dataclass
+class Match:
+    expected_index: int  # index into the expected/planned series
+    actual_index: int  # index into the detected series
+    drift: float  # actual - expected, same unit as the inputs
+
+
+def match_monotonic(
+    expected: list[float],
+    actual: list[float],
+    tolerance: float,
+) -> list[Match]:
+    """Greedy monotonic matching: walk both sorted series, pair each expected
+    event with the nearest unconsumed actual event within tolerance. Keeps
+    ordering (no crossing pairs), so one spurious detection can't steal a
+    later boundary's match."""
+    matches: list[Match] = []
+    j = 0
+    for i, e in enumerate(expected):
+        best: tuple[float, int] | None = None
+        k = j
+        while k < len(actual) and actual[k] <= e + tolerance:
+            d = abs(actual[k] - e)
+            if d <= tolerance and (best is None or d < best[0]):
+                best = (d, k)
+            k += 1
+        if best is not None:
+            matches.append(Match(i, best[1], actual[best[1]] - e))
+            j = best[1] + 1
+    return matches
+
+
+@dataclass
+class DriftSummary:
+    mean: float
+    max_abs: float
+    slope_per_event: float  # least-squares slope over event index
+    intercept: float
+
+    @property
+    def is_cumulative(self) -> bool:
+        """Heuristic: drift growing event-over-event (concat/fps rounding bug)
+        rather than a constant head offset."""
+        return abs(self.slope_per_event) > 1e-9 and abs(self.slope_per_event) * 3 > abs(
+            self.intercept
+        )
+
+
+def summarize_drift(matches: list[Match]) -> DriftSummary | None:
+    if not matches:
+        return None
+    drifts = np.array([m.drift for m in matches], dtype=np.float64)
+    indices = np.array([m.expected_index for m in matches], dtype=np.float64)
+    if len(matches) >= 2:
+        slope, intercept = np.polyfit(indices, drifts, 1)
+    else:
+        slope, intercept = 0.0, drifts[0]
+    return DriftSummary(
+        mean=float(drifts.mean()),
+        max_abs=float(np.abs(drifts).max()),
+        slope_per_event=float(slope),
+        intercept=float(intercept),
+    )

--- a/src/video_studio/qc/analysis/beats.py
+++ b/src/video_studio/qc/analysis/beats.py
@@ -1,0 +1,41 @@
+"""Beat tracking via librosa ([beats] extra) — cuts landing on beats.
+
+The one capability worth librosa's numba tax: beat_track gives musical beat
+times, and `beat_alignment` measures what fraction of scene cuts land within
+a window of a beat — the plan's beatAlignmentScore, rubric dimension 4's
+last mile. Everything degrades to None when librosa is absent.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+BEAT_WINDOW_SEC = 0.10
+
+
+def beat_times(pcm: np.ndarray, sample_rate: int) -> list[float] | None:
+    """Beat positions in seconds, or None when librosa isn't installed or
+    the audio has no usable tempo."""
+    try:
+        import librosa
+    except ImportError:
+        return None
+    if len(pcm) < sample_rate:
+        return None
+    try:
+        _tempo, frames = librosa.beat.beat_track(y=pcm.astype(np.float32), sr=sample_rate)
+        times = librosa.frames_to_time(frames, sr=sample_rate)
+        return [float(t) for t in times]
+    except Exception:
+        return None
+
+
+def beat_alignment(
+    cuts: list[float], beats: list[float], window_sec: float = BEAT_WINDOW_SEC
+) -> float | None:
+    """Fraction of cuts within ±window of a beat. None when either is empty."""
+    if not cuts or not beats:
+        return None
+    arr = np.asarray(beats)
+    hits = sum(1 for c in cuts if float(np.abs(arr - c).min()) <= window_sec)
+    return hits / len(cuts)

--- a/src/video_studio/qc/analysis/onsets.py
+++ b/src/video_studio/qc/analysis/onsets.py
@@ -1,0 +1,123 @@
+"""Audio onset + band-energy envelopes (numpy + scipy.signal; librosa's numba
+tax still not worth it for these).
+
+Spectral flux onset strength: framewise rfft (40 ms window, 10 ms hop),
+half-wave-rectified log-magnitude first difference summed over bins. The
+result is a 100 Hz envelope aligned with align.ENVELOPE_RATE_HZ so the
+av_sync detector can correlate it directly against visual motion energy.
+
+Peak picking is scipy.signal.find_peaks; the speech band is a zero-phase
+Butterworth bandpass (sosfiltfilt — no group delay, so lag estimates stay
+honest). The original hand-rolled implementations survive as `_legacy_*`
+oracles in tests only.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import butter, find_peaks, sosfiltfilt
+
+RATE_HZ = 100  # 10 ms hop, matches align.ENVELOPE_RATE_HZ
+WINDOW_SEC = 0.040
+
+
+def _frames(pcm: np.ndarray, sample_rate: int) -> np.ndarray:
+    hop = sample_rate // RATE_HZ
+    win = int(sample_rate * WINDOW_SEC)
+    n = max(0, (len(pcm) - win) // hop + 1)
+    if n == 0:
+        return np.zeros((0, win), dtype=np.float64)
+    idx = np.arange(win)[None, :] + hop * np.arange(n)[:, None]
+    out: np.ndarray = pcm[idx].astype(np.float64) * np.hanning(win)[None, :]
+    return out
+
+
+def onset_envelope(pcm: np.ndarray, sample_rate: int = 16_000) -> np.ndarray:
+    """Spectral-flux onset strength at RATE_HZ. Empty input -> empty array."""
+    frames = _frames(pcm, sample_rate)
+    if len(frames) == 0:
+        return np.zeros(0, dtype=np.float32)
+    mags = np.log1p(np.abs(np.fft.rfft(frames, axis=1)))
+    flux = np.diff(mags, axis=0, prepend=mags[:1])
+    flux = np.maximum(flux, 0.0)  # half-wave rectify: energy INCREASES only
+    out: np.ndarray = flux.sum(axis=1).astype(np.float32)
+    return out
+
+
+def band_envelope(
+    pcm: np.ndarray,
+    sample_rate: int = 16_000,
+    lo_hz: float = 300.0,
+    hi_hz: float = 3400.0,
+) -> np.ndarray:
+    """Energy envelope restricted to a frequency band (speech band by default)
+    at RATE_HZ — for lip-sync, where broadband music must not dominate.
+
+    Zero-phase Butterworth bandpass then framewise RMS: unlike the old
+    FFT-bin-sum, real filter rolloff and NO group delay (sosfiltfilt), so
+    downstream lag estimates aren't biased by the filter itself."""
+    if len(pcm) < 32:
+        return np.zeros(0, dtype=np.float32)
+    nyquist = sample_rate / 2.0
+    hi = min(hi_hz, nyquist * 0.99)
+    sos = butter(4, [lo_hz, hi], btype="bandpass", fs=sample_rate, output="sos")
+    filtered = sosfiltfilt(sos, pcm.astype(np.float64))
+    frames = _frames(filtered, sample_rate)
+    if len(frames) == 0:
+        return np.zeros(0, dtype=np.float32)
+    out: np.ndarray = np.sqrt(np.mean(frames**2, axis=1)).astype(np.float32)
+    return out
+
+
+def pick_peaks(
+    envelope: np.ndarray,
+    rate_hz: int = RATE_HZ,
+    min_separation_sec: float = 0.15,
+) -> list[int]:
+    """Indices of prominent peaks: above median + 3*MAD, spaced at least
+    min_separation apart. scipy.find_peaks with `distance` implements the
+    same greedy strongest-first spacing the hand-rolled version did."""
+    if len(envelope) < 3:
+        return []
+    med = float(np.median(envelope))
+    mad = float(np.median(np.abs(envelope - med))) or 1e-9
+    threshold = med + 3.0 * mad
+    min_gap = max(1, int(min_separation_sec * rate_hz))
+    peaks, _ = find_peaks(
+        envelope.astype(np.float64),
+        height=np.nextafter(threshold, np.inf),  # strict >, matching the oracle
+        distance=min_gap,
+        prominence=mad,
+    )
+    return [int(p) for p in peaks]
+
+
+def normalized_xcorr_lag(a: np.ndarray, b: np.ndarray, max_lag: int) -> tuple[int, float] | None:
+    """Best lag of b relative to a within +/-max_lag, by normalized correlation.
+    Returns (lag, correlation) or None on degenerate input. Positive lag means
+    b happens LATER than a."""
+    n = min(len(a), len(b))
+    if n < 8:
+        return None
+    a = a[:n].astype(np.float64)
+    b = b[:n].astype(np.float64)
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = np.linalg.norm(a) * np.linalg.norm(b)
+    if denom < 1e-9:
+        return None
+    best: tuple[int, float] | None = None
+    for lag in range(-max_lag, max_lag + 1):
+        if lag >= 0:
+            xa, xb = a[: n - lag], b[lag:]
+        else:
+            xa, xb = a[-lag:], b[: n + lag]
+        if len(xa) < 8:
+            continue
+        d = np.linalg.norm(xa) * np.linalg.norm(xb)
+        if d < 1e-9:
+            continue
+        score = float(np.dot(xa, xb) / d)
+        if best is None or score > best[1]:
+            best = (lag, score)
+    return best

--- a/src/video_studio/qc/analysis/textmatch.py
+++ b/src/video_studio/qc/analysis/textmatch.py
@@ -1,0 +1,50 @@
+"""Text normalization + tolerant matching shared by OCR/whisper detectors.
+
+Port of analyzer/ocr_util.py (minus the easyocr singleton, which lives in the
+detectors that need it). word_error_rate upgraded from v1's O(n*m) Python
+double loop to rapidfuzz's C++ Levenshtein — identical value, ~100-1000x
+faster on paragraph-length narration.
+"""
+
+from __future__ import annotations
+
+import re
+
+_NORM_RE = re.compile(r"[^a-z0-9']")
+
+
+def normalize_word(text: str) -> str:
+    return _NORM_RE.sub("", text.lower())
+
+
+def edit_distance_le1(a: str, b: str) -> bool:
+    """True when levenshtein(a, b) <= 1 — tolerates one OCR misread."""
+    if a == b:
+        return True
+    la, lb = len(a), len(b)
+    if abs(la - lb) > 1:
+        return False
+    if la > lb:
+        a, b, la, lb = b, a, lb, la
+    i = j = edits = 0
+    while i < la and j < lb:
+        if a[i] == b[j]:
+            i += 1
+            j += 1
+            continue
+        edits += 1
+        if edits > 1:
+            return False
+        if la == lb:
+            i += 1  # substitution
+        j += 1  # insertion into a / deletion from b
+    return edits + (lb - j) + (la - i) <= 1
+
+
+def word_error_rate(ref: list[str], hyp: list[str]) -> float:
+    """Standard Levenshtein WER. Same value as v1's DP matrix, via rapidfuzz."""
+    if not ref:
+        return 0.0 if not hyp else 1.0
+    from rapidfuzz.distance import Levenshtein
+
+    return Levenshtein.distance(ref, hyp) / len(ref)

--- a/src/video_studio/qc/context.py
+++ b/src/video_studio/qc/context.py
@@ -1,0 +1,71 @@
+"""The typed boundary between the media phase and the detector phase.
+
+Detectors are pure functions `run(ctx: Context) -> None` — this module is the
+whole surface they may touch. v1 (and early showwatcher) typed this boundary
+`Any` to dodge a circular import; nothing here imports detectors or the
+engine, so the dodge is gone and mypy checks the most important seam in the
+codebase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from video_studio.qc.media.audio import AudioTrack
+from video_studio.qc.media.ffmpeg_filters import FilterPassResult
+from video_studio.qc.media.probe import VideoInfo
+from video_studio.qc.report.model import Report
+from video_studio.qc.ground_truth import GroundTruth
+
+
+@dataclass
+class FrameStats:
+    """Per-frame visual measurements from the shared decode (visual service)."""
+
+    blur_scores: list[float] = field(default_factory=list)
+    banding_scores: list[float] = field(default_factory=list)
+    off_palette_fractions: list[float] = field(default_factory=list)
+    worst_blur: tuple[float, float] | None = None  # (score, t_sec)
+    palette_checked: bool = False
+
+
+@dataclass
+class PaneStats:
+    """Per-frame composition profiles from the shared decode (pane service)."""
+
+    column_profiles: list[Any] = field(default_factory=list)  # per-frame |Sobel_x| col means
+    block_energies: list[Any] = field(default_factory=list)  # per-frame column-block motion
+    key_hue_fractions: list[float] = field(default_factory=list)  # chroma-hue pixel fraction
+
+
+@dataclass
+class Artifacts:
+    """Everything the media phase produced for the detector phase."""
+
+    filter_pass: FilterPassResult | None = None
+    cuts: list[float] | None = None
+    frame_stats: FrameStats | None = None
+    motion_samples: list[tuple[float, float, float]] | None = None  # (t_prev, t_cur, speed)
+    energy_samples: list[tuple[float, float]] | None = None  # (t, frame-diff energy) @25fps
+    pane_stats: PaneStats | None = None
+    mouth_series: list[tuple[float, float]] | None = None  # (t, mouth openness/energy)
+    mouth_mode: str | None = None  # "mediapipe" (real aperture) | "haar" (degraded) | "none"
+    # Up to N small color frames per scene id, for CLIP prompt-fit scoring.
+    scene_frames: dict[str, list[Any]] | None = None
+    # Model-backed services (see services.model_services):
+    caption_sightings: list[tuple[float, set[str]]] | None = None  # (t_ms, words)
+    ocr_boxes: list[dict[str, Any]] | None = None  # full-frame OCR per layout sample
+    detections: list[tuple[float, set[str], int]] | None = None  # (t, classes, persons)
+
+
+@dataclass
+class Context:
+    video_path: str
+    video: VideoInfo
+    report: Report
+    audio: AudioTrack
+    artifacts: Artifacts
+    ground_truth: GroundTruth | None = None
+    evidence_dir: str | None = None
+    taxonomy: str | None = None

--- a/src/video_studio/qc/detectors/audio_quality.py
+++ b/src/video_studio/qc/detectors/audio_quality.py
@@ -1,0 +1,153 @@
+"""Audio quality: EBU R128 loudness, trailing silence, music ducking.
+
+Loudness arrives from the shared ffmpeg filter pass (chained with black/freeze
+detection — one decode instead of v1's three); the envelope work uses the
+shared AudioTrack. Heuristics, thresholds, and messages are v1 verbatim.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from video_studio.qc.analysis.align import ENVELOPE_RATE_HZ
+from video_studio.qc.context import Context
+from video_studio.qc.report.model import Finding
+
+# Social platforms normalize to roughly -14 LUFS; renders far off get penalized
+# or pumped by platform processing.
+LUFS_TARGET = -14.0
+LUFS_WARN_DELTA = 6.0
+TRAILING_SILENCE_WARN_SEC = 1.25  # narration naturally ends ~1s before the video
+DUCKING_MIN_DROP_DB = 2.0
+GAP_MIN_SEC = 0.4
+
+
+def run(ctx: Context) -> None:
+    r = ctx.report
+    v = ctx.video
+    gt = ctx.ground_truth
+
+    if v.audio is None:
+        return  # container detector already reports the missing stream
+
+    fp = ctx.artifacts.filter_pass
+    assert fp is not None, "engine must run the filter pass before audio_quality"
+    loud = fp.loudness
+    if loud is not None:
+        integrated, lra, peak = loud
+        r.set_metric("audio.integratedLufs", integrated)
+        r.set_metric("audio.loudnessRangeLu", lra)
+        if peak is not None:
+            r.set_metric("audio.truePeakDbfs", peak)
+        if abs(integrated - LUFS_TARGET) > LUFS_WARN_DELTA:
+            direction = "quiet" if integrated < LUFS_TARGET else "loud"
+            r.add(
+                Finding(
+                    "audio_quality",
+                    "LOUDNESS_OFF_TARGET",
+                    "warning",
+                    f"Integrated loudness {integrated:.1f} LUFS is far {direction} of the "
+                    f"~{LUFS_TARGET:.0f} LUFS social-platform target — platforms will "
+                    "renormalize and may pump artifacts",
+                    metrics={"integratedLufs": integrated},
+                    rubric_dimension="audio",
+                )
+            )
+        if peak is not None and peak > -1.0:
+            r.add(
+                Finding(
+                    "audio_quality",
+                    "PEAK_CLIPPING_RISK",
+                    "warning",
+                    f"True peak {peak:.1f} dBFS exceeds -1 dBFS — risk of clipping after "
+                    "platform transcode",
+                    metrics={"truePeakDbfs": peak},
+                    rubric_dimension="audio",
+                )
+            )
+
+    # Envelope-based tail + ducking analysis (shared AudioTrack decode).
+    env = ctx.audio.envelope
+    if len(env) == 0:
+        return
+    env_db = ctx.audio.envelope_db
+    silence_floor = -50.0
+
+    # Trailing silence measured against the VIDEO's end, not the audio
+    # track's — an audio stream that simply ends early is the same defect.
+    active = np.where(env_db > silence_floor)[0]
+    if len(active):
+        audio_active_end_sec = active[-1] / ENVELOPE_RATE_HZ
+        trailing = max(0.0, v.duration_sec - audio_active_end_sec)
+        r.set_metric("audio.trailingSilenceSec", trailing)
+        if trailing > TRAILING_SILENCE_WARN_SEC:
+            r.add(
+                Finding(
+                    "audio_quality",
+                    "TRAILING_SILENCE",
+                    "warning",
+                    f"Audio goes silent {trailing:.2f}s before the video ends — audio/visual "
+                    "timeline mismatch (the audible counterpart of a black-frame tail)",
+                    span_sec=(v.duration_sec - trailing, v.duration_sec),
+                    metrics={"trailingSilenceSec": round(trailing, 3)},
+                    rubric_dimension="audio",
+                )
+            )
+
+    # Ducking heuristic — needs narration gap positions from scene WAVs.
+    if gt is None or not gt.options.get("music") or gt.options.get("music") == "none":
+        return
+    gap_windows: list[tuple[int, int]] = []
+    speech_windows: list[tuple[int, int]] = []
+    any_wav = False
+    for scene in gt.scenes:
+        wav = gt.scene_wav(scene.id)
+        if wav is None:
+            continue
+        any_wav = True
+        wav_env = ctx.audio.wav_envelope(wav)
+        wav_db = 20 * np.log10(np.maximum(wav_env, 1e-6))
+        base = int(scene.start_sec * ENVELOPE_RATE_HZ)
+        is_speech = wav_db > silence_floor
+        # Contiguous silent runs >= GAP_MIN_SEC inside the scene = narration gaps.
+        i = 0
+        while i < len(is_speech):
+            j = i
+            while j < len(is_speech) and not is_speech[j]:
+                j += 1
+            if j - i >= GAP_MIN_SEC * ENVELOPE_RATE_HZ:
+                gap_windows.append((base + i, base + j))
+            if j == i:
+                k = i
+                while k < len(is_speech) and is_speech[k]:
+                    k += 1
+                speech_windows.append((base + i, base + k))
+                i = k
+            else:
+                i = j
+    if not any_wav or not gap_windows or not speech_windows:
+        return
+
+    def mean_db(windows: list[tuple[int, int]]) -> float:
+        vals = np.concatenate([env_db[a:b] for a, b in windows if b <= len(env_db) and b > a])
+        return float(vals.mean()) if len(vals) else -float(np.inf)
+
+    gap_db = mean_db(gap_windows)
+    speech_db = mean_db(speech_windows)
+    if not np.isfinite(gap_db) or not np.isfinite(speech_db):
+        return
+    drop = speech_db - gap_db
+    r.set_metric("audio.narrationGapDropDb", drop)
+    if drop < DUCKING_MIN_DROP_DB:
+        r.add(
+            Finding(
+                "audio_quality",
+                "MUSIC_NOT_DUCKING",
+                "warning",
+                f"Mix level in narration gaps ({gap_db:.1f} dB) is within {drop:.1f} dB of the "
+                f"level under speech ({speech_db:.1f} dB) — the music bed does not appear to "
+                "duck under narration",
+                metrics={"gapDb": round(gap_db, 1), "speechDb": round(speech_db, 1)},
+                rubric_dimension="audio",
+            )
+        )

--- a/src/video_studio/qc/detectors/audio_sync.py
+++ b/src/video_studio/qc/detectors/audio_sync.py
@@ -1,0 +1,128 @@
+"""Per-scene narration timing vs the final mix, over the shared AudioTrack.
+
+v1 decoded the mix once here and once in audio_quality, plus every scene WAV;
+AudioTrack now caches all of it. envelope_offset_ms is the vectorized version
+(same lag selection, oracle-tested). avDesync = audioOffset - sceneCutDrift
+isolates true A/V desync: audio and video drifting together is benign,
+diverging is the bug.
+"""
+
+from __future__ import annotations
+
+from video_studio.qc.analysis.align import ENVELOPE_RATE_HZ, envelope_offset_ms, rms_envelope
+from video_studio.qc.context import Context
+from video_studio.qc.report.model import Finding, Severity
+
+SAMPLE_RATE = 16_000
+NEEDLE_SEC = 2.0  # correlate the first 2s of each scene's narration
+SEARCH_RADIUS_SEC = 2.0  # ± window around the planned start
+MIN_CONFIDENCE = 0.5  # correlation peak below this → unreliable, skip
+OFFSET_WARN_MS = 150.0
+OFFSET_ERROR_MS = 500.0
+AV_DESYNC_WARN_MS = 200.0
+
+
+def run(ctx: Context) -> None:
+    gt = ctx.ground_truth
+    r = ctx.report
+    assert gt is not None
+
+    wavs = {s.id: gt.scene_wav(s.id) for s in gt.scenes}
+    if not any(wavs.values()):
+        r.add(
+            Finding(
+                "audio_sync",
+                "NO_SCENE_WAVS",
+                "info",
+                "No per-scene narration WAVs found in the workdir — audio sync analysis skipped",
+            )
+        )
+        return
+
+    mix_env = ctx.audio.envelope
+    offsets: dict[str, float] = {}
+
+    for scene in gt.scenes:
+        wav = wavs[scene.id]
+        if wav is None:
+            continue
+        needle_pcm = ctx.audio.wav_pcm_head(wav, NEEDLE_SEC)
+        needle_env = rms_envelope(needle_pcm, SAMPLE_RATE)
+        result = envelope_offset_ms(
+            needle_env,
+            mix_env,
+            expected_index=int(scene.start_sec * ENVELOPE_RATE_HZ),
+            search_radius=int(SEARCH_RADIUS_SEC * ENVELOPE_RATE_HZ),
+        )
+        if result is None:
+            continue
+        offset_ms, confidence = result
+        if confidence < MIN_CONFIDENCE:
+            r.add(
+                Finding(
+                    "audio_sync",
+                    "AUDIO_NOT_LOCATED",
+                    "warning",
+                    f"Scene '{scene.id}' narration could not be confidently located in the final "
+                    f"mix near {scene.start_sec:.2f}s (best correlation {confidence:.2f}) — "
+                    "narration may be missing, heavily masked by music, or far out of position",
+                    scene_id=scene.id,
+                    span_sec=(scene.start_sec, scene.end_sec),
+                    metrics={"confidence": round(confidence, 3)},
+                    rubric_dimension="audio",
+                )
+            )
+            continue
+
+        offsets[scene.id] = offset_ms
+        for st in r.scenes:
+            if st.id == scene.id:
+                st.audio_offset_ms = offset_ms
+
+        if abs(offset_ms) >= OFFSET_WARN_MS:
+            severity: Severity = "error" if abs(offset_ms) >= OFFSET_ERROR_MS else "warning"
+            direction = "late" if offset_ms > 0 else "early"
+            r.add(
+                Finding(
+                    "audio_sync",
+                    "AUDIO_OFFSET",
+                    severity,
+                    f"Scene '{scene.id}' narration starts {abs(offset_ms):.0f}ms {direction} vs "
+                    f"the planned timeline (correlation {confidence:.2f})",
+                    scene_id=scene.id,
+                    span_sec=(scene.start_sec, scene.start_sec + NEEDLE_SEC),
+                    metrics={"offsetMs": round(offset_ms, 1), "confidence": round(confidence, 3)},
+                    rubric_dimension="audio",
+                )
+            )
+
+    if offsets:
+        vals = list(offsets.values())
+        r.set_metric("sync.meanAudioOffsetMs", sum(vals) / len(vals))
+        r.set_metric("sync.maxAudioOffsetMs", max(abs(v) for v in vals))
+
+    # True A/V desync: audio and video boundaries diverging within a scene.
+    for st in r.scenes:
+        if st.audio_offset_ms is None or st.detected_cut_sec is None:
+            continue
+        cut_drift_ms = (st.detected_cut_sec - st.planned_start_sec) * 1000.0
+        av_desync = st.audio_offset_ms - cut_drift_ms
+        if abs(av_desync) >= AV_DESYNC_WARN_MS:
+            r.add(
+                Finding(
+                    "audio_sync",
+                    "AV_DESYNC",
+                    "error",
+                    f"Scene '{st.id}': narration is {abs(av_desync):.0f}ms "
+                    f"{'behind' if av_desync > 0 else 'ahead of'} its visuals — the video cut "
+                    f"moved {cut_drift_ms:+.0f}ms but the audio moved {st.audio_offset_ms:+.0f}ms",
+                    scene_id=st.id,
+                    span_sec=(st.planned_start_sec, st.planned_end_sec),
+                    metrics={
+                        "avDesyncMs": round(av_desync, 1),
+                        "cutDriftMs": round(cut_drift_ms, 1),
+                        "audioOffsetMs": round(st.audio_offset_ms, 1),
+                    },
+                    rubric_dimension="audio",
+                )
+            )

--- a/src/video_studio/qc/detectors/av_sync.py
+++ b/src/video_studio/qc/detectors/av_sync.py
@@ -1,0 +1,137 @@
+"""Audio-visual correlation: does the picture move when the sound happens?
+
+Targets the two taxonomy gaps showrunner's own README admits its analyzer
+cannot see: 3.3 ASMR (micro-interaction vs audio spike) and 4.2 lip-sync
+(global track alignment). Signals:
+
+  video: frame-diff energy at 25 fps from the shared decode (Artifacts.energy_samples)
+  audio: spectral-flux onset envelope at 100 Hz from the shared AudioTrack
+
+Global lag by normalized cross-correlation; event-level match rate over the
+top onset peaks. New detector — no v1 counterpart, excluded from parity.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from video_studio.qc.analysis.beats import beat_alignment, beat_times
+from video_studio.qc.analysis.onsets import RATE_HZ, normalized_xcorr_lag, onset_envelope, pick_peaks
+from video_studio.qc.context import Context
+from video_studio.qc.report import ids
+from video_studio.qc.report.model import Finding, Severity
+
+LAG_WARN_MS = 67.0  # ~2 frames at 30fps
+LAG_ERROR_MS = 200.0
+WEAK_COUPLING = 0.2
+EVENT_WINDOW_MS = 200.0
+MAX_EVENTS = 40
+
+
+def _motion_at_100hz(samples: list[tuple[float, float]], duration_sec: float) -> np.ndarray:
+    """Resample (t, energy) pairs onto the 100 Hz onset grid by interpolation."""
+    if not samples or duration_sec <= 0:
+        return np.zeros(0, dtype=np.float64)
+    times = np.array([t for t, _ in samples])
+    values = np.array([v for _, v in samples])
+    grid = np.arange(0, duration_sec, 1.0 / RATE_HZ)
+    out: np.ndarray = np.interp(grid, times, values)
+    return out
+
+
+def run(ctx: Context) -> None:
+    r = ctx.report
+    samples = ctx.artifacts.energy_samples
+    assert samples is not None, "engine must run the energy service before av_sync"
+
+    if ctx.video.audio is None:
+        r.add(
+            Finding(
+                "av_sync",
+                "NO_AUDIO_TO_CORRELATE",
+                "info",
+                "Video has no audio stream — audio-visual correlation is undefined",
+            )
+        )
+        return
+
+    onsets = onset_envelope(ctx.audio.pcm, ctx.audio.sample_rate)
+    motion = _motion_at_100hz(samples, ctx.video.duration_sec)
+    n = min(len(onsets), len(motion))
+    if n < RATE_HZ:  # under a second of overlap: nothing to say
+        return
+    onsets = onsets[:n]
+    motion = motion[:n]
+
+    result = normalized_xcorr_lag(motion, onsets, max_lag=2 * RATE_HZ)
+    if result is not None:
+        lag, correlation = result
+        lag_ms = lag * 1000.0 / RATE_HZ
+        r.set_metric("avSync.offsetMs", lag_ms)
+        r.set_metric("avSync.correlation", correlation)
+        if correlation >= WEAK_COUPLING and abs(lag_ms) >= LAG_WARN_MS:
+            severity: Severity = "error" if abs(lag_ms) >= LAG_ERROR_MS else "warning"
+            r.add(
+                Finding(
+                    "av_sync",
+                    "AV_LAG",
+                    severity,
+                    f"Audio events land {abs(lag_ms):.0f}ms "
+                    f"{'after' if lag_ms > 0 else 'before'} their visual motion "
+                    f"(correlation {correlation:.2f}) — a global A/V offset",
+                    metrics={"lagMs": round(lag_ms, 1), "correlation": round(correlation, 3)},
+                    rubric_dimension="audio",
+                )
+            )
+        if correlation < WEAK_COUPLING:
+            r.add(
+                Finding(
+                    "av_sync",
+                    "WEAK_AV_COUPLING",
+                    "warning",
+                    f"Visual motion barely tracks the audio (peak correlation "
+                    f"{correlation:.2f}) — sounds happen without visible causes, the "
+                    "signature failure for ASMR/sync-driven content",
+                    metrics={"correlation": round(correlation, 3)},
+                    rubric_dimension="audio",
+                )
+            )
+
+    # Event level: every prominent sound should have a visible cause nearby.
+    peaks = pick_peaks(onsets)[:MAX_EVENTS]
+    if peaks:
+        window = int(EVENT_WINDOW_MS / 1000.0 * RATE_HZ)
+        motion_med = float(np.median(motion))
+        motion_mad = float(np.median(np.abs(motion - motion_med))) or 1e-9
+        matched = 0
+        for peak in peaks:
+            lo = max(0, peak - window)
+            hi = min(len(motion), peak + window + 1)
+            if float(motion[lo:hi].max()) > motion_med + 2.0 * motion_mad:
+                matched += 1
+            else:
+                t = peak / RATE_HZ
+                r.add(
+                    Finding(
+                        "av_sync",
+                        "UNMATCHED_ONSET",
+                        "info",
+                        f"Distinct sound at {t:.2f}s has no visible motion within "
+                        f"±{EVENT_WINDOW_MS:.0f}ms — audio without a visual cause",
+                        key=ids.time_key(t, 0.1),
+                        span_sec=(t, t),
+                    )
+                )
+        r.set_metric("avSync.onsetMatchRate", matched / len(peaks))
+        r.set_metric("avSync.onsetCount", len(peaks))
+
+    # Beat alignment ([beats] extra; metric-only, no deduction until
+    # calibrated): what fraction of detected cuts land ON a musical beat.
+    cuts = ctx.artifacts.cuts
+    if cuts:
+        beats = beat_times(ctx.audio.pcm, ctx.audio.sample_rate)
+        if beats:
+            score = beat_alignment(cuts, beats)
+            if score is not None:
+                r.set_metric("sync.beatAlignmentScore", score)
+                r.set_metric("sync.beatCount", len(beats))

--- a/src/video_studio/qc/detectors/black_freeze.py
+++ b/src/video_studio/qc/detectors/black_freeze.py
@@ -1,0 +1,86 @@
+"""Black-frame and freeze-frame findings over the shared ffmpeg filter pass.
+
+v1 ran blackdetect and freezedetect as two separate full decodes; the spans now
+arrive precomputed in ctx.artifacts.filter_pass (one chained invocation, shared
+with audio_quality's ebur128). Severity/tail heuristics are v1's verbatim.
+
+v2 id note: BLACK_SPAN/FREEZE_SPAN legitimately recur, so they carry a
+time-bucketed `key` — the exact case the positional `:2` suffix got wrong.
+"""
+
+from __future__ import annotations
+
+from video_studio.qc.context import Context
+from video_studio.qc.report import ids
+from video_studio.qc.report.model import Finding, Severity
+
+TAIL_WINDOW_SEC = 0.5  # a black span ending within this of EOF counts as a tail
+
+
+def run(ctx: Context) -> None:
+    v = ctx.video
+    r = ctx.report
+    gt = ctx.ground_truth
+    fp = ctx.artifacts.filter_pass
+    assert fp is not None, "engine must run the filter pass before black_freeze"
+
+    def scene_id_at(t: float) -> str | None:
+        if gt is None:
+            return None
+        s = gt.scene_at(t)
+        return s.id if s else None
+
+    r.set_metric("blackFreeze.blackSpanCount", len(fp.black_spans))
+    for start, end in fp.black_spans:
+        is_tail = end >= v.duration_sec - TAIL_WINDOW_SEC
+        if is_tail:
+            r.add(
+                Finding(
+                    "black_freeze",
+                    "BLACK_TAIL",
+                    "error",
+                    f"Video ends with {end - start:.2f}s of black frames (from {start:.2f}s to "
+                    "end) — rendered timeline is longer than the visual content",
+                    span_sec=(start, end),
+                    scene_id=scene_id_at(start),
+                    key=ids.time_key(start),
+                    metrics={"durationSec": round(end - start, 3)},
+                    rubric_dimension="motion-timing",
+                )
+            )
+        else:
+            r.add(
+                Finding(
+                    "black_freeze",
+                    "BLACK_SPAN",
+                    "warning",
+                    f"Black frames from {start:.2f}s to {end:.2f}s ({end - start:.2f}s)",
+                    span_sec=(start, end),
+                    scene_id=scene_id_at(start),
+                    key=ids.time_key(start),
+                    metrics={"durationSec": round(end - start, 3)},
+                )
+            )
+
+    r.set_metric("blackFreeze.freezeSpanCount", len(fp.freeze_spans))
+    for start, end in fp.freeze_spans:
+        open_ended = end < 0
+        end_eff = v.duration_sec if open_ended else end
+        dur = end_eff - start
+        # A still image can be a legitimate design choice in motion graphics;
+        # freezes running to EOF or eating most of a scene are not.
+        severity: Severity = "warning" if (open_ended or dur >= 3.0) else "info"
+        suffix = " (runs to end of video)" if open_ended else ""
+        r.add(
+            Finding(
+                "black_freeze",
+                "FREEZE_SPAN",
+                severity,
+                f"Frozen frame from {start:.2f}s to {end_eff:.2f}s ({dur:.2f}s){suffix}",
+                span_sec=(start, end_eff),
+                scene_id=scene_id_at(start),
+                key=ids.time_key(start),
+                metrics={"durationSec": round(dur, 3)},
+                rubric_dimension="motion-timing",
+            )
+        )

--- a/src/video_studio/qc/detectors/caption_sync.py
+++ b/src/video_studio/qc/detectors/caption_sync.py
@@ -1,0 +1,145 @@
+"""On-screen caption timing vs captions/*.json ground truth. [ocr]
+
+v1 port, now PURE over Artifacts.caption_sightings — the OCR pass rides the
+shared decode (services.model_services.CaptionOcrService, 5 fps caption-band
+crops). Thresholds and messages unchanged.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from video_studio.qc.analysis.textmatch import edit_distance_le1, normalize_word
+from video_studio.qc.context import Context
+from video_studio.qc.report.model import Finding, Severity
+
+SAMPLE_FPS = 5.0
+MATCH_WINDOW_MS = 1500.0
+OFFSET_WARN_MS = 200.0
+OFFSET_ERROR_MS = 600.0
+MATCH_RATE_WARN = 0.85
+BLEED_GRACE_MS = 600.0
+
+
+def run(ctx: Context) -> None:
+    gt = ctx.ground_truth
+    r = ctx.report
+    assert gt is not None
+
+    if not gt.caption_words:
+        r.add(
+            Finding(
+                "caption_sync",
+                "NO_CAPTION_DATA",
+                "info",
+                "No captions/*.json in the workdir (captions disabled?) — caption sync skipped",
+            )
+        )
+        return
+
+    sightings = ctx.artifacts.caption_sightings
+    assert sightings is not None, "engine must run the caption OCR service first"
+
+    def first_and_last_seen(word: str, around_ms: float) -> tuple[float | None, float | None]:
+        first = last = None
+        for t_ms, words in sightings:
+            if t_ms < around_ms - MATCH_WINDOW_MS:
+                continue
+            if t_ms > around_ms + MATCH_WINDOW_MS + BLEED_GRACE_MS * 4:
+                break
+            if any(edit_distance_le1(word, w) for w in words):
+                if first is None:
+                    first = t_ms
+                last = t_ms
+        return first, last
+
+    offsets_by_scene: dict[str, list[float]] = {}
+    all_offsets: list[float] = []
+    missing = 0
+    considered = 0
+
+    for cw in gt.caption_words:
+        word = normalize_word(cw.text)
+        if len(word) < 3:  # 1-2 char words OCR too unreliably to score
+            continue
+        considered += 1
+        first, last = first_and_last_seen(word, cw.start_ms)
+        if first is None:
+            missing += 1
+            continue
+        offset = first - cw.start_ms
+        all_offsets.append(offset)
+        offsets_by_scene.setdefault(cw.scene_id, []).append(offset)
+
+        scene = next((s for s in gt.scenes if s.id == cw.scene_id), None)
+        if scene and last is not None:
+            scene_end_ms = scene.end_sec * 1000.0
+            if cw.end_ms <= scene_end_ms and last > scene_end_ms + BLEED_GRACE_MS:
+                r.add(
+                    Finding(
+                        "caption_sync",
+                        "CAPTION_BLEED",
+                        "warning",
+                        f"Caption word \"{cw.text}\" (scene '{cw.scene_id}') still on screen at "
+                        f"{last / 1000:.2f}s, {last - scene_end_ms:.0f}ms past its scene's end",
+                        scene_id=cw.scene_id,
+                        key=normalize_word(cw.text),
+                        span_sec=(scene_end_ms / 1000, last / 1000),
+                    )
+                )
+
+    if considered == 0:
+        return
+
+    match_rate = 1.0 - missing / considered
+    r.set_metric("sync.captionWordMatchRate", match_rate)
+    if match_rate < MATCH_RATE_WARN:
+        r.add(
+            Finding(
+                "caption_sync",
+                "CAPTIONS_NOT_RENDERED",
+                "error",
+                f"Only {match_rate:.0%} of caption words were found on screen near their "
+                f"scheduled time ({missing}/{considered} missing) — captions may not be "
+                "rendering, or timing is off by more than the search window",
+                metrics={"matchRate": round(match_rate, 3)},
+                rubric_dimension="captions",
+            )
+        )
+
+    if all_offsets:
+        arr = np.array(all_offsets)
+        median = float(np.median(arr))
+        iqr = float(np.percentile(arr, 75) - np.percentile(arr, 25))
+        r.set_metric("sync.medianCaptionOffsetMs", median)
+        r.set_metric("sync.captionOffsetIqrMs", iqr)
+
+        for scene_id, offs in offsets_by_scene.items():
+            scene_median = float(np.median(offs))
+            for st in r.scenes:
+                if st.id == scene_id:
+                    st.caption_offset_ms = scene_median
+
+        # Sampling at 5 fps quantizes appearance times to ~200ms; only a
+        # median beyond one sampling period is a real systemic lag.
+        sample_period_ms = 1000.0 / SAMPLE_FPS
+        if abs(median) > max(OFFSET_WARN_MS, sample_period_ms):
+            severity: Severity = "error" if abs(median) > OFFSET_ERROR_MS else "warning"
+            direction = "late" if median > 0 else "early"
+            r.add(
+                Finding(
+                    "caption_sync",
+                    "CAPTION_OFFSET",
+                    severity,
+                    (
+                        f"Captions render a median of {abs(median):.0f}ms {direction} vs their "
+                        f"word timings (IQR {iqr:.0f}ms across {len(all_offsets)} words) — a "
+                        "systemic renderer lag, not per-word jitter"
+                        if iqr < abs(median)
+                        else f"Captions render a median of {abs(median):.0f}ms {direction} with "
+                        f"high jitter (IQR {iqr:.0f}ms) — word timings themselves look unstable"
+                    ),
+                    metrics={"medianOffsetMs": round(median, 1), "iqrMs": round(iqr, 1)},
+                    rubric_dimension="captions",
+                )
+            )

--- a/src/video_studio/qc/detectors/composition.py
+++ b/src/video_studio/qc/detectors/composition.py
@@ -1,0 +1,157 @@
+"""Split-screen / multi-pane composition + chromakey QC. Pure CV, no new deps.
+
+Targets 4.1 (duet: two independent panes) and 2.1 (greenscreen speaker over
+content). Seam detection: a persistent, full-height ridge in the temporal
+mean of |Sobel_x| column profiles. Independence: cross-correlation of the two
+panes' motion-energy series — a wall edge inside one continuous shot moves
+WITH both sides; a real duet seam separates sides that move independently.
+
+When the plan carries composite `layers`, declared chromakey/pip rects become
+checkable ground truth (KEY_SPILL, PANE findings). New detector, no v1
+counterpart, excluded from parity.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from video_studio.qc.context import Context
+from video_studio.qc.report import ids
+from video_studio.qc.report.model import Finding
+
+SEAM_PERSISTENCE = 0.8  # ridge must be present in this fraction of frames
+SEAM_PROMINENCE = 2.5  # x the local median edge energy
+INDEPENDENT_BELOW = 0.35  # pane motion correlation under this = separate sources
+EDGE_MARGIN_FRAC = 0.08  # ignore ridges hugging the frame edge
+KEY_SPILL_WARN = 0.10  # fraction of pane pixels within the key hue
+
+
+def _find_seam(profiles: np.ndarray) -> tuple[int, float] | None:
+    """profiles: (frames, width) of per-column |Sobel_x| means. Returns
+    (column, persistence) of the strongest persistent interior ridge."""
+    if profiles.ndim != 2 or profiles.shape[0] < 3:
+        return None
+    width = profiles.shape[1]
+    margin = max(2, int(width * EDGE_MARGIN_FRAC))
+    interior = slice(margin, width - margin)
+    median_energy = np.median(profiles, axis=1, keepdims=True) + 1e-9
+    prominent = profiles[:, interior] > SEAM_PROMINENCE * median_energy
+    persistence = prominent.mean(axis=0)
+    best = int(np.argmax(persistence))
+    if persistence[best] < SEAM_PERSISTENCE:
+        return None
+    return best + margin, float(persistence[best])
+
+
+def _pane_motion_correlation(block_energy: np.ndarray, seam_col_frac: float) -> float | None:
+    """block_energy: (frames, blocks_x) column-block motion energy. Correlate
+    the summed left-of-seam vs right-of-seam series."""
+    if block_energy.ndim != 2 or block_energy.shape[0] < 5:
+        return None
+    split = round(seam_col_frac * block_energy.shape[1])
+    split = min(max(split, 1), block_energy.shape[1] - 1)
+    left = block_energy[:, :split].sum(axis=1)
+    right = block_energy[:, split:].sum(axis=1)
+    left = left - left.mean()
+    right = right - right.mean()
+    denom = np.linalg.norm(left) * np.linalg.norm(right)
+    if denom < 1e-9:
+        return None
+    return float(np.dot(left, right) / denom)
+
+
+def run(ctx: Context) -> None:
+    r = ctx.report
+    gt = ctx.ground_truth
+    stats = ctx.artifacts.pane_stats
+    assert stats is not None, "engine must run the pane service before composition"
+
+    col_profiles = np.array(stats.column_profiles)
+    block_energy = np.array(stats.block_energies)
+
+    pane_count = 1
+    seam = _find_seam(col_profiles)
+    if seam is not None:
+        col, persistence = seam
+        width = col_profiles.shape[1]
+        frac = col / width
+        correlation = _pane_motion_correlation(block_energy, frac)
+        r.set_metric("composition.seamPersistence", persistence)
+        if correlation is not None:
+            r.set_metric("composition.paneMotionCorrelation", correlation)
+        if correlation is not None and correlation < INDEPENDENT_BELOW:
+            pane_count = 2
+            r.add(
+                Finding(
+                    "composition",
+                    "SPLIT_SCREEN_DETECTED",
+                    "info",
+                    f"Persistent vertical seam at {frac:.0%} of frame width with "
+                    f"independently-moving sides (motion correlation {correlation:.2f}) — "
+                    "a genuine two-pane composition",
+                    key=ids.pane_key((frac, 0.0, 1 - frac, 1.0)),
+                    metrics={
+                        "seamFrac": round(frac, 3),
+                        "motionCorrelation": round(correlation, 3),
+                    },
+                )
+            )
+    r.set_metric("composition.paneCount", pane_count)
+
+    # Ground truth from composite layers, when declared.
+    if gt is None:
+        return
+    declared: list[tuple[str, str, Any, Any]] = []  # (scene, layer, role, extra)
+    for scene in gt.scenes:
+        raw = _plan_layers(gt, scene.id)
+        for layer in raw:
+            declared.append((scene.id, str(layer.get("id")), layer.get("role"), layer))
+
+    stacked = [d for d in declared if d[2] in ("hstack", "vstack")]
+    if stacked and pane_count < 2:
+        scene_id, layer_id = stacked[0][0], stacked[0][1]
+        r.add(
+            Finding(
+                "composition",
+                "MISSING_PANE",
+                "warning",
+                f"The plan declares stacked layers (e.g. '{layer_id}' in scene "
+                f"'{scene_id}') but no persistent independent pane seam was detected — "
+                "the composition may have collapsed to a single stream",
+                scene_id=scene_id,
+            )
+        )
+
+    chroma = [d for d in declared if d[2] == "chromakey"]
+    if chroma and stats.key_hue_fractions:
+        spill = float(np.median(stats.key_hue_fractions))
+        r.set_metric("composition.keySpillFraction", spill)
+        if spill > KEY_SPILL_WARN:
+            scene_id = chroma[0][0]
+            r.add(
+                Finding(
+                    "composition",
+                    "KEY_SPILL",
+                    "warning",
+                    f"A median {spill:.0%} of frame pixels sit within the chroma-key hue — "
+                    "green spill or an unkeyed region survived the composite",
+                    scene_id=scene_id,
+                    metrics={"spillFraction": round(spill, 3)},
+                    rubric_dimension="visual-quality",
+                )
+            )
+
+
+def _plan_layers(gt: Any, scene_id: str) -> list[dict[str, Any]]:
+    import json
+
+    try:
+        plan = json.loads((gt.workdir / "plan.json").read_text())
+    except Exception:
+        return []
+    for scene in plan.get("scenes", []):
+        if scene.get("id") == scene_id:
+            return scene.get("layers") or []
+    return []

--- a/src/video_studio/qc/detectors/container.py
+++ b/src/video_studio/qc/detectors/container.py
@@ -1,0 +1,97 @@
+"""Container-level checks: duration vs plan, resolution/aspect, fps, pix_fmt, streams.
+
+Pure over Context — no media access. Verbatim v1 thresholds and messages.
+"""
+
+from __future__ import annotations
+
+from video_studio.qc.context import Context
+from video_studio.qc.report.model import Finding, Severity
+
+# H.264 yuv420p at 30fps is showrunner's output contract for every format.
+EXPECTED_PIX_FMT = "yuv420p"
+EXPECTED_FPS = 30.0
+FPS_TOLERANCE = 0.5
+# Rendered duration may legitimately differ slightly from the plan (transition
+# overlaps, audio padding); beyond these it's a real defect.
+DURATION_WARN_SEC = 0.5
+DURATION_ERROR_SEC = 2.0
+
+ASPECT_DIMENSIONS = {
+    "9:16": (1080, 1920),
+    "16:9": (1920, 1080),
+    "1:1": (1080, 1080),
+    "4:5": (1080, 1350),
+}
+
+
+def run(ctx: Context) -> None:
+    v = ctx.video
+    r = ctx.report
+
+    if v.audio is None:
+        r.add(
+            Finding("container", "NO_AUDIO_STREAM", "error", "Rendered video has no audio stream")
+        )
+
+    if v.pix_fmt and v.pix_fmt != EXPECTED_PIX_FMT:
+        r.add(
+            Finding(
+                "container",
+                "UNEXPECTED_PIX_FMT",
+                "warning",
+                f"Pixel format is {v.pix_fmt}, expected {EXPECTED_PIX_FMT} "
+                "(compatibility risk on social platforms)",
+            )
+        )
+
+    if v.fps and abs(v.fps - EXPECTED_FPS) > FPS_TOLERANCE:
+        r.add(
+            Finding(
+                "container",
+                "UNEXPECTED_FPS",
+                "warning",
+                f"Frame rate is {v.fps:.2f} fps, expected {EXPECTED_FPS:.0f}",
+                metrics={"fps": v.fps},
+            )
+        )
+
+    gt = ctx.ground_truth
+    if gt is None:
+        return
+
+    # Resolution vs declared aspect ratio.
+    expected = ASPECT_DIMENSIONS.get(gt.aspect_ratio)
+    if gt.render_width and gt.render_height:
+        expected = (gt.render_width, gt.render_height)
+    if expected and (v.width, v.height) != expected:
+        r.add(
+            Finding(
+                "container",
+                "RESOLUTION_MISMATCH",
+                "error",
+                f"Video is {v.width}x{v.height}, expected {expected[0]}x{expected[1]} "
+                f"for aspect {gt.aspect_ratio}",
+                metrics={"width": v.width, "height": v.height},
+            )
+        )
+
+    # Duration vs the planned timeline (real audio durations when available).
+    target = gt.timeline_duration_sec or gt.planned_total_duration_sec
+    if target > 0:
+        drift = v.duration_sec - target
+        r.set_metric("container.durationDriftSec", drift)
+        if abs(drift) > DURATION_WARN_SEC:
+            severity: Severity = "error" if abs(drift) > DURATION_ERROR_SEC else "warning"
+            direction = "longer" if drift > 0 else "shorter"
+            r.add(
+                Finding(
+                    "container",
+                    "DURATION_DRIFT",
+                    severity,
+                    f"Rendered video is {abs(drift):.2f}s {direction} than the planned timeline "
+                    f"({v.duration_sec:.2f}s vs {target:.2f}s)",
+                    metrics={"driftSec": round(drift, 3)},
+                    rubric_dimension="motion-timing",
+                )
+            )

--- a/src/video_studio/qc/detectors/entity_tracking.py
+++ b/src/video_studio/qc/detectors/entity_tracking.py
@@ -1,0 +1,169 @@
+"""Entity tracking across cuts (4.3 multi-character, 3.2 unboxing). [yolo,track]
+
+YOLO detections at 2 fps -> supervision ByteTrack -> per-track lifetimes,
+plus HSV-histogram appearance signatures for cross-cut re-linking. Findings:
+
+  PRODUCT_NOT_SHOWN   — a plan noun maps to a COCO class but no track of that
+                        class lives >= 1s (reuses objects.KEYWORD_CLASSES)
+  PRODUCT_TOO_BRIEF   — the planned subject appears under 0.8s
+  SAME_ACTOR_TWO_CHARACTERS — two person tracks in disjoint time spans whose
+                        face-region signatures match but torso signatures
+                        differ (the 4.3 eval target), heuristic confidence.
+
+Heavy extras are imported lazily inside run(): absent ultralytics/supervision
+surfaces as a typed missing_extra skip, never a crash — the standing rule.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from video_studio.qc.context import Context
+from video_studio.qc.detectors.objects import FOOTAGE_FORMATS, expected_classes
+from video_studio.qc.media.sampling import sample_frames
+from video_studio.qc.report import ids
+from video_studio.qc.report.model import Finding
+
+SAMPLE_FPS = 2.0
+CONFIDENCE = 0.35
+MIN_PRESENCE_SEC = 1.0
+BRIEF_SEC = 0.8
+FACE_MATCH = 0.80  # cosine of HSV hists: same-ish face region
+TORSO_DIFFER = 0.60  # below this = different clothing
+
+
+def _hsv_hist(bgr: np.ndarray) -> np.ndarray:
+    import cv2
+
+    hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+    hist = cv2.calcHist([hsv], [0, 1], None, [16, 8], [0, 180, 0, 256]).flatten()
+    norm = np.linalg.norm(hist) or 1.0
+    return np.asarray(hist / norm)
+
+
+def _cos(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.dot(a, b))
+
+
+def run(ctx: Context) -> None:
+    gt = ctx.ground_truth
+    r = ctx.report
+    assert gt is not None
+
+    if gt.format not in FOOTAGE_FORMATS:
+        r.add(
+            Finding(
+                "entity_tracking",
+                "NOT_APPLICABLE",
+                "info",
+                f"Entity tracking skipped: format '{gt.format}' is motion graphics",
+            )
+        )
+        return
+
+    import supervision as sv  # [track]
+    from ultralytics import YOLO  # [yolo]
+
+    model = YOLO("yolov8n.pt")
+    names = model.names
+    tracker = sv.ByteTrack()
+
+    # track_id -> {class, first, last, frames, face_sig, torso_sig}
+    tracks: dict[int, dict[str, Any]] = {}
+
+    for frame in sample_frames(ctx.video_path, SAMPLE_FPS):
+        results = model.predict(frame.image, conf=CONFIDENCE, verbose=False)
+        detections = sv.Detections.from_ultralytics(results[0])
+        detections = tracker.update_with_detections(detections)
+        if detections.tracker_id is None:
+            continue
+        for xyxy, cls_id, track_id in zip(
+            detections.xyxy, detections.class_id, detections.tracker_id, strict=False
+        ):
+            x0, y0, x1, y1 = (int(v) for v in xyxy)
+            crop = frame.image[max(0, y0) : y1, max(0, x0) : x1]
+            if crop.size == 0:
+                continue
+            entry = tracks.setdefault(
+                int(track_id),
+                {
+                    "class": names[int(cls_id)],
+                    "first": frame.t_sec,
+                    "last": frame.t_sec,
+                    "frames": 0,
+                    "face": None,
+                    "torso": None,
+                },
+            )
+            entry["last"] = frame.t_sec
+            entry["frames"] += 1
+            if entry["class"] == "person" and entry["frames"] <= 5:
+                h = crop.shape[0]
+                face = crop[: max(1, h // 3)]
+                torso = crop[h // 3 : max(2, 2 * h // 3)]
+                entry["face"] = _hsv_hist(face) if entry["face"] is None else entry["face"]
+                entry["torso"] = _hsv_hist(torso) if entry["torso"] is None else entry["torso"]
+
+    r.set_metric("entity.trackCount", len(tracks))
+    if tracks:
+        lifetimes = [t["last"] - t["first"] for t in tracks.values()]
+        r.set_metric("entity.meanTrackLifetimeSec", float(np.mean(lifetimes)))
+
+    # Planned-subject presence, by tracked lifetime rather than any-frame hits.
+    seen_by_class: dict[str, float] = {}
+    for t in tracks.values():
+        seen_by_class[t["class"]] = max(seen_by_class.get(t["class"], 0.0), t["last"] - t["first"])
+    for scene in gt.scenes:
+        for cls in sorted(expected_classes(scene.visual)):
+            lifetime = seen_by_class.get(cls, 0.0)
+            if lifetime == 0.0:
+                r.add(
+                    Finding(
+                        "entity_tracking",
+                        "PRODUCT_NOT_SHOWN",
+                        "warning",
+                        f"Scene '{scene.id}' plans a {cls} but no track of that class "
+                        "exists anywhere in the video",
+                        scene_id=scene.id,
+                        key=ids.class_key(cls),
+                        rubric_dimension="visual-quality",
+                    )
+                )
+            elif lifetime < BRIEF_SEC:
+                r.add(
+                    Finding(
+                        "entity_tracking",
+                        "PRODUCT_TOO_BRIEF",
+                        "info",
+                        f"The planned {cls} is on screen for only {lifetime:.1f}s total",
+                        scene_id=scene.id,
+                        key=ids.class_key(cls),
+                    )
+                )
+
+    # 4.3: same face, different clothes, disjoint spans.
+    persons = [t for t in tracks.values() if t["class"] == "person" and t["face"] is not None]
+    for i in range(len(persons)):
+        for j in range(i + 1, len(persons)):
+            a, b = persons[i], persons[j]
+            disjoint = a["last"] < b["first"] or b["last"] < a["first"]
+            if not disjoint or a["torso"] is None or b["torso"] is None:
+                continue
+            if (
+                _cos(a["face"], b["face"]) > FACE_MATCH
+                and _cos(a["torso"], b["torso"]) < TORSO_DIFFER
+            ):
+                r.add(
+                    Finding(
+                        "entity_tracking",
+                        "SAME_ACTOR_TWO_CHARACTERS",
+                        "info",
+                        "Two disjoint person tracks share a face signature but wear "
+                        "different clothing — one actor appears to play two characters",
+                        confidence=0.6,
+                    )
+                )
+                r.set_metric("entity.sameActorPairs", 1.0)
+                return

--- a/src/video_studio/qc/detectors/layout.py
+++ b/src/video_studio/qc/detectors/layout.py
@@ -1,0 +1,193 @@
+"""Text layout QC: clipping, safe-margin overflow, overlap, watermark. [ocr]
+
+v1 port, now PURE over Artifacts.ocr_boxes — the full-frame OCR pass rides
+the shared decode (services.model_services.LayoutOcrService, 1 fps).
+Evidence stills carry v2 `key`s derived from the clipped text, so re-running
+with a new black span elsewhere no longer renames layout findings.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from video_studio.qc.analysis.textmatch import normalize_word
+from video_studio.qc.context import Context
+from video_studio.qc.report import ids
+from video_studio.qc.report.model import Finding
+
+SAMPLE_FPS = 1.0
+SAFE_MARGIN_FRAC = 0.05  # industry-standard 5% title-safe margin
+EDGE_CLIP_PX = 4  # a box within this of the frame edge is cut off
+MIN_OCR_CONFIDENCE = 0.4
+# Clipped text OCRs badly BECAUSE it's clipped — a low-confidence read at the
+# frame edge is evidence, not noise, so the clip check uses a lower floor.
+MIN_CLIP_CONFIDENCE = 0.1
+OVERLAP_IOU = 0.15
+MIN_TEXT_HEIGHT_FRAC = 0.015  # ignore tiny incidental text
+
+Box = tuple[float, float, float, float]
+
+
+def _iou(a: Box, b: Box) -> float:
+    ax0, ay0, ax1, ay1 = a
+    bx0, by0, bx1, by1 = b
+    ix0, iy0 = max(ax0, bx0), max(ay0, by0)
+    ix1, iy1 = min(ax1, bx1), min(ay1, by1)
+    if ix1 <= ix0 or iy1 <= iy0:
+        return 0.0
+    inter = (ix1 - ix0) * (iy1 - iy0)
+    union = (ax1 - ax0) * (ay1 - ay0) + (bx1 - bx0) * (by1 - by0) - inter
+    return inter / union
+
+
+def run(ctx: Context) -> None:
+    r = ctx.report
+    gt = ctx.ground_truth
+    samples = ctx.artifacts.ocr_boxes
+    assert samples is not None, "engine must run the layout OCR service first"
+
+    h_frame, w_frame = None, None
+    clipped_reported: set[str] = set()
+    overflow_reported: set[str] = set()
+    overlap_reported: set[tuple[str, str]] = set()
+    watermark_seen = False
+    frames_scanned = 0
+
+    for sample in samples:
+        frames_scanned += 1
+        t_sec = sample["t_sec"]
+        h_frame, w_frame = sample["shape"]
+        img = sample["frame"]  # None unless an evidence dir is configured
+        results = sample["results"]
+
+        boxes: list[tuple[Box, str]] = []
+        low_conf_boxes: list[tuple[Box, str]] = []
+        for bbox, text, conf in results:
+            if conf < MIN_CLIP_CONFIDENCE or not str(text).strip():
+                continue
+            xs = [p[0] for p in bbox]
+            ys = [p[1] for p in bbox]
+            box = (min(xs), min(ys), max(xs), max(ys))
+            if (box[3] - box[1]) < h_frame * MIN_TEXT_HEIGHT_FRAC:
+                continue
+            if conf >= MIN_OCR_CONFIDENCE:
+                boxes.append((box, str(text).strip()))
+            else:
+                low_conf_boxes.append((box, str(text).strip()))
+
+        scene = gt.scene_at(t_sec) if gt else None
+        scene_id = scene.id if scene else None
+
+        for box, text in boxes + low_conf_boxes:
+            is_low_conf = (box, text) in low_conf_boxes
+            x0, y0, x1, y1 = box
+            key = text.lower()[:30]
+
+            # Watermark: small text hugging a corner in the top or bottom band.
+            in_corner = (y1 < h_frame * 0.12 or y0 > h_frame * 0.88) and (
+                x0 < w_frame * 0.25 or x1 > w_frame * 0.75
+            )
+            if in_corner and (y1 - y0) < h_frame * 0.04:
+                watermark_seen = True
+                continue  # corner bugs are exempt from margin rules
+
+            if key not in clipped_reported and (
+                x0 <= EDGE_CLIP_PX
+                or y0 <= EDGE_CLIP_PX
+                or x1 >= w_frame - EDGE_CLIP_PX
+                or y1 >= h_frame - EDGE_CLIP_PX
+            ):
+                clipped_reported.add(key)
+                r.add(
+                    Finding(
+                        "layout",
+                        "TEXT_CLIPPED",
+                        "error",
+                        f'Text "{text[:60]}" touches the frame edge at {t_sec:.1f}s — '
+                        "it is being cut off",
+                        scene_id=scene_id,
+                        key=ids.text_key(text),
+                        span_sec=(t_sec, t_sec),
+                        evidence=_save_evidence(ctx, img, box, f"clipped-{len(clipped_reported)}"),
+                        rubric_dimension="layout",
+                    )
+                )
+            elif (
+                not is_low_conf
+                and key not in overflow_reported
+                and key not in clipped_reported
+                and (
+                    x0 < w_frame * SAFE_MARGIN_FRAC
+                    or y0 < h_frame * SAFE_MARGIN_FRAC
+                    or x1 > w_frame * (1 - SAFE_MARGIN_FRAC)
+                    or y1 > h_frame * (1 - SAFE_MARGIN_FRAC)
+                )
+            ):
+                overflow_reported.add(key)
+                r.add(
+                    Finding(
+                        "layout",
+                        "TEXT_OVERFLOW",
+                        "warning",
+                        f'Text "{text[:60]}" extends into the 5% safe margin at '
+                        f"{t_sec:.1f}s — risks being cropped by platform UI or TV overscan",
+                        scene_id=scene_id,
+                        key=ids.text_key(text),
+                        span_sec=(t_sec, t_sec),
+                        rubric_dimension="layout",
+                    )
+                )
+
+        for i in range(len(boxes)):
+            for j in range(i + 1, len(boxes)):
+                (box_a, text_a), (box_b, text_b) = boxes[i], boxes[j]
+                pair = (
+                    min(text_a.lower()[:30], text_b.lower()[:30]),
+                    max(text_a.lower()[:30], text_b.lower()[:30]),
+                )
+                if pair in overlap_reported:
+                    continue
+                if _iou(box_a, box_b) > OVERLAP_IOU:
+                    overlap_reported.add(pair)
+                    r.add(
+                        Finding(
+                            "layout",
+                            "TEXT_OVERLAP",
+                            "error",
+                            f'Text blocks "{text_a[:40]}" and "{text_b[:40]}" overlap at '
+                            f"{t_sec:.1f}s",
+                            scene_id=scene_id,
+                            key=ids.slug_key(f"{normalize_word(text_a)}-{normalize_word(text_b)}"),
+                            span_sec=(t_sec, t_sec),
+                            rubric_dimension="layout",
+                        )
+                    )
+
+    r.set_metric("layout.framesScanned", frames_scanned)
+    r.set_metric("layout.clippedTextCount", len(clipped_reported))
+    r.set_metric("layout.overflowTextCount", len(overflow_reported))
+
+    if gt and gt.options.get("watermark") and not watermark_seen:
+        r.add(
+            Finding(
+                "layout",
+                "WATERMARK_MISSING",
+                "warning",
+                f'Run options request watermark "{gt.options["watermark"]}" but no corner '
+                "watermark text was detected in any sampled frame",
+                rubric_dimension="layout",
+            )
+        )
+
+
+def _save_evidence(ctx: Any, img: Any, box: Box, name: str) -> dict[str, str]:
+    if not ctx.evidence_dir:
+        return {}
+    import cv2
+
+    x0, y0, x1, y1 = (int(v) for v in box)
+    annotated = img.copy()
+    cv2.rectangle(annotated, (x0, y0), (x1, y1), (0, 0, 255), 3)
+    path = f"{ctx.evidence_dir}/{name}.png"
+    cv2.imwrite(path, annotated)
+    return {"frame": f"evidence/{name}.png"}

--- a/src/video_studio/qc/detectors/lip_sync.py
+++ b/src/video_studio/qc/detectors/lip_sync.py
@@ -1,0 +1,90 @@
+"""Lip/track sync (4.2): does the mouth move when the speech happens?
+
+Two mouth backends (see services.MouthService): mediapipe FaceMesh gives real
+inner-lip aperture (findings carry confidence 0.9); the Haar fallback proxies
+openness with mouth-ROI frame-diff energy (confidence 0.5, degraded mode).
+Either way the series is correlated against the SPEECH-BAND (300-3400 Hz)
+envelope — broadband would let music drown the voice.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from video_studio.qc.analysis.onsets import RATE_HZ, band_envelope, normalized_xcorr_lag
+from video_studio.qc.context import Context
+from video_studio.qc.report.model import Finding, Severity
+
+OFFSET_WARN_MS = 80.0  # the broadcast +/-100ms window, minus a frame of slack
+OFFSET_ERROR_MS = 200.0
+ABSENT_BELOW = 0.15
+MIN_FACE_SECONDS = 1.0
+
+
+def run(ctx: Context) -> None:
+    r = ctx.report
+    series = ctx.artifacts.mouth_series  # list[(t, openness/energy)] or None
+    assert series is not None, "engine must run the face service before lip_sync"
+    confidence = 0.9 if ctx.artifacts.mouth_mode == "mediapipe" else 0.5
+
+    if ctx.video.audio is None:
+        return
+    face_seconds = len(series) / 10.0  # sampled at 10 fps
+    if face_seconds < MIN_FACE_SECONDS:
+        r.add(
+            Finding(
+                "lip_sync",
+                "NO_FACE_TRACKED",
+                "info",
+                f"No face visible for >= {MIN_FACE_SECONDS:.0f}s of sampled frames — "
+                "lip-sync analysis skipped",
+            )
+        )
+        return
+
+    speech = band_envelope(ctx.audio.pcm, ctx.audio.sample_rate)
+    if not len(speech) or float(speech.std()) < 1e-6:
+        return
+
+    times = np.array([t for t, _ in series])
+    values = np.array([v for _, v in series])
+    grid = np.arange(0, ctx.video.duration_sec, 1.0 / RATE_HZ)
+    mouth = np.interp(grid, times, values)
+    n = min(len(mouth), len(speech))
+    result = normalized_xcorr_lag(mouth[:n], speech[:n], max_lag=RATE_HZ // 2)  # +/-500ms
+    if result is None:
+        return
+    lag, correlation = result
+    lag_ms = lag * 1000.0 / RATE_HZ
+    r.set_metric("lipSync.offsetMs", lag_ms)
+    r.set_metric("lipSync.correlation", correlation)
+
+    if correlation < ABSENT_BELOW:
+        r.add(
+            Finding(
+                "lip_sync",
+                "LIP_SYNC_ABSENT",
+                "warning",
+                f"Mouth motion does not track the speech band (correlation "
+                f"{correlation:.2f}) — the on-screen face is not producing the audio "
+                "(dubbed, mis-cut, or a still)",
+                confidence=confidence,
+                metrics={"correlation": round(correlation, 3)},
+                rubric_dimension="audio",
+            )
+        )
+    elif abs(lag_ms) >= OFFSET_WARN_MS:
+        severity: Severity = "error" if abs(lag_ms) >= OFFSET_ERROR_MS else "warning"
+        r.add(
+            Finding(
+                "lip_sync",
+                "LIP_AUDIO_OFFSET",
+                severity,
+                f"Speech runs {abs(lag_ms):.0f}ms {'behind' if lag_ms > 0 else 'ahead of'} "
+                f"the mouth (correlation {correlation:.2f}) — outside the broadcast "
+                "±100ms comfort window",
+                confidence=confidence,
+                metrics={"lagMs": round(lag_ms, 1), "correlation": round(correlation, 3)},
+                rubric_dimension="audio",
+            )
+        )

--- a/src/video_studio/qc/detectors/motion.py
+++ b/src/video_studio/qc/detectors/motion.py
@@ -1,0 +1,121 @@
+"""Motion character analysis over the shared decode's global flow series.
+
+v1's root perf defect lived here: velocity_series() called sample_frames per
+scene, but sample_frames always decodes from frame 0 — O(scenes x full decode).
+The engine's motion service now computes optical flow ONCE for the whole video
+at 10 fps; this detector slices the series per scene span.
+
+Honest behavioral delta from v1 (declared in the parity allowlist): v1
+restarted the 10 fps sampling grid at each scene start; the global grid starts
+at 0, so sample times inside a scene shift by up to 100 ms. Easing score
+(coefficient of variation over the longest moving run) is robust to that, but
+borderline ROBOTIC_MOTION findings can flip.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from video_studio.qc.context import Context
+from video_studio.qc.report.model import Finding
+
+MIN_MOTION_PX = 0.15  # mean |flow| below this = static, ignore
+MIN_SEGMENT_SAMPLES = 8  # need ~0.8s of continuous motion to judge easing
+EASING_SCORE_WARN = 0.18
+ROBOTIC_SCENE_FRACTION = 0.5
+
+
+def easing_score(speeds: np.ndarray) -> float | None:
+    """Coefficient of variation of velocity inside the longest moving run.
+    None when there's no sustained motion to judge. v1 verbatim."""
+    moving = speeds > MIN_MOTION_PX
+    best_len, best_start = 0, None
+    i = 0
+    while i < len(moving):
+        if moving[i]:
+            j = i
+            while j < len(moving) and moving[j]:
+                j += 1
+            if j - i > best_len:
+                best_len, best_start = j - i, i
+            i = j
+        else:
+            i += 1
+    if best_len < MIN_SEGMENT_SAMPLES or best_start is None:
+        return None
+    seg = speeds[best_start : best_start + best_len]
+    return float(seg.std() / (seg.mean() + 1e-9))
+
+
+def run(ctx: Context) -> None:
+    r = ctx.report
+    gt = ctx.ground_truth
+    samples = ctx.artifacts.motion_samples
+    assert samples is not None, "engine must run the motion service before motion"
+
+    if gt and gt.scenes:
+        spans = [(s.id, s.start_sec, min(s.end_sec, ctx.video.duration_sec)) for s in gt.scenes]
+    else:
+        # No ground truth: analyze in 5s windows.
+        spans = [
+            (f"window-{i}", t, min(t + 5.0, ctx.video.duration_sec))
+            for i, t in enumerate(np.arange(0.0, ctx.video.duration_sec, 5.0))
+        ]
+
+    scores: list[float] = []
+    robotic_scenes: list[tuple[str, float, float, float]] = []
+    for scene_id, start, end in spans:
+        if end - start < 1.0:
+            continue
+        # Pairs fully inside the span — a pair straddling the boundary mixes
+        # two scenes' motion, which v1's per-scene decode never saw.
+        speeds = np.array(
+            [
+                speed
+                for t_prev, t_cur, speed in samples
+                if t_prev >= start - 1e-6 and t_cur <= end + 1e-6
+            ]
+        )
+        score = easing_score(speeds)
+        if score is None:
+            continue
+        scores.append(score)
+        if score < EASING_SCORE_WARN:
+            robotic_scenes.append((scene_id, start, end, score))
+
+    if not scores:
+        r.set_metric("motion.scenesWithMotion", 0)
+        return
+
+    r.set_metric("motion.scenesWithMotion", len(scores))
+    r.set_metric("motion.easingScoreMean", float(np.mean(scores)))
+    r.set_metric("motion.easingScoreMin", float(np.min(scores)))
+
+    for scene_id, start, end, score in robotic_scenes:
+        r.add(
+            Finding(
+                "motion",
+                "ROBOTIC_MOTION",
+                "warning",
+                f"Scene '{scene_id}': sustained motion at near-constant velocity (easing score "
+                f"{score:.2f}) — reads as linear/robotic; add easing curves",
+                scene_id=scene_id if gt else None,
+                span_sec=(start, end),
+                metrics={"easingScore": round(score, 3)},
+                rubric_dimension="motion-timing",
+            )
+        )
+
+    if len(robotic_scenes) / len(scores) >= ROBOTIC_SCENE_FRACTION and len(scores) >= 2:
+        r.add(
+            Finding(
+                "motion",
+                "PERVASIVE_LINEAR_MOTION",
+                "error",
+                f"{len(robotic_scenes)}/{len(scores)} moving scenes have un-eased "
+                "constant-velocity motion — the single strongest AI-made tell per the quality "
+                "rubric",
+                metrics={"roboticFraction": round(len(robotic_scenes) / len(scores), 3)},
+                rubric_dimension="motion-timing",
+            )
+        )

--- a/src/video_studio/qc/detectors/objects.py
+++ b/src/video_studio/qc/detectors/objects.py
@@ -1,0 +1,134 @@
+"""Planned-subject presence via YOLOv8n. [yolo]
+
+v1 port, including the KEYWORD_CLASSES table verbatim (and its documented
+"glass" exclusion — usually a material adjective, not a drinking glass).
+Now PURE over Artifacts.detections — YOLO rides the shared decode
+(services.model_services.ObjectService, 1 fps).
+"""
+
+from __future__ import annotations
+
+import re
+
+from video_studio.qc.context import Context
+from video_studio.qc.report import ids
+from video_studio.qc.report.model import Finding
+
+SAMPLE_FPS = 1.0
+CONFIDENCE = 0.35
+FOOTAGE_FORMATS = {"ai-video", "composite"}
+
+# prompt keyword (regex, word-boundary) -> COCO class name
+KEYWORD_CLASSES: list[tuple[str, str]] = [
+    (
+        r"\b(woman|man|person|people|creator|girl|boy|guy|lady|chef|host|speaker|hand|face|selfie)\b",
+        "person",
+    ),
+    (r"\b(car|vehicle)\b", "car"),
+    (r"\b(dog|puppy)\b", "dog"),
+    (r"\b(cat|kitten)\b", "cat"),
+    (r"\b(phone|smartphone|iphone)\b", "cell phone"),
+    (r"\b(laptop|macbook)\b", "laptop"),
+    (r"\b(tv|television|screen|monitor)\b", "tv"),
+    (r"\b(bottle)\b", "bottle"),
+    # "glass" excluded: usually a material adjective ("glass dropper"), not a drinking glass
+    (r"\b(cup|mug)\b", "cup"),
+    (r"\b(bowl)\b", "bowl"),
+    (r"\b(pizza)\b", "pizza"),
+    (r"\b(cake)\b", "cake"),
+    (r"\b(sandwich|burger)\b", "sandwich"),
+    (r"\b(chair)\b", "chair"),
+    (r"\b(couch|sofa)\b", "couch"),
+    (r"\b(bed)\b", "bed"),
+    (r"\b(book)\b", "book"),
+    (r"\b(clock|watch)\b", "clock"),
+    (r"\b(keyboard)\b", "keyboard"),
+    (r"\b(scissors)\b", "scissors"),
+]
+
+
+def expected_classes(visual_prompt: str) -> set[str]:
+    text = visual_prompt.lower()
+    return {cls for pattern, cls in KEYWORD_CLASSES if re.search(pattern, text)}
+
+
+def run(ctx: Context) -> None:
+    gt = ctx.ground_truth
+    r = ctx.report
+    assert gt is not None
+
+    if gt.format not in FOOTAGE_FORMATS:
+        r.add(
+            Finding(
+                "objects",
+                "NOT_APPLICABLE",
+                "info",
+                f"Object detection skipped: format '{gt.format}' is motion graphics, not footage",
+            )
+        )
+        return
+
+    scene_expectations = {s.id: expected_classes(s.visual) for s in gt.scenes}
+    if not any(scene_expectations.values()):
+        r.add(
+            Finding(
+                "objects",
+                "NO_MAPPABLE_SUBJECTS",
+                "info",
+                "No scene visual prompts mapped to detectable object classes",
+            )
+        )
+        return
+
+    frames = ctx.artifacts.detections
+    assert frames is not None, "engine must run the object service first"
+
+    seen_by_scene: dict[str, set[str]] = {s.id: set() for s in gt.scenes}
+    person_counts: dict[str, list[int]] = {s.id: [] for s in gt.scenes}
+
+    for t_sec, detected, persons in frames:
+        scene = gt.scene_at(t_sec)
+        if scene is None:
+            continue
+        seen_by_scene[scene.id] |= detected
+        person_counts[scene.id].append(persons)
+
+    missing_total = 0
+    for scene in gt.scenes:
+        expected = scene_expectations[scene.id]
+        if not expected:
+            continue
+        missing = expected - seen_by_scene[scene.id]
+        missing_total += len(missing)
+        for cls in sorted(missing):
+            r.add(
+                Finding(
+                    "objects",
+                    "SUBJECT_MISSING",
+                    "warning",
+                    f"Scene '{scene.id}' plans a {cls} on screen "
+                    f'("{scene.visual[:80]}...") but none was detected in any sampled frame',
+                    scene_id=scene.id,
+                    key=ids.class_key(cls),
+                    span_sec=(scene.start_sec, scene.end_sec),
+                    rubric_dimension="visual-quality",
+                )
+            )
+        # Person-count anomaly: prompt says one subject, footage shows a crowd.
+        counts = person_counts[scene.id]
+        if "person" in expected and counts and max(counts) >= 3:
+            r.add(
+                Finding(
+                    "objects",
+                    "UNEXPECTED_CROWD",
+                    "info",
+                    f"Scene '{scene.id}' shows up to {max(counts)} people; the visual prompt "
+                    "suggests a single subject — check for AI-generated extras/duplicates",
+                    scene_id=scene.id,
+                    span_sec=(scene.start_sec, scene.end_sec),
+                )
+            )
+
+    checked = sum(1 for v in scene_expectations.values() if v)
+    r.set_metric("objects.scenesChecked", checked)
+    r.set_metric("objects.missingSubjectCount", missing_total)

--- a/src/video_studio/qc/detectors/prompt_fit.py
+++ b/src/video_studio/qc/detectors/prompt_fit.py
@@ -1,0 +1,177 @@
+"""Prompt-fit scorecards: the video vs its CSV taxonomy row's eval target.
+
+Deterministic by construction — checks are declarative predicates over the
+metrics and findings other detectors already produced, defined in
+data/checks.yaml. No LLM in the loop, so the score is reproducible; an
+optional VLM judge can layer on later without touching this contract.
+
+The taxonomy row resolves from AnalyzeOptions.taxonomy ("4.1"), else inferred
+from the workdir topic against the vendored SocialBench CSV.
+"""
+
+from __future__ import annotations
+
+import csv
+import re
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any
+
+from video_studio.qc.context import Context
+from video_studio.qc.report.model import Finding
+
+_EXPR_RE = re.compile(
+    r"^(?P<neg>!)?(?P<kind>metric|finding):(?P<key>[A-Za-z0-9_.]+)"
+    r"(?:\s*(?P<op>>=|<=|==|>|<)\s*(?P<value>-?[\d.]+))?$"
+)
+
+
+@dataclass(frozen=True)
+class TaxonomyEntry:
+    sub_no: str
+    sub_name: str
+    description: str
+    eval_target: str
+
+
+def load_taxonomy() -> dict[str, TaxonomyEntry]:
+    text = resources.files("showwatcher.data").joinpath("taxonomy.csv").read_text()
+    out: dict[str, TaxonomyEntry] = {}
+    for row in csv.DictReader(text.splitlines()):
+        sub_no = (row.get("Subcategory #") or "").strip()
+        if not sub_no:
+            continue
+        out[sub_no] = TaxonomyEntry(
+            sub_no=sub_no,
+            sub_name=(row.get("Subcategory") or "").strip(),
+            description=(row.get("Format Description") or "").strip(),
+            eval_target=(row.get("LLM Evaluation Target") or "").strip(),
+        )
+    return out
+
+
+def load_checks() -> dict[str, Any]:
+    import yaml
+
+    text = resources.files("showwatcher.data").joinpath("checks.yaml").read_text()
+    return dict(yaml.safe_load(text))
+
+
+def _eval(expr: str, metrics: dict[str, float], finding_keys: set[str]) -> tuple[bool, Any]:
+    """Tiny closed grammar — never python eval."""
+    m = _EXPR_RE.match(expr.strip())
+    if m is None:
+        raise ValueError(f"malformed check expr: {expr!r}")
+    negated = bool(m.group("neg"))
+    kind, key, op, raw = m.group("kind"), m.group("key"), m.group("op"), m.group("value")
+    if kind == "finding":
+        present = key in finding_keys
+        return (not present if negated else present), present
+    value = metrics.get(key)
+    if value is None:
+        return False, None  # missing metric: the check simply fails
+    threshold = float(raw)
+    key_abs = abs(value) if "offsetMs" in key or "lagMs" in key else value
+    result = {
+        ">": key_abs > threshold,
+        ">=": key_abs >= threshold,
+        "<": key_abs < threshold,
+        "<=": key_abs <= threshold,
+        "==": key_abs == threshold,
+    }[op]
+    return (not result if negated else result), value
+
+
+def infer_subcategory(topic: str | None, plan_title: str | None) -> str | None:
+    """Cheap inference from the workdir's own words — explicit --taxonomy wins."""
+    text = f"{topic or ''} {plan_title or ''}".lower()
+    hints = [
+        ("asmr", "3.3"),
+        ("duet", "4.1"),
+        ("stitch", "4.1"),
+        ("lip sync", "4.2"),
+        ("lipsync", "4.2"),
+        ("lip-sync", "4.2"),
+        ("greenscreen", "2.1"),
+        ("green screen", "2.1"),
+        ("unboxing", "3.2"),
+        ("haul", "3.2"),
+        ("recipe", "3.1"),
+        ("skit", "4.3"),
+        ("roleplay", "4.3"),
+    ]
+    for needle, sub in hints:
+        if needle in text:
+            return sub
+    return None
+
+
+def run(ctx: Context) -> None:
+    r = ctx.report
+    gt = ctx.ground_truth
+
+    sub_no = getattr(ctx, "taxonomy", None)
+    source = "explicit"
+    if sub_no is None and gt is not None:
+        sub_no = infer_subcategory(gt.topic, gt.plan_title)
+        source = "inferred"
+    if sub_no is None:
+        return  # nothing to score against; silence, not noise
+
+    taxonomy = load_taxonomy()
+    checks = load_checks()
+    entry = taxonomy.get(sub_no)
+    spec = checks.get(sub_no)
+    if entry is None or spec is None:
+        return
+
+    r.taxonomy = {"subcategory": sub_no, "name": entry.sub_name, "source": source}
+
+    metrics = dict(r.metrics)
+    finding_keys = {f"{f.detector}.{f.code}" for f in r.findings}
+
+    results = []
+    total_weight = 0.0
+    passed_weight = 0.0
+    for check in spec.get("checks", []):
+        weight = float(check.get("weight", 1))
+        ok, value = _eval(check["expr"], metrics, finding_keys)
+        total_weight += weight
+        if ok:
+            passed_weight += weight
+        results.append(
+            {
+                "id": check["id"],
+                "expr": check["expr"],
+                "passed": ok,
+                "value": value,
+                "weight": weight,
+            }
+        )
+
+    score = passed_weight / total_weight if total_weight else 0.0
+    verdict = "pass" if score >= 0.8 else ("partial" if score >= 0.5 else "fail")
+    r.scorecards.append(
+        {
+            "subcategory": sub_no,
+            "name": entry.sub_name,
+            "evalTarget": entry.eval_target[:200],
+            "score": round(score, 3),
+            "verdict": verdict,
+            "checks": results,
+        }
+    )
+    r.set_metric("promptFit.score", score)
+
+    if verdict == "fail":
+        failed = [c["id"] for c in results if not c["passed"]]
+        r.add(
+            Finding(
+                "prompt_fit",
+                "SUBCATEGORY_UNMET",
+                "warning",
+                f"Scores {score:.0%} against taxonomy {sub_no} ({entry.sub_name}) — "
+                f"failing checks: {', '.join(failed)}",
+                metrics={"score": round(score, 3)},
+            )
+        )

--- a/src/video_studio/qc/detectors/prompt_visual.py
+++ b/src/video_studio/qc/detectors/prompt_visual.py
@@ -1,0 +1,99 @@
+"""CLIP prompt-fit: does each scene's footage match its own visual prompt?
+
+The general form of what objects.py's ~20-noun COCO table approximates — CLIP
+text-image similarity has no vocabulary, so EVERY scene gets scored against
+the exact prompt the generator was given. The judgment is a RELATIVE margin:
+a scene's similarity to its own prompt minus its mean similarity to the other
+scenes' prompts. Absolute CLIP cosines are uncalibrated (0.2 can be a great
+match); a scene that matches everyone else's prompt better than its own is a
+mismatch regardless of the absolute number.
+
+Needs the [store] extra (fastembed); models download ~0.6 GB on first use.
+Single-scene plans get an absolute floor only — no cross-prompts to compare.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from video_studio.qc.context import Context
+from video_studio.qc.report.model import Finding
+
+MIN_FRAMES = 1
+ABSOLUTE_FLOOR = 0.15  # below this even the RIGHT footage rarely scores; hard fail
+MARGIN_WARN = 0.0  # own-prompt similarity must beat the mean cross-prompt
+
+
+def run(ctx: Context) -> None:
+    gt = ctx.ground_truth
+    r = ctx.report
+    assert gt is not None
+    frames_by_scene = ctx.artifacts.scene_frames
+    assert frames_by_scene is not None, "engine must run the scene-frame service first"
+
+    scenes = [s for s in gt.scenes if len(frames_by_scene.get(s.id) or []) >= MIN_FRAMES]
+    if not scenes:
+        return
+
+    from video_studio.qc.embeddings.clip import ClipPair  # fastembed — [store] extra
+
+    clip = ClipPair()
+    prompts = [s.visual or s.narration or s.id for s in scenes]
+    text_vecs = clip.embed_texts(prompts)  # (n, 512), normalized
+
+    scene_vecs = []
+    for s in scenes:
+        img_vecs = clip.embed_bgr_frames(frames_by_scene[s.id])
+        scene_vecs.append(img_vecs.mean(axis=0))
+    image_mat = np.array(scene_vecs)
+    norms = np.linalg.norm(image_mat, axis=1, keepdims=True)
+    image_mat = image_mat / np.maximum(norms, 1e-9)
+
+    # sims[i, j] = similarity of scene i's footage to scene j's prompt.
+    sims = image_mat @ text_vecs.T
+    n = len(scenes)
+
+    own = np.diag(sims)
+    if n > 1:
+        cross = (sims.sum(axis=1) - own) / (n - 1)
+        margins = own - cross
+    else:
+        margins = np.zeros(1)
+
+    r.set_metric("promptVisual.meanClipScore", float(own.mean()))
+    r.set_metric("promptVisual.minClipScore", float(own.min()))
+    if n > 1:
+        r.set_metric("promptVisual.meanMargin", float(margins.mean()))
+        r.set_metric("promptVisual.minMargin", float(margins.min()))
+
+    for i, scene in enumerate(scenes):
+        score = float(own[i])
+        margin = float(margins[i]) if n > 1 else None
+        mismatch = score < ABSOLUTE_FLOOR or (margin is not None and margin < MARGIN_WARN)
+        if not mismatch:
+            continue
+        if margin is not None and margin < MARGIN_WARN:
+            best = int(np.argmax(sims[i]))
+            detail = (
+                f"its footage matches scene '{scenes[best].id}'s prompt better "
+                f"(CLIP {sims[i, best]:.3f} vs own {score:.3f})"
+            )
+        else:
+            detail = f"CLIP similarity {score:.3f} is below the {ABSOLUTE_FLOOR} floor"
+        r.add(
+            Finding(
+                "prompt_visual",
+                "VISUAL_PROMPT_MISMATCH",
+                "warning",
+                f"Scene '{scene.id}': the rendered footage does not match its visual "
+                f"prompt — {detail}. Prompt: \"{(scene.visual or '')[:120]}\"",
+                scene_id=scene.id,
+                span_sec=(scene.start_sec, scene.end_sec),
+                metrics={
+                    "clipScore": round(score, 4),
+                    **({"margin": round(margin, 4)} if margin is not None else {}),
+                },
+                rubric_dimension="visual-quality",
+                taxonomy_targets=["visual"],
+            )
+        )

--- a/src/video_studio/qc/detectors/scene_sync.py
+++ b/src/video_studio/qc/detectors/scene_sync.py
@@ -1,0 +1,126 @@
+"""Scene-cut timing vs the planned timeline, over the precomputed cut list.
+
+Cut detection itself moved to the engine (one SceneManager pass instead of
+v1's two detect() decodes); this detector is now pure matching + reporting.
+Thresholds, messages, and the cumulative-vs-offset reasoning are v1 verbatim.
+"""
+
+from __future__ import annotations
+
+from video_studio.qc.analysis.align import match_monotonic, summarize_drift
+from video_studio.qc.context import Context
+from video_studio.qc.report import ids
+from video_studio.qc.report.model import Finding, Severity
+
+MATCH_TOLERANCE_SEC = 1.5
+DRIFT_WARN_MS = 150.0
+DRIFT_ERROR_MS = 500.0
+
+# Formats whose scenes are continuous motion graphics — a missing hard cut
+# between scenes is often intentional there (crossfades), so downgrade.
+CONTINUOUS_FORMATS = {"faceless-explainer", "manim-explainer"}
+
+
+def run(ctx: Context) -> None:
+    gt = ctx.ground_truth
+    r = ctx.report
+    assert gt is not None
+
+    # Planned boundaries: the start of every scene after the first.
+    boundaries = [s.start_sec for s in gt.scenes[1:]]
+    if not boundaries:
+        return
+
+    cuts = ctx.artifacts.cuts
+    assert cuts is not None, "engine must run cut detection before scene_sync"
+    r.set_metric("sync.detectedCutCount", len(cuts))
+
+    matches = match_monotonic(boundaries, cuts, MATCH_TOLERANCE_SEC)
+    matched_expected = {m.expected_index for m in matches}
+    matched_actual = {m.actual_index for m in matches}
+
+    for m in matches:
+        scene = gt.scenes[m.expected_index + 1]  # boundary i starts scene i+1
+        drift_ms = m.drift * 1000.0
+        # Record on the scene timing spine.
+        for st in r.scenes:
+            if st.id == scene.id:
+                st.detected_cut_sec = cuts[m.actual_index]
+        if abs(drift_ms) >= DRIFT_WARN_MS:
+            severity: Severity = "error" if abs(drift_ms) >= DRIFT_ERROR_MS else "warning"
+            direction = "after" if drift_ms > 0 else "before"
+            r.add(
+                Finding(
+                    "scene_sync",
+                    "SCENE_CUT_DRIFT",
+                    severity,
+                    f"Cut into scene '{scene.id}' lands {abs(drift_ms):.0f}ms {direction} its "
+                    f"planned boundary ({cuts[m.actual_index]:.2f}s vs {scene.start_sec:.2f}s)",
+                    scene_id=scene.id,
+                    span_sec=(
+                        min(cuts[m.actual_index], scene.start_sec),
+                        max(cuts[m.actual_index], scene.start_sec),
+                    ),
+                    metrics={"driftMs": round(drift_ms, 1)},
+                    rubric_dimension="motion-timing",
+                )
+            )
+
+    # Planned boundaries with no matching detected cut.
+    for i, b in enumerate(boundaries):
+        if i in matched_expected:
+            continue
+        scene = gt.scenes[i + 1]
+        soft = gt.format in CONTINUOUS_FORMATS or scene.transition != "cut"
+        r.add(
+            Finding(
+                "scene_sync",
+                "MISSING_SCENE_CUT",
+                "info" if soft else "warning",
+                f"No visual cut detected near the planned start of scene '{scene.id}' ({b:.2f}s)"
+                + (
+                    " — its transition is a crossfade/motion, which may be intentional"
+                    if soft
+                    else ""
+                ),
+                scene_id=scene.id,
+                span_sec=(max(0.0, b - MATCH_TOLERANCE_SEC), b + MATCH_TOLERANCE_SEC),
+            )
+        )
+
+    # Detected cuts that match no planned boundary (mid-scene glitches,
+    # sideways/short clips in ai-video, double cuts).
+    for j, t in enumerate(cuts):
+        if j in matched_actual:
+            continue
+        host = gt.scene_at(t)  # None when the cut lands outside every scene
+        r.add(
+            Finding(
+                "scene_sync",
+                "UNPLANNED_CUT",
+                "warning",
+                f"Unplanned visual cut at {t:.2f}s inside scene '{host.id if host else '?'}'",
+                scene_id=host.id if host else None,
+                key=ids.time_key(t),
+                span_sec=(t, t),
+            )
+        )
+
+    summary = summarize_drift(matches)
+    if summary is not None:
+        r.set_metric("sync.meanSceneCutDriftMs", summary.mean * 1000)
+        r.set_metric("sync.maxSceneCutDriftMs", summary.max_abs * 1000)
+        r.set_metric("sync.cumulativeDriftSlopeMsPerScene", summary.slope_per_event * 1000)
+        if summary.is_cumulative and abs(summary.slope_per_event) * 1000 >= 30:
+            r.add(
+                Finding(
+                    "scene_sync",
+                    "CUMULATIVE_DRIFT",
+                    "error",
+                    f"Scene-cut drift grows ~{summary.slope_per_event * 1000:.0f}ms per scene — "
+                    "scene durations in the render are systematically longer/shorter than planned "
+                    "(classic concat or fps-rounding bug), not a one-off offset",
+                    metrics={"slopeMsPerScene": round(summary.slope_per_event * 1000, 1)},
+                    rubric_dimension="motion-timing",
+                )
+            )

--- a/src/video_studio/qc/detectors/timeline.py
+++ b/src/video_studio/qc/detectors/timeline.py
@@ -1,0 +1,128 @@
+"""NEW in showwatcher: the three-clock timeline audit.
+
+The one detector v1 structurally could not have. It resolves the video, audio,
+and caption timelines independently from the workdir's own artifacts and
+reports where they diverge — pure arithmetic over text files and ffprobe, no
+video decoding.
+
+The motivating case (measured, shipped): round3-2.1-greenscreen's clips_norm
+are 5.000s each while its WAVs are 4.925/3.050/3.325s. Video clock 15.0s,
+audio clock 11.3s — narration ran 3.7s ahead of its visuals, and the v1
+analyzer had nowhere to put a second clock, so it reported nothing.
+
+Not part of the v1 parity set; the parity harness compares shared detectors only.
+"""
+
+from __future__ import annotations
+
+from video_studio.qc.context import Context
+from video_studio.qc.report import ids
+from video_studio.qc.report.model import Finding
+from video_studio.qc.showrunner.timeline import (
+    CLOCK_SKEW_ERROR_SEC,
+    detect_generation,
+    resolve_timelines,
+)
+
+CLIP_SHORT_TOLERANCE_SEC = 1.0 / 30.0  # one frame at 30fps
+SOURCE_DISAGREE_WARN_SEC = 1.0 / 30.0
+
+
+def run(ctx: Context) -> None:
+    gt = ctx.ground_truth
+    r = ctx.report
+    assert gt is not None
+
+    timelines = resolve_timelines(gt)
+    generation = detect_generation(gt)
+    if generation != "n/a":
+        r.set_metric("timeline.audioSizedGeneration", 1.0 if generation == "audio-sized" else 0.0)
+
+    if timelines.video:
+        r.set_metric("timeline.videoClockSec", timelines.video[-1].end_sec)
+    if timelines.audio:
+        r.set_metric("timeline.audioClockSec", timelines.audio[-1].end_sec)
+
+    # The headline check: do the video and audio clocks agree?
+    worst = timelines.max_clock_skew()
+    if worst is not None:
+        scene_id, skew = worst
+        r.set_metric("timeline.maxClockSkewSec", skew)
+        if skew > CLOCK_SKEW_ERROR_SEC:
+            video_end = timelines.video[-1].end_sec
+            audio_end = timelines.audio[-1].end_sec
+            r.add(
+                Finding(
+                    "timeline",
+                    "TIMELINE_CLOCK_MISMATCH",
+                    "error",
+                    f"The visual and audio timelines diverge by {skew:.2f}s at scene "
+                    f"'{scene_id}' (video clock ends {video_end:.2f}s, audio clock "
+                    f"{audio_end:.2f}s) — narration and visuals are built on different "
+                    "clocks and drift apart scene by scene. Detected from the workdir's own "
+                    "concat manifests, before any video decoding.",
+                    scene_id=scene_id,
+                    metrics={
+                        "maxSkewSec": round(skew, 3),
+                        "videoClockSec": round(video_end, 3),
+                        "audioClockSec": round(audio_end, 3),
+                    },
+                    rubric_dimension="audio",
+                )
+            )
+
+    # Provider clips shorter than their planned scene: ffmpeg -t can only trim,
+    # never lengthen, so the visual timeline silently shrinks.
+    plan_durations = {s.id: s for s in gt.scenes}
+    for span in timelines.video:
+        planned = plan_durations.get(span.scene_id)
+        if planned is None:
+            continue
+        short_by = planned.duration_sec - span.duration_sec
+        if short_by > CLIP_SHORT_TOLERANCE_SEC:
+            r.add(
+                Finding(
+                    "timeline",
+                    "CLIP_SHORTER_THAN_SCENE",
+                    "warning",
+                    f"Scene '{span.scene_id}': the rendered clip is {span.duration_sec:.2f}s "
+                    f"but the plan calls for {planned.duration_sec:.2f}s — the provider clip "
+                    f"came up {short_by:.2f}s short and -t cannot lengthen it",
+                    scene_id=span.scene_id,
+                    key=ids.time_key(span.start_sec),
+                    metrics={"shortBySec": round(short_by, 3)},
+                    rubric_dimension="motion-timing",
+                )
+            )
+
+    # Artifact clock vs the v1 single-timeline: disagreement means the old
+    # ground truth was measuring against the wrong reference.
+    gt_by_id = {s.id: s for s in gt.scenes}
+    worst_disagreement: tuple[str, float] | None = None
+    for span in timelines.video:
+        planned = gt_by_id.get(span.scene_id)
+        if planned is None:
+            continue
+        delta = abs(span.start_sec - planned.start_sec)
+        if worst_disagreement is None or delta > worst_disagreement[1]:
+            worst_disagreement = (span.scene_id, delta)
+    if worst_disagreement is not None and worst_disagreement[1] > SOURCE_DISAGREE_WARN_SEC:
+        scene_id, delta = worst_disagreement
+        r.add(
+            Finding(
+                "timeline",
+                "TIMELINE_SOURCE_DISAGREEMENT",
+                "warning",
+                f"The workdir's own render artifacts place scene '{scene_id}' "
+                f"{delta:.2f}s away from the single-timeline ground truth the sync "
+                "detectors measure against — their per-scene offsets are measured "
+                "against a reference the render did not actually use",
+                scene_id=scene_id,
+                metrics={"maxDisagreementSec": round(delta, 3)},
+            )
+        )
+
+    # Sanity: does the container agree with the artifact video clock?
+    if timelines.video:
+        artifact_end = timelines.video[-1].end_sec
+        r.set_metric("timeline.containerVsVideoClockSec", ctx.video.duration_sec - artifact_end)

--- a/src/video_studio/qc/detectors/transcript.py
+++ b/src/video_studio/qc/detectors/transcript.py
@@ -1,0 +1,140 @@
+"""Spoken-word verification via faster-whisper. [audio]
+
+v1 port. word_error_rate now routes through rapidfuzz (same value, C++ speed).
+The two-alignment design is preserved: whisper-vs-captions isolates "caption
+DATA wrong" from "caption RENDERER late" (which is caption_sync's finding).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from video_studio.qc.analysis.textmatch import edit_distance_le1, normalize_word, word_error_rate
+from video_studio.qc.context import Context
+from video_studio.qc.report.model import Finding, Severity
+
+WHISPER_MODEL = "base"
+MATCH_WINDOW_MS = 1500.0
+CAPTION_DATA_OFFSET_WARN_MS = 250.0
+WER_WARN = 0.25
+WER_ERROR = 0.5
+
+
+def transcribe_words(pcm: np.ndarray) -> list[tuple[str, float, float]]:
+    """[(normalized_word, start_ms, end_ms)] from 16 kHz mono PCM — the
+    shared AudioTrack decode, not a second ffmpeg pass of the file."""
+    from faster_whisper import WhisperModel
+
+    model = WhisperModel(WHISPER_MODEL, device="cpu", compute_type="int8")
+    segments, _info = model.transcribe(
+        pcm.astype(np.float32), word_timestamps=True, language="en"
+    )
+    words: list[tuple[str, float, float]] = []
+    for seg in segments:
+        for w in seg.words or []:
+            norm = normalize_word(w.word)
+            if norm:
+                words.append((norm, w.start * 1000.0, w.end * 1000.0))
+    return words
+
+
+def run(ctx: Context) -> None:
+    gt = ctx.ground_truth
+    r = ctx.report
+    assert gt is not None
+
+    if ctx.video.audio is None:
+        return
+
+    spoken = transcribe_words(ctx.audio.pcm)
+    r.set_metric("transcript.spokenWordCount", len(spoken))
+    if not spoken:
+        if any(s.narration.strip() for s in gt.scenes):
+            r.add(
+                Finding(
+                    "transcript",
+                    "NO_SPEECH_DETECTED",
+                    "error",
+                    "The plan has narration but whisper detected no speech in the final mix",
+                    rubric_dimension="audio",
+                )
+            )
+        return
+
+    # (b) per-scene WER vs planned narration, assigning spoken words to scenes
+    # by the planned timeline.
+    total_ref_words = 0
+    weighted_wer = 0.0
+    for scene in gt.scenes:
+        ref = [normalize_word(w) for w in scene.narration.split()]
+        ref = [w for w in ref if w]
+        if not ref:
+            continue
+        hyp = [
+            w
+            for w, start_ms, _end in spoken
+            if scene.start_sec * 1000 - 500 <= start_ms < scene.end_sec * 1000 + 500
+        ]
+        wer = word_error_rate(ref, hyp)
+        total_ref_words += len(ref)
+        weighted_wer += wer * len(ref)
+        if wer >= WER_WARN:
+            severity: Severity = "error" if wer >= WER_ERROR else "warning"
+            r.add(
+                Finding(
+                    "transcript",
+                    "NARRATION_MISMATCH",
+                    severity,
+                    f"Scene '{scene.id}': spoken audio differs from planned narration "
+                    f"(WER {wer:.0%}) — TTS may have dropped/garbled text, or scene audio is "
+                    "positioned in the wrong scene's time window",
+                    scene_id=scene.id,
+                    span_sec=(scene.start_sec, scene.end_sec),
+                    metrics={"wer": round(wer, 3)},
+                    rubric_dimension="audio",
+                )
+            )
+    if total_ref_words:
+        r.set_metric("transcript.meanWer", weighted_wer / total_ref_words)
+
+    # (a) whisper timestamps vs caption timestamps (both describe when words
+    # are SPOKEN; caption render lag is caption_sync's job).
+    if gt.caption_words:
+        offsets: list[float] = []
+        used: set[int] = set()
+        for cw in gt.caption_words:
+            target = normalize_word(cw.text)
+            if len(target) < 3:
+                continue
+            best: tuple[float, int] | None = None
+            for idx, (w, start_ms, _end) in enumerate(spoken):
+                if idx in used or abs(start_ms - cw.start_ms) > MATCH_WINDOW_MS:
+                    continue
+                if edit_distance_le1(target, w):
+                    d = abs(start_ms - cw.start_ms)
+                    if best is None or d < best[0]:
+                        best = (d, idx)
+            if best is not None:
+                used.add(best[1])
+                offsets.append(spoken[best[1]][1] - cw.start_ms)
+        if offsets:
+            median = float(np.median(offsets))
+            r.set_metric("sync.whisperVsCaptionMedianMs", median)
+            r.set_metric(
+                "sync.whisperCaptionMatchRate",
+                len(offsets)
+                / max(1, sum(1 for c in gt.caption_words if len(normalize_word(c.text)) >= 3)),
+            )
+            if abs(median) > CAPTION_DATA_OFFSET_WARN_MS:
+                r.add(
+                    Finding(
+                        "transcript",
+                        "CAPTION_DATA_OFFSET",
+                        "warning",
+                        f"Caption word timings are a median of {abs(median):.0f}ms "
+                        f"{'behind' if median > 0 else 'ahead of'} the actually-spoken words — "
+                        "the captions FILE is mistimed (independent of any renderer lag)",
+                        metrics={"medianOffsetMs": round(median, 1)},
+                        rubric_dimension="captions",
+                    )
+                )

--- a/src/video_studio/qc/detectors/visual.py
+++ b/src/video_studio/qc/detectors/visual.py
@@ -1,0 +1,89 @@
+"""Frame visual quality findings over the shared decode's FrameStats.
+
+The per-frame measurement (blur, banding, palette ΔE) happens in the engine's
+visual service on the single shared decode; this detector applies v1's
+thresholds to the collected series.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from video_studio.qc.context import Context
+from video_studio.qc.report.model import Finding
+
+BLUR_THRESHOLDS = {  # Laplacian variance below this = soft/blurry frame
+    "faceless-explainer": 60.0,
+    "manim-explainer": 60.0,
+    "ai-video": 25.0,
+    "composite": 25.0,
+}
+DEFAULT_BLUR_THRESHOLD = 25.0
+BLUR_FRACTION_WARN = 0.4  # this share of frames soft → finding
+PALETTE_DELTA_E = 25.0  # Lab distance counting as "off palette"
+PALETTE_OFF_FRACTION_WARN = 0.35
+
+
+def run(ctx: Context) -> None:
+    r = ctx.report
+    gt = ctx.ground_truth
+    fmt = gt.format if gt else None
+    stats = ctx.artifacts.frame_stats
+    assert stats is not None, "engine must run the visual service before visual"
+
+    blur_threshold = BLUR_THRESHOLDS.get(fmt or "", DEFAULT_BLUR_THRESHOLD)
+
+    if not stats.blur_scores:
+        return
+
+    arr = np.array(stats.blur_scores)
+    r.set_metric("visual.blurLaplacianP10", float(np.percentile(arr, 10)))
+    r.set_metric("visual.blurLaplacianMedian", float(np.median(arr)))
+    soft_fraction = float((arr < blur_threshold).mean())
+    worst_blur = stats.worst_blur
+    if soft_fraction >= BLUR_FRACTION_WARN and worst_blur is not None:
+        r.add(
+            Finding(
+                "visual",
+                "SOFT_FOOTAGE",
+                "warning",
+                f"{soft_fraction:.0%} of sampled frames are soft/blurry (Laplacian variance < "
+                f"{blur_threshold:.0f}; worst {worst_blur[0]:.0f} at {worst_blur[1]:.1f}s)",
+                span_sec=(worst_blur[1], worst_blur[1]),
+                metrics={"softFraction": round(soft_fraction, 3)},
+                rubric_dimension="visual-quality",
+            )
+        )
+
+    band = float(np.median(stats.banding_scores))
+    r.set_metric("visual.bandingScoreMedian", band)
+    if band > 0.25:
+        r.add(
+            Finding(
+                "visual",
+                "BANDING",
+                "info",
+                f"Large smooth-gradient regions ({band:.0%} of frame area) — vulnerable to "
+                "visible banding after platform re-encode; consider subtle noise/dither in "
+                "backgrounds",
+                metrics={"bandingScore": round(band, 3)},
+                rubric_dimension="visual-quality",
+            )
+        )
+
+    if stats.off_palette_fractions:
+        off_med = float(np.median(stats.off_palette_fractions))
+        r.set_metric("visual.offPaletteFraction", off_med)
+        if off_med > PALETTE_OFF_FRACTION_WARN and gt is not None:
+            r.add(
+                Finding(
+                    "visual",
+                    "OFF_PALETTE",
+                    "warning",
+                    f"A median {off_med:.0%} of pixels sit far (ΔE > {PALETTE_DELTA_E:.0f}) "
+                    f"from every style-preset color — the render drifts from the '{gt.style}' "
+                    "palette",
+                    metrics={"offPaletteFraction": round(off_med, 3)},
+                    rubric_dimension="visual-quality",
+                )
+            )

--- a/src/video_studio/qc/embeddings/__init__.py
+++ b/src/video_studio/qc/embeddings/__init__.py
@@ -1,0 +1,75 @@
+"""Embedding backends.
+
+Default is fastembed with nomic-embed-text-v1.5 — ONNX, no torch, no daemon,
+and the same model family + dimension (768) as the Ollama vectors the TS tool
+used. The prefix trap, stated loudly: nomic is trained with task prefixes
+(`search_document:` / `search_query:`) that Ollama does NOT apply, so vectors
+from the two backends are not interchangeable despite identical dimension.
+The Embedder owns the prefixes; call sites never prepend.
+
+FakeEmbedder is deterministic and dependency-free — the test backend, and the
+offline fallback for structural work where ranking quality is irrelevant.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Protocol
+
+
+class Embedder(Protocol):
+    model_id: str
+    dim: int
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]: ...
+    def embed_query(self, text: str) -> list[float]: ...
+
+
+class FakeEmbedder:
+    """Deterministic hashed unit vectors. Useful ranking? No. Stable? Yes."""
+
+    model_id = "fake:blake2s-16d"
+    dim = 16
+
+    def _one(self, text: str) -> list[float]:
+        digest = hashlib.blake2s(text.encode("utf-8"), digest_size=self.dim * 2).digest()
+        vals = [int.from_bytes(digest[i * 2 : i * 2 + 2], "big") - 32768 for i in range(self.dim)]
+        norm = math.sqrt(sum(v * v for v in vals)) or 1.0
+        return [v / norm for v in vals]
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self._one(t) for t in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._one(text)
+
+
+class FastembedEmbedder:
+    """nomic-embed-text-v1.5 via fastembed (ONNX). ~130 MB one-time download."""
+
+    model_id = "fastembed:nomic-ai/nomic-embed-text-v1.5"
+    dim = 768
+    _DOC_PREFIX = "search_document: "
+    _QUERY_PREFIX = "search_query: "
+
+    def __init__(self) -> None:
+        from fastembed import TextEmbedding
+
+        self._model = TextEmbedding("nomic-ai/nomic-embed-text-v1.5")
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        prefixed = [self._DOC_PREFIX + t for t in texts]
+        return [list(map(float, v)) for v in self._model.embed(prefixed)]
+
+    def embed_query(self, text: str) -> list[float]:
+        (vec,) = list(self._model.embed([self._QUERY_PREFIX + text]))
+        return list(map(float, vec))
+
+
+def resolve_embedder(name: str = "fastembed") -> Embedder:
+    if name == "fake":
+        return FakeEmbedder()
+    if name == "fastembed":
+        return FastembedEmbedder()
+    raise ValueError(f"unknown embedder backend: {name}")

--- a/src/video_studio/qc/embeddings/clip.py
+++ b/src/video_studio/qc/embeddings/clip.py
@@ -1,0 +1,42 @@
+"""CLIP text/image pair via fastembed's ONNX models — zero new dependencies.
+
+`Qdrant/clip-ViT-B-32-text` (0.25 GB) and `Qdrant/clip-ViT-B-32-vision`
+(0.34 GB) share one 512-d space and both L2-normalize their output, so
+cosine similarity is a plain dot product. First use downloads the models to
+the fastembed cache.
+
+fastembed's ImageEmbedding accepts paths or PIL Images — NOT numpy arrays —
+so cv2 BGR frames go through `PIL.Image.fromarray(frame[:, :, ::-1])`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+TEXT_MODEL = "Qdrant/clip-ViT-B-32-text"
+VISION_MODEL = "Qdrant/clip-ViT-B-32-vision"
+DIM = 512
+
+
+class ClipPair:
+    """Lazy holder for the matched text+vision encoders."""
+
+    def __init__(self) -> None:
+        from fastembed import ImageEmbedding, TextEmbedding
+
+        self._text = TextEmbedding(TEXT_MODEL)
+        self._vision = ImageEmbedding(VISION_MODEL)
+
+    def embed_texts(self, texts: list[str]) -> np.ndarray:
+        """(n, 512) L2-normalized. CLIP truncates at 77 tokens — long scene
+        prompts lose their tail, which is fine for gist matching."""
+        return np.array([list(map(float, v)) for v in self._text.embed(texts)])
+
+    def embed_bgr_frames(self, frames: list[Any]) -> np.ndarray:
+        """(n, 512) L2-normalized from cv2 BGR ndarrays."""
+        from PIL import Image
+
+        images = [Image.fromarray(f[:, :, ::-1]) for f in frames]
+        return np.array([list(map(float, v)) for v in self._vision.embed(images)])

--- a/src/video_studio/qc/engine.py
+++ b/src/video_studio/qc/engine.py
@@ -1,0 +1,292 @@
+"""The analysis engine: media phase (decode once) then detector phase (pure).
+
+v1's architecture had every detector open the video itself — ~10 full decodes
+per analysis, and the swallowed-ImportError registry. Here:
+
+  Phase A (media): one chained ffmpeg filter pass, one shared frame-pipeline
+  decode for the always-on frame services (see showwatcher.services), one
+  PySceneDetect pass with BOTH detectors in a single SceneManager (v1 ran two
+  full detect() passes), and one lazily-decoded AudioTrack.
+
+  Phase B (detectors): pure functions over the typed Context (see
+  showwatcher.context) — the ported v1 behavior, emitting findings/metrics
+  onto the report.
+
+Failure semantics mirror v1's CLI exactly (they are part of the parity
+contract): a missing optional dep becomes a skip entry with the extra hint, a
+crash becomes a skip entry with a truncated traceback, and findings never
+affect the exit code.
+"""
+
+from __future__ import annotations
+
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# Re-exported for compatibility: these lived here before the context/services
+# split, and tests + external callers import them from the engine.
+from video_studio.qc.context import Artifacts, Context, FrameStats, PaneStats
+from video_studio.qc.media.audio import AudioTrack
+from video_studio.qc.media.ffmpeg_filters import run_filter_pass
+from video_studio.qc.media.probe import probe
+from video_studio.qc.report.model import Report, SceneTiming, Skip
+from video_studio.qc.services import run_frame_services
+from video_studio.qc.ground_truth import load_ground_truth
+
+__all__ = [
+    "KNOWN_DETECTORS",
+    "AnalyzeOptions",
+    "Artifacts",
+    "Context",
+    "FrameStats",
+    "PaneStats",
+    "analyze",
+    "detect_cuts",
+    "run_frame_services",
+]
+
+
+# ---------------------------------------------------------------------------
+# Media phase services
+# ---------------------------------------------------------------------------
+
+
+def detect_cuts(video_path: str) -> list[float]:
+    """PySceneDetect ContentDetector + AdaptiveDetector in ONE SceneManager pass.
+
+    v1 ran detect() twice (two full decodes) and unioned the results. A single
+    SceneManager with both detectors cuts wherever EITHER fires — the same
+    union — in one decode. The parity gate over the corpus is the check that
+    this equivalence holds on real footage.
+    """
+    from scenedetect import AdaptiveDetector, ContentDetector, SceneManager, open_video
+
+    video = open_video(video_path)
+    manager = SceneManager()
+    manager.add_detector(ContentDetector())
+    manager.add_detector(AdaptiveDetector())
+    manager.detect_scenes(video)
+    scene_list = manager.get_scene_list()
+
+    cuts: set[float] = set()
+    for start, _end in scene_list:
+        t = start.seconds
+        if t > 0.01:  # the first scene's start is not a cut
+            cuts.add(round(t, 3))
+    merged: list[float] = []
+    for t in sorted(cuts):
+        if merged and t - merged[-1] < 0.1:
+            continue
+        merged.append(t)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Detector registry — explicit, no swallowed ImportError
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DetectorSpec:
+    name: str
+    needs_ground_truth: bool
+    extra: str | None  # pyproject extra providing its heavy deps
+
+
+KNOWN_DETECTORS: list[DetectorSpec] = [
+    DetectorSpec("container", False, None),
+    DetectorSpec("black_freeze", False, None),
+    DetectorSpec("scene_sync", True, None),
+    DetectorSpec("audio_sync", True, None),
+    DetectorSpec("caption_sync", True, "ocr"),
+    DetectorSpec("layout", False, "ocr"),
+    DetectorSpec("transcript", True, "audio"),
+    DetectorSpec("audio_quality", False, None),
+    DetectorSpec("visual", False, None),
+    DetectorSpec("motion", False, None),
+    DetectorSpec("objects", True, "yolo"),
+    # New in showwatcher — not part of the v1 parity set.
+    DetectorSpec("timeline", True, None),
+    DetectorSpec("av_sync", False, None),
+    DetectorSpec("composition", False, None),
+    DetectorSpec("lip_sync", False, None),
+    DetectorSpec("entity_tracking", True, "yolo"),
+    DetectorSpec("prompt_fit", False, None),
+    DetectorSpec("prompt_visual", True, "store"),  # CLIP via fastembed
+]
+
+
+def _detector_run(name: str) -> Any:
+    """Import a detector module loudly — an ImportError here is a real bug,
+    unless it names a module an extra provides (handled by the caller)."""
+    import importlib
+
+    module = importlib.import_module(f"video_studio.qc.detectors.{name}")
+    return module.run
+
+
+@dataclass
+class AnalyzeOptions:
+    workdir: str | None = None
+    detectors: set[str] | None = None  # None = all
+    evidence_dir: str | None = None
+    taxonomy: str | None = None  # SocialBench subcategory, e.g. "4.1"
+    verbose: bool = False
+
+
+def analyze(video_path: str | Path, opts: AnalyzeOptions | None = None) -> Report:
+    opts = opts or AnalyzeOptions()
+    video_path = str(video_path)
+
+    video = probe(video_path)
+    ground_truth = load_ground_truth(opts.workdir) if opts.workdir else None
+
+    report = Report(
+        video=video.to_json(),
+        workdir=ground_truth.to_json() if ground_truth else None,
+    )
+    if ground_truth:
+        report.scenes = [
+            SceneTiming(
+                id=s.id,
+                index=s.index,
+                planned_start_sec=s.start_sec,
+                planned_end_sec=s.end_sec,
+                narration=s.narration,
+            )
+            for s in ground_truth.scenes
+        ]
+
+    if opts.evidence_dir:
+        Path(opts.evidence_dir).mkdir(parents=True, exist_ok=True)
+
+    ctx = Context(
+        video_path=video_path,
+        video=video,
+        report=report,
+        audio=AudioTrack(video_path),
+        artifacts=Artifacts(),
+        ground_truth=ground_truth,
+        evidence_dir=opts.evidence_dir,
+        taxonomy=opts.taxonomy,
+    )
+
+    only = opts.detectors
+    known_names = {spec.name for spec in KNOWN_DETECTORS}
+    if only:
+        for name in sorted(only - known_names):
+            report.skipped.append(Skip(name=name, code="unknown"))
+
+    will_run = [
+        spec
+        for spec in KNOWN_DETECTORS
+        if (only is None or spec.name in only)
+        and not (spec.needs_ground_truth and ground_truth is None)
+    ]
+    run_names = {spec.name for spec in will_run}
+
+    # Model-backed extras: availability decided HERE (find_spec) so detectors
+    # never import model packages. An absent extra becomes a missing_extra
+    # skip before any media work happens.
+    import importlib.util
+
+    def _drop_missing_extra(names: tuple[str, ...], module: str, extra: str) -> bool:
+        present = importlib.util.find_spec(module) is not None
+        if not present:
+            for name in names:
+                if name in run_names:
+                    run_names.discard(name)
+                    report.skipped.append(
+                        Skip(name=name, code="missing_extra", extra=extra, detail=module)
+                    )
+        return present
+
+    have_ocr = _drop_missing_extra(("caption_sync", "layout"), "easyocr", "ocr")
+    have_yolo = _drop_missing_extra(("objects", "entity_tracking"), "ultralytics", "yolo")
+
+    # OCR/YOLO frame streams are wasted work when the detector would return
+    # early anyway — mirror those cheap early-out conditions here.
+    want_caption_ocr = (
+        have_ocr
+        and "caption_sync" in run_names
+        and ground_truth is not None
+        and bool(ground_truth.caption_words)
+    )
+    want_layout_ocr = have_ocr and "layout" in run_names
+    want_objects_svc = False
+    if have_yolo and "objects" in run_names and ground_truth is not None:
+        from video_studio.qc.detectors.objects import FOOTAGE_FORMATS, expected_classes
+
+        want_objects_svc = ground_truth.format in FOOTAGE_FORMATS and any(
+            expected_classes(s.visual) for s in ground_truth.scenes
+        )
+
+    # --- Phase A: media, computed once, only what the selected detectors need
+    if {"black_freeze", "audio_quality"} & run_names:
+        ctx.artifacts.filter_pass = run_filter_pass(video_path, has_audio=video.audio is not None)
+    if "scene_sync" in run_names:
+        # scenedetect is the one heavyweight import the media phase needs, and
+        # it was reached unconditionally: without it installed, a missing cut
+        # detector took down the WHOLE run, including the detectors that need
+        # no models at all. Gate it like any other extra — one detector skips,
+        # the rest still report.
+        try:
+            ctx.artifacts.cuts = detect_cuts(video_path)
+        except ImportError as e:
+            run_names.discard("scene_sync")
+            report.skipped.append(
+                Skip(name="scene_sync", code="missing_extra", extra="qc", detail=e.name)
+            )
+    run_frame_services(
+        ctx,
+        want_visual="visual" in run_names,
+        want_motion="motion" in run_names,
+        want_energy="av_sync" in run_names,
+        want_panes="composition" in run_names,
+        want_mouth="lip_sync" in run_names,
+        want_scene_frames="prompt_visual" in run_names,
+        want_caption_ocr=want_caption_ocr,
+        want_layout_ocr=want_layout_ocr,
+        want_objects=want_objects_svc,
+    )
+
+    # --- Phase B: detectors, in v1 order (audio_sync depends on scene_sync's
+    # scene-spine writes; the list order IS the dependency order).
+    for spec in KNOWN_DETECTORS:
+        if spec.name not in run_names:
+            if (
+                spec.needs_ground_truth
+                and ground_truth is None
+                and (only is None or spec.name in only)
+            ):
+                report.skipped.append(Skip(name=spec.name, code="requires_workdir"))
+            continue
+        try:
+            run = _detector_run(spec.name)
+            run(ctx)
+            report.detectors_run.append(spec.name)
+        except ImportError as e:
+            # Only an ImportError naming a module OUTSIDE this package is a
+            # missing extra. Treating every ImportError that way is how the
+            # port to video_studio silently reported a clean bill of health on
+            # every video: the detector loader still named the old package, so
+            # each detector raised ImportError('showwatcher') and was filed as
+            # "you did not install the model" rather than "this is broken".
+            missing = (e.name or "").split(".")[0]
+            if missing == "video_studio":
+                report.skipped.append(
+                    Skip(name=spec.name, code="crashed",
+                         detail=f"detector failed to import: {e}")
+                )
+            else:
+                report.skipped.append(
+                    Skip(name=spec.name, code="missing_extra", extra=spec.extra, detail=e.name)
+                )
+        except Exception:
+            report.skipped.append(
+                Skip(name=spec.name, code="crashed", detail=traceback.format_exc(limit=3))
+            )
+
+    return report

--- a/src/video_studio/qc/ground_truth.py
+++ b/src/video_studio/qc/ground_truth.py
@@ -1,0 +1,264 @@
+"""What the video was SUPPOSED to be, read from this repo's own documents.
+
+The detectors and the decode layer ported across from showwatcher without
+modification. This module is the seam that did not: showwatcher read a
+showrunner work_dir — `plan.json` beside `checkpoint_compose.json`,
+`checkpoint_render.json` and a manifest of run options — and none of that
+exists here.
+
+What does exist is better suited to the job. `build_props` already writes
+`plan.json` with the comment "Ground truth for the quality check, which wants a
+plan.json describing what SHOULD be on screen when", using the MEASURED scene
+durations the render actually used rather than the storyboard's estimates. And
+`tts_kokoro`/`gen_captions` write `<scene>.timings.json` in a shape that is
+already word-level: `{"text", "startMs", "endMs"}`, scene-relative — which is
+exactly a CaptionWord once the scene's start offset is added.
+
+So the ground truth here is:
+
+    <project>/plan.json                    durations, narration, visual intent
+    <project>/storyboard.json              size, fps, style  (optional)
+    <project>/audio/<scene>.timings.json   caption words     (optional)
+    <project>/audio/<scene>.wav            per-scene narration
+
+`duration_source` is always "plan" rather than "checkpoint": there is no
+separate per-stage checkpoint to disagree with, because build_props measured
+the audio and wrote the result straight into the plan.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+class GroundTruthError(RuntimeError):
+    pass
+
+
+@dataclass
+class CaptionWord:
+    text: str
+    start_ms: float
+    end_ms: float
+    scene_id: str
+
+
+@dataclass
+class PlannedScene:
+    id: str
+    index: int
+    start_sec: float
+    end_sec: float
+    narration: str
+    visual: str
+    transition: str
+    duration_source: str  # "plan" here; showwatcher also had "checkpoint"
+
+    @property
+    def duration_sec(self) -> float:
+        return self.end_sec - self.start_sec
+
+
+@dataclass
+class GroundTruth:
+    workdir: Path
+    format: str
+    aspect_ratio: str
+    style: str | None
+    topic: str | None
+    options: dict[str, Any]
+    plan_title: str
+    planned_total_duration_sec: float
+    scenes: list[PlannedScene]
+    caption_words: list[CaptionWord] = field(default_factory=list)
+    render_width: int | None = None
+    render_height: int | None = None
+    render_output_path: str | None = None
+
+    @property
+    def timeline_duration_sec(self) -> float:
+        return self.scenes[-1].end_sec if self.scenes else 0.0
+
+    def scene_wav(self, scene_id: str) -> Path | None:
+        """Narration for one scene. `audio/` is where tts_kokoro writes."""
+        for rel in (f"audio/{scene_id}.wav", f"public/audio/{scene_id}.wav"):
+            p = self.workdir / rel
+            if p.is_file():
+                return p
+        return None
+
+    def scene_at(self, t_sec: float) -> PlannedScene | None:
+        for s in self.scenes:
+            if s.start_sec <= t_sec < s.end_sec:
+                return s
+        return self.scenes[-1] if self.scenes and t_sec >= self.scenes[-1].end_sec else None
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "path": str(self.workdir),
+            "format": self.format,
+            "aspectRatio": self.aspect_ratio,
+            "style": self.style,
+            "topic": self.topic,
+            "planTitle": self.plan_title,
+            "plannedDurationSec": round(self.planned_total_duration_sec, 3),
+            "realAudioDurationSec": None,
+            "options": {k: self.options.get(k) for k in ("captions", "music", "voice")
+                        if k in self.options},
+        }
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError as e:
+        raise GroundTruthError(f"invalid JSON in {path}: {e}") from e
+
+
+def _aspect(width: int, height: int) -> str:
+    """'9:16' style label, reduced. Falls back to WxH for odd sizes."""
+    from math import gcd
+    if not width or not height:
+        return "unknown"
+    g = gcd(width, height)
+    return f"{width // g}:{height // g}"
+
+
+def load_ground_truth(project: str | Path) -> GroundTruth:
+    """Build a GroundTruth from a video_studio project directory."""
+    root = Path(project)
+    if not root.is_dir():
+        raise GroundTruthError(f"not a project directory: {root}")
+
+    plan = _load_json(root / "plan.json")
+    if plan is None:
+        raise GroundTruthError(
+            f"no plan.json in {root} — build_props writes it beside the project. "
+            f"Without it there is nothing to check the render against."
+        )
+
+    storyboard = _load_json(root / "storyboard.json") or {}
+    width = int(storyboard.get("width", 0)) or None
+    height = int(storyboard.get("height", 0)) or None
+
+    # Scene boundaries accumulate, matching how build_props snapped them: the
+    # running total is the authority, not each duration on its own.
+    scenes: list[PlannedScene] = []
+    cursor = 0.0
+    for i, raw in enumerate(plan.get("scenes") or []):
+        duration = float(raw.get("duration", 0.0))
+        start, end = cursor, round(cursor + duration, 6)
+        cursor = end
+        scenes.append(PlannedScene(
+            id=str(raw.get("id", f"scene{i}")),
+            index=i,
+            start_sec=start,
+            end_sec=end,
+            narration=str(raw.get("narration", "") or ""),
+            visual=str(raw.get("visual", "") or ""),
+            transition=str(raw.get("transition", "") or ""),
+            duration_source="plan",
+        ))
+
+    # Caption words are per-scene and scene-relative on disk; the detectors
+    # want composition-absolute, so each scene's start is folded in here.
+    caption_words: list[CaptionWord] = []
+    for scene in scenes:
+        timings = _load_json(root / "audio" / f"{scene.id}.timings.json")
+        if not isinstance(timings, list):
+            continue
+        offset_ms = scene.start_sec * 1000.0
+        for word in timings:
+            text = str(word.get("text", "")).strip()
+            if not text:
+                continue
+            caption_words.append(CaptionWord(
+                text=text,
+                start_ms=float(word.get("startMs", 0)) + offset_ms,
+                end_ms=float(word.get("endMs", 0)) + offset_ms,
+                scene_id=scene.id,
+            ))
+
+    options: dict[str, Any] = {}
+    if storyboard.get("music"):
+        options["music"] = storyboard["music"]
+    if caption_words:
+        options["captions"] = True
+
+    return GroundTruth(
+        workdir=root,
+        # video_studio has no pluggable "format" the way showrunner did; the
+        # storyboard's own name is the closest true answer, and detectors that
+        # branch on format treat an unknown one as "no format-specific rule".
+        format=str(storyboard.get("format", "video-studio")),
+        aspect_ratio=_aspect(width or 0, height or 0),
+        style=storyboard.get("styleApplied") or storyboard.get("style"),
+        topic=plan.get("title") or storyboard.get("title"),
+        options=options,
+        plan_title=str(plan.get("title", "")),
+        planned_total_duration_sec=float(
+            plan.get("totalDuration", scenes[-1].end_sec if scenes else 0.0)),
+        scenes=scenes,
+        caption_words=caption_words,
+        render_width=width,
+        render_height=height,
+    )
+
+
+#: Six-digit hex colours, the only form styles.py writes.
+_HEX_RE = re.compile(r"#([0-9a-fA-F]{6})\b")
+
+
+def load_palette(project: str | Path) -> Any | None:
+    """The video's intended colours as an Nx3 Lab array, or None.
+
+    showwatcher read these out of a generated Remotion token file. The
+    equivalent here is the storyboard itself: `styles.py --apply` EXPANDS a
+    preset into the storyboard rather than leaving a name to resolve at render
+    time — deliberately, so the document says what the video actually looks
+    like. That makes the storyboard the most truthful source of the palette,
+    and it needs no preset lookup.
+
+    If the storyboard yields nothing (no style applied), the named preset is
+    tried as a fallback so an un-expanded project still gets a palette.
+    """
+    root = Path(project)
+    text = ""
+    storyboard_path = root / "storyboard.json"
+    if storyboard_path.is_file():
+        text = storyboard_path.read_text()
+
+    hexes = set(_HEX_RE.findall(text))
+
+    if not hexes and text:
+        # Nothing expanded into the storyboard — fall back to the preset it names.
+        try:
+            name = (json.loads(text) or {}).get("styleApplied")
+        except json.JSONDecodeError:
+            name = None
+        if name:
+            for base in (Path.home() / ".config" / "video-studio" / "styles",
+                         Path(__file__).resolve().parent.parent / "styles"):
+                candidate = base / f"{name}.md"
+                if candidate.is_file():
+                    hexes = set(_HEX_RE.findall(candidate.read_text()))
+                    break
+
+    if not hexes:
+        return None
+
+    import cv2
+    import numpy as np
+
+    rgb = np.array(
+        [[int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)] for h in sorted(hexes)],
+        dtype=np.uint8,
+    )
+    lab = cv2.cvtColor(rgb.reshape(-1, 1, 3), cv2.COLOR_RGB2Lab).reshape(-1, 3)
+    return lab.astype(np.float64)

--- a/src/video_studio/qc/media/audio.py
+++ b/src/video_studio/qc/media/audio.py
@@ -1,0 +1,56 @@
+"""AudioTrack: one PCM decode per file, with cached envelopes.
+
+v1 decoded the mix PCM independently in audio_sync AND audio_quality, and
+decoded every scene WAV once per consumer. This class is the single audio
+entry point: the mix decodes once, envelopes memoize, and per-path WAV
+envelopes cache in a dict.
+"""
+
+from __future__ import annotations
+
+from functools import cached_property
+from pathlib import Path
+
+import numpy as np
+
+from video_studio.qc.analysis.align import ENVELOPE_RATE_HZ, decode_pcm, rms_envelope
+
+SAMPLE_RATE = 16_000
+
+
+class AudioTrack:
+    """Lazy, cached audio access for one media file (usually the final mix)."""
+
+    def __init__(self, path: str | Path, sample_rate: int = SAMPLE_RATE) -> None:
+        self.path = str(path)
+        self.sample_rate = sample_rate
+        self._wav_envelopes: dict[str, np.ndarray] = {}
+
+    @cached_property
+    def pcm(self) -> np.ndarray:
+        return decode_pcm(self.path, self.sample_rate)
+
+    @cached_property
+    def envelope(self) -> np.ndarray:
+        """RMS envelope at ENVELOPE_RATE_HZ (10 ms hop)."""
+        return rms_envelope(self.pcm, self.sample_rate)
+
+    @cached_property
+    def envelope_db(self) -> np.ndarray:
+        return np.asarray(20 * np.log10(np.maximum(self.envelope, 1e-6)))
+
+    def wav_envelope(self, wav_path: str | Path) -> np.ndarray:
+        """Envelope of a sidecar WAV (per-scene narration), cached per path."""
+        key = str(wav_path)
+        if key not in self._wav_envelopes:
+            self._wav_envelopes[key] = rms_envelope(
+                decode_pcm(key, self.sample_rate), self.sample_rate
+            )
+        return self._wav_envelopes[key]
+
+    def wav_pcm_head(self, wav_path: str | Path, seconds: float) -> np.ndarray:
+        """First N seconds of a sidecar WAV's PCM (for needle extraction)."""
+        return decode_pcm(str(wav_path), self.sample_rate)[: int(seconds * self.sample_rate)]
+
+
+__all__ = ["ENVELOPE_RATE_HZ", "SAMPLE_RATE", "AudioTrack"]

--- a/src/video_studio/qc/media/ffmpeg_filters.py
+++ b/src/video_studio/qc/media/ffmpeg_filters.py
@@ -1,0 +1,94 @@
+"""One chained ffmpeg pass: blackdetect + freezedetect + ebur128.
+
+v1 ran these as THREE separate full-decode invocations (black_freeze.py ran
+two, audio_quality.py a third). All three filters are pass-through analyzers
+that log to stderr, so they chain into a single command — one decode instead
+of three. The parsing regexes are v1's verbatim; the parity gate holds the
+outputs to the same values.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+
+BLACK_MIN_SEC = 0.15  # ignore sub-frame flickers / intentional dips shorter than this
+FREEZE_MIN_SEC = 1.5  # motion-graphics scenes legitimately hold stills briefly
+
+_BLACK_RE = re.compile(r"black_start:(?P<start>[\d.]+).*?black_end:(?P<end>[\d.]+)")
+_FREEZE_START_RE = re.compile(r"lavfi\.freezedetect\.freeze_start: (?P<t>[\d.]+)")
+_FREEZE_END_RE = re.compile(r"lavfi\.freezedetect\.freeze_end: (?P<t>[\d.]+)")
+_SUMMARY_RE = re.compile(
+    r"Integrated loudness:.*?I:\s*(?P<i>-?[\d.]+)\s*LUFS.*?"
+    r"Loudness range:.*?LRA:\s*(?P<lra>[\d.]+)\s*LU",
+    re.S,
+)
+_PEAK_RE = re.compile(r"Peak:\s*(?P<peak>-?[\d.]+|-inf)\s*dBFS")
+
+
+@dataclass
+class FilterPassResult:
+    black_spans: list[tuple[float, float]] = field(default_factory=list)
+    freeze_spans: list[tuple[float, float]] = field(default_factory=list)  # end=-1.0: open
+    integrated_lufs: float | None = None
+    loudness_range_lu: float | None = None
+    true_peak_dbfs: float | None = None
+
+    @property
+    def loudness(self) -> tuple[float, float, float | None] | None:
+        """(integrated LUFS, LRA, true peak dBFS) or None — v1's tuple shape."""
+        if self.integrated_lufs is None or self.loudness_range_lu is None:
+            return None
+        return self.integrated_lufs, self.loudness_range_lu, self.true_peak_dbfs
+
+
+def run_filter_pass(
+    video_path: str,
+    *,
+    has_audio: bool,
+    black_min_sec: float = BLACK_MIN_SEC,
+    freeze_min_sec: float = FREEZE_MIN_SEC,
+) -> FilterPassResult:
+    """Decode once, run all three analyzers, parse one stderr."""
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-i",
+        video_path,
+        "-vf",
+        f"blackdetect=d={black_min_sec}:pix_th=0.10,freezedetect=n=-60dB:d={freeze_min_sec}",
+    ]
+    if has_audio:
+        cmd += ["-af", "ebur128=peak=true"]
+    else:
+        cmd += ["-an"]
+    cmd += ["-f", "null", "-"]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return parse_filter_stderr(result.stderr)
+
+
+def parse_filter_stderr(stderr: str) -> FilterPassResult:
+    out = FilterPassResult()
+
+    out.black_spans = [
+        (float(m.group("start")), float(m.group("end"))) for m in _BLACK_RE.finditer(stderr)
+    ]
+
+    starts = [float(m.group("t")) for m in _FREEZE_START_RE.finditer(stderr)]
+    ends = [float(m.group("t")) for m in _FREEZE_END_RE.finditer(stderr)]
+    spans = list(zip(starts, ends, strict=False))
+    if len(starts) > len(ends):
+        # A freeze still running at EOF has a start but no end line.
+        spans.append((starts[len(ends)], -1.0))
+    out.freeze_spans = spans
+
+    m = _SUMMARY_RE.search(stderr)
+    if m:
+        out.integrated_lufs = float(m.group("i"))
+        out.loudness_range_lu = float(m.group("lra"))
+        peak_m = _PEAK_RE.search(stderr)
+        if peak_m and peak_m.group("peak") != "-inf":
+            out.true_peak_dbfs = float(peak_m.group("peak"))
+    return out

--- a/src/video_studio/qc/media/frames.py
+++ b/src/video_studio/qc/media/frames.py
@@ -1,0 +1,207 @@
+"""Dense keyframe extraction: dHash scene selection ported from frame-extract.ts.
+
+The selection logic (`select_kept_frames`, `cap_frames`) is pure and streaming —
+one implementation serves both the unit tests (synthetic Candidate lists) and
+the real extractor (a generator that decodes frames as selection consumes them).
+
+Honest divergence from the TS pipeline: sharp resized in RGB with Lanczos3;
+OpenCV here uses INTER_AREA. Individual hash bits will differ slightly, so the
+parity test asserts kept-frame counts/timestamps agree loosely, never that
+hashes are bit-identical. Nothing persisted ever depended on the old hashes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+HASH_SIZE = 8  # dHash: 8x8 grid of bit comparisons = 64-bit hash
+TOTAL_BITS = HASH_SIZE * HASH_SIZE
+
+
+@dataclass(frozen=True)
+class Candidate:
+    index: int
+    timestamp_sec: float
+    hash: bytes  # exactly HASH_SIZE bytes
+
+
+@dataclass(frozen=True)
+class FrameExtractOptions:
+    base_fps: float = 2.0
+    max_width: int = 1280
+    scene_threshold: float = 0.12  # normalized Hamming distance for a scene change
+    floor_interval_sec: float = 10.0  # force-keep at least one frame this often
+    dedup_window_size: int = 5  # compare against last N *kept* frames
+    max_frames: int = 150  # hard cap, evenly downsampled if exceeded
+
+
+DEFAULTS = FrameExtractOptions()
+
+
+def compute_dhash(bgr: Any) -> bytes:
+    """dHash: each pixel vs its right neighbor on a 9x8 greyscale grid.
+
+    More robust to brightness/exposure flicker than a naive pixel diff — the
+    same reasoning as the TS original. MSB-first bit packing matches the TS
+    `byte = (byte << 1) | bit` loop.
+    """
+    import cv2
+    import numpy as np
+
+    small = cv2.resize(bgr, (HASH_SIZE + 1, HASH_SIZE), interpolation=cv2.INTER_AREA)
+    if small.ndim == 3:
+        small = cv2.cvtColor(small, cv2.COLOR_BGR2GRAY)
+    bits = small[:, 1:] > small[:, :-1]  # left < right -> 1
+    return np.packbits(bits, axis=1).tobytes()
+
+
+def hamming_distance(a: bytes, b: bytes) -> int:
+    return (int.from_bytes(a, "big") ^ int.from_bytes(b, "big")).bit_count()
+
+
+def normalized_distance(a: bytes, b: bytes) -> float:
+    return hamming_distance(a, b) / TOTAL_BITS
+
+
+def select_kept_frames(
+    candidates: Iterable[Candidate],
+    opts: FrameExtractOptions = DEFAULTS,
+) -> Iterator[Candidate]:
+    """Scene-change detection + fps-floor guarantee + N-frame dedup window.
+
+    A streaming generator: each candidate is decided on arrival with no
+    lookahead, so the real extractor can decode lazily and drop frames the
+    moment they are rejected. Semantics are the TS original's exactly:
+
+    - keep when the hash moved >= scene_threshold from the PREVIOUS candidate
+      (not the previous kept frame), or when the floor interval has elapsed;
+    - then reject if within scene_threshold of any of the last N KEPT hashes
+      (A/B flicker dedup) — unless the floor is due, which always wins.
+    """
+    kept_hash_window: list[bytes] = []
+    prev_hash: bytes | None = None
+    last_kept_timestamp = float("-inf")
+
+    for cand in candidates:
+        is_scene_change = (
+            prev_hash is None or normalized_distance(cand.hash, prev_hash) >= opts.scene_threshold
+        )
+        is_floor_due = cand.timestamp_sec - last_kept_timestamp >= opts.floor_interval_sec
+        prev_hash = cand.hash
+
+        if not is_scene_change and not is_floor_due:
+            continue
+
+        is_dup_of_recent_kept = any(
+            normalized_distance(cand.hash, kh) < opts.scene_threshold for kh in kept_hash_window
+        )
+        if is_dup_of_recent_kept and not is_floor_due:
+            continue
+
+        yield cand
+        last_kept_timestamp = cand.timestamp_sec
+        kept_hash_window.append(cand.hash)
+        if len(kept_hash_window) > opts.dedup_window_size:
+            kept_hash_window.pop(0)
+
+
+def cap_frames(kept: Sequence[Candidate], max_frames: int) -> Sequence[Candidate]:
+    """Evenly downsample across the whole timeline rather than truncating.
+
+    Returns the SAME sequence object when already under the cap — the TS test
+    asserts identity (`toBe`), and callers rely on the no-copy fast path.
+    `(i * len) // max` is integer math, identical to JS `Math.floor` here.
+    """
+    if len(kept) <= max_frames:
+        return kept
+    return [kept[(i * len(kept)) // max_frames] for i in range(max_frames)]
+
+
+def extract_frames(
+    video_path: Path,
+    out_dir: Path,
+    opts: FrameExtractOptions = DEFAULTS,
+) -> list[Candidate]:
+    """Decode a local video once, select keyframes, write JPEGs.
+
+    Replaces the TS pipeline's ffmpeg-to-2000-JPEGs spill + sharp rehash with an
+    in-process sequential decode: frames are hashed in memory and only KEPT
+    frames ever touch disk. Filename convention matches the TS original
+    (`frame-000001-00012.50s.jpg`) so downstream consumers keep working.
+    """
+    import cv2
+
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        raise RuntimeError(f"could not open video: {video_path}")
+
+    native_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    step = max(1, round(native_fps / opts.base_fps))
+
+    frames_dir = out_dir / "frames"
+    frames_dir.mkdir(parents=True, exist_ok=True)
+
+    # Retain the pixels only for the candidate currently being decided —
+    # selection is synchronous with decode, so one frame is live at a time.
+    pending: dict[int, Any] = {}
+
+    def candidates() -> Iterator[Candidate]:
+        frame_idx = 0
+        cand_idx = 0
+        while True:
+            grabbed = cap.grab()
+            if not grabbed:
+                return
+            if frame_idx % step == 0:
+                ok, frame = cap.retrieve()
+                if ok:
+                    if opts.max_width and frame.shape[1] > opts.max_width:
+                        scale = opts.max_width / frame.shape[1]
+                        frame = cv2.resize(
+                            frame,
+                            (opts.max_width, max(2, int(frame.shape[0] * scale)) & ~1),
+                            interpolation=cv2.INTER_AREA,
+                        )
+                    pending.clear()
+                    pending[cand_idx] = frame
+                    yield Candidate(
+                        index=cand_idx,
+                        timestamp_sec=frame_idx / native_fps,
+                        hash=compute_dhash(frame),
+                    )
+                    cand_idx += 1
+            frame_idx += 1
+
+    try:
+        kept_stream: list[tuple[Candidate, Any]] = []
+        scratch: list[tuple[Candidate, Path]] = []
+        scratch_dir = out_dir / ".scratch"
+        scratch_dir.mkdir(parents=True, exist_ok=True)
+        for cand in select_kept_frames(candidates(), opts):
+            frame = pending.get(cand.index)
+            if frame is None:  # pragma: no cover — selection is synchronous
+                continue
+            tmp = scratch_dir / f"cand-{cand.index:08d}.jpg"
+            cv2.imwrite(str(tmp), frame, [cv2.IMWRITE_JPEG_QUALITY, 90])
+            scratch.append((cand, tmp))
+        del kept_stream
+    finally:
+        cap.release()
+
+    survivors = cap_frames([c for c, _ in scratch], opts.max_frames)
+    survivor_set = {c.index for c in survivors}
+    result: list[Candidate] = []
+    seq = 0
+    for cand, tmp in scratch:
+        if cand.index not in survivor_set:
+            tmp.unlink(missing_ok=True)
+            continue
+        seq += 1
+        dest = frames_dir / f"frame-{seq:06d}-{cand.timestamp_sec:08.2f}s.jpg"
+        tmp.rename(dest)
+        result.append(cand)
+    scratch_dir.rmdir()
+    return result

--- a/src/video_studio/qc/media/pipeline.py
+++ b/src/video_studio/qc/media/pipeline.py
@@ -1,0 +1,123 @@
+"""Single-pass frame pipeline: decode once, fan out to every consumer.
+
+The v1 analyzer's root performance defect: every frame-consuming detector
+called `sample_frames()` itself, so one analysis decoded the video 4+N times
+(visual, layout, caption_sync, objects, and motion once PER SCENE). Here the
+video is decoded exactly once; each consumer declares its own sampling fps and
+receives the frames it is due, with per-frame views (gray, resized) memoized so
+five consumers asking for the same conversion pay for one.
+
+The scheduling semantics per consumer are v1's `sample_frames` verbatim —
+deliver the next decoded frame at-or-past each sample point, resync when decode
+falls behind — so a consumer at fps F sees the SAME frames it would have seen
+decoding privately. That equivalence is what makes the parity gate meaningful.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+class FrameView:
+    """One decoded frame with memoized derived views."""
+
+    def __init__(self, t_sec: float, bgr: Any) -> None:
+        self.t_sec = t_sec
+        self.bgr = bgr
+        self._gray: Any = None
+        self._resized: dict[tuple[int, int, bool], Any] = {}
+
+    @property
+    def gray(self) -> Any:
+        if self._gray is None:
+            import cv2
+
+            self._gray = cv2.cvtColor(self.bgr, cv2.COLOR_BGR2GRAY)
+        return self._gray
+
+    def resized(self, size: tuple[int, int], *, gray: bool = False) -> Any:
+        """Downscale (INTER_AREA), memoized per (size, gray)."""
+        key = (size[0], size[1], gray)
+        if key not in self._resized:
+            import cv2
+
+            src = self.gray if gray else self.bgr
+            self._resized[key] = cv2.resize(src, size, interpolation=cv2.INTER_AREA)
+        return self._resized[key]
+
+
+@dataclass
+class FrameConsumer:
+    """A subscriber to the shared decode at its own sampling rate."""
+
+    name: str
+    fps: float
+    on_frame: Callable[[FrameView], None]
+    _next_sample: float = field(default=0.0, repr=False)
+
+    def offer(self, view: FrameView) -> None:
+        if view.t_sec + 1e-6 >= self._next_sample:
+            self.on_frame(view)
+            self._next_sample += 1.0 / self.fps
+            # If decode fell far behind the schedule, resync (v1 semantics).
+            if self._next_sample < view.t_sec:
+                self._next_sample = view.t_sec + 1.0 / self.fps
+
+
+class FrameSource(Protocol):
+    """Anything that yields (t_sec, bgr_frame) sequentially. One call = one decode."""
+
+    def frames(self) -> Iterator[tuple[float, Any]]: ...
+
+
+class CvFrameSource:
+    """OpenCV sequential decode, timestamps from CAP_PROP_POS_MSEC (v1's clock).
+
+    Tracks `open_count` so tests can assert the whole analysis decoded the
+    video exactly once — the regression guard for the v1 defect.
+    """
+
+    def __init__(self, video_path: str) -> None:
+        self.video_path = video_path
+        self.open_count = 0
+
+    def frames(self) -> Iterator[tuple[float, Any]]:
+        import cv2
+
+        self.open_count += 1
+        cap = cv2.VideoCapture(self.video_path)
+        if not cap.isOpened():
+            raise RuntimeError(f"OpenCV could not open {self.video_path}")
+        try:
+            while True:
+                ok, frame = cap.read()
+                if not ok:
+                    break
+                t = cap.get(cv2.CAP_PROP_POS_MSEC) / 1000.0
+                yield t, frame
+        finally:
+            cap.release()
+
+
+class FramePipeline:
+    def __init__(self, source: FrameSource) -> None:
+        self.source = source
+        self.consumers: list[FrameConsumer] = []
+
+    def subscribe(
+        self, name: str, fps: float, on_frame: Callable[[FrameView], None]
+    ) -> FrameConsumer:
+        consumer = FrameConsumer(name=name, fps=fps, on_frame=on_frame)
+        self.consumers.append(consumer)
+        return consumer
+
+    def run(self) -> None:
+        """One decode; every consumer sees exactly its due frames."""
+        if not self.consumers:
+            return
+        for t_sec, bgr in self.source.frames():
+            view = FrameView(t_sec, bgr)
+            for consumer in self.consumers:
+                consumer.offer(view)

--- a/src/video_studio/qc/media/probe.py
+++ b/src/video_studio/qc/media/probe.py
@@ -1,0 +1,100 @@
+"""ffprobe wrapper: container/stream facts for the report header.
+
+Verbatim port of analyzer/probe.py — the report's `video` block is part of the
+parity contract, so field names, rounding, and fps fallback order are preserved.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Any
+
+
+class ProbeError(RuntimeError):
+    pass
+
+
+@dataclass
+class VideoInfo:
+    path: str
+    duration_sec: float
+    width: int
+    height: int
+    fps: float
+    pix_fmt: str | None
+    video_codec: str | None
+    audio: dict[str, Any] | None  # {codec, sampleRate, channels} or None
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "durationSec": round(self.duration_sec, 3),
+            "width": self.width,
+            "height": self.height,
+            "fps": round(self.fps, 3),
+            "pixFmt": self.pix_fmt,
+            "videoCodec": self.video_codec,
+            "audio": self.audio,
+        }
+
+
+def _parse_rate(rate: str | None) -> float:
+    if not rate or rate in {"0/0", "N/A"}:
+        return 0.0
+    try:
+        return float(Fraction(rate))
+    except (ValueError, ZeroDivisionError):
+        return 0.0
+
+
+def probe(video_path: str) -> VideoInfo:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-print_format",
+        "json",
+        "-show_format",
+        "-show_streams",
+        video_path,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except FileNotFoundError as e:
+        raise ProbeError(
+            "ffprobe not found on PATH — install ffmpeg (e.g. `brew install ffmpeg`)"
+        ) from e
+    except subprocess.CalledProcessError as e:
+        raise ProbeError(f"ffprobe failed for {video_path}: {e.stderr.strip()}") from e
+
+    data = json.loads(result.stdout)
+    streams = data.get("streams", [])
+    vstream = next((s for s in streams if s.get("codec_type") == "video"), None)
+    astream = next((s for s in streams if s.get("codec_type") == "audio"), None)
+    if vstream is None:
+        raise ProbeError(f"no video stream in {video_path}")
+
+    fmt = data.get("format", {})
+    duration = float(fmt.get("duration") or vstream.get("duration") or 0.0)
+
+    audio = None
+    if astream is not None:
+        audio = {
+            "codec": astream.get("codec_name"),
+            "sampleRate": int(astream.get("sample_rate") or 0),
+            "channels": int(astream.get("channels") or 0),
+        }
+
+    return VideoInfo(
+        path=video_path,
+        duration_sec=duration,
+        width=int(vstream.get("width") or 0),
+        height=int(vstream.get("height") or 0),
+        fps=_parse_rate(vstream.get("avg_frame_rate")) or _parse_rate(vstream.get("r_frame_rate")),
+        pix_fmt=vstream.get("pix_fmt"),
+        video_codec=vstream.get("codec_name"),
+        audio=audio,
+    )

--- a/src/video_studio/qc/media/sampling.py
+++ b/src/video_studio/qc/media/sampling.py
@@ -1,0 +1,61 @@
+"""v1-style private frame sampling, retained for the extras-backed detectors.
+
+caption_sync/layout/transcript/objects run heavy models (easyocr, whisper,
+YOLO) that dominate their runtime — folding their decode into the shared
+pipeline buys little and complicates model batching, so they keep v1's
+self-decoding loop for now. The always-on core path (visual, motion, cuts,
+filters) is what the single-pass pipeline serves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class SampledFrame:
+    t_sec: float
+    image: Any  # BGR ndarray
+
+
+def sample_frames(
+    video_path: str,
+    fps: float,
+    start_sec: float = 0.0,
+    end_sec: float | None = None,
+) -> Iterator[SampledFrame]:
+    """Yield frames at ~fps; decodes sequentially and picks the next frame past
+    each sample point (v1 semantics, robust on long-GOP H.264)."""
+    import cv2
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise RuntimeError(f"OpenCV could not open {video_path}")
+    try:
+        interval = 1.0 / fps
+        next_sample = start_sec
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            t = cap.get(cv2.CAP_PROP_POS_MSEC) / 1000.0
+            if end_sec is not None and t > end_sec:
+                break
+            if t + 1e-6 >= next_sample:
+                yield SampledFrame(t_sec=t, image=frame)
+                next_sample += interval
+                if next_sample < t:
+                    next_sample = t + interval
+    finally:
+        cap.release()
+
+
+def caption_band(image: Any, aspect_ratio: str) -> tuple[Any, int]:
+    """Crop the caption region; returns (crop, y_offset). Bottom 35% for 9:16,
+    30% otherwise — where showrunner renders captions."""
+    h = image.shape[0]
+    frac = 0.35 if aspect_ratio == "9:16" else 0.30
+    y0 = int(h * (1 - frac))
+    return image[y0:], y0

--- a/src/video_studio/qc/qc_analyze.py
+++ b/src/video_studio/qc/qc_analyze.py
@@ -1,0 +1,107 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["numpy>=1.26", "opencv-python-headless>=4.9", "scenedetect>=0.6.4", "rapidfuzz>=3.9", "scipy>=1.14,<1.18"]
+# ///
+"""The render, checked against the plan — the full pass, with decoded frames.
+
+Usage:
+  video-studio qc_analyze --video out/video.mp4 --project projects/foo
+  video-studio qc_analyze --video out/video.mp4 --project projects/foo --json
+  video-studio qc_analyze ... --detectors container,visual,motion
+  video-studio qc_analyze --list
+
+There are two gates in this repo and they are not the same size. The
+`video-production` skill bundles `qc_render.py`, which needs no install and
+answers "does this file match its plan" from ffprobe and one ffmpeg pass. This
+is the other one: it decodes frames and reports on the picture — blur, banding,
+motion character, split-pane composition, audio structure, and with the model
+extras, captions, objects and speech.
+
+Install what you need, not everything:
+
+  pip install 'video-studio-engine[qc] @ git+https://github.com/scrollmark/social-skills.git'
+
+then optionally `[qc-ocr]` (captions, text layout), `[qc-yolo]` (planned
+subjects, entity tracking), `[qc-face]` (lip sync), `[qc-clip]` (prompt fit).
+A detector whose extra is absent SKIPS and says so; it never fails the run.
+
+Ground truth is `<project>/plan.json`, which `build_props` already writes for
+exactly this, plus `storyboard.json` for size and palette and
+`audio/<scene>.timings.json` for caption words.
+
+Exit 0 = no error-severity findings. Exit 1 = at least one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def main() -> None:
+    from video_studio.qc.engine import KNOWN_DETECTORS, AnalyzeOptions, analyze
+
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--video")
+    ap.add_argument("--project", help="the project directory holding plan.json")
+    ap.add_argument("--detectors", help="comma-separated subset (default: all)")
+    ap.add_argument("--evidence", help="directory for extracted evidence frames")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--list", action="store_true", help="print detector names and exit")
+    a = ap.parse_args()
+
+    if a.list:
+        for spec in KNOWN_DETECTORS:
+            need = f"  [{spec.extra}]" if spec.extra else ""
+            print(f"{spec.name}{need}")
+        return
+
+    if not a.video or not a.project:
+        raise SystemExit("--video and --project are both required (or use --list)")
+
+    wanted = None
+    if a.detectors:
+        wanted = {d.strip() for d in a.detectors.split(",") if d.strip()}
+        known = {s.name for s in KNOWN_DETECTORS}
+        unknown = sorted(wanted - known)
+        if unknown:
+            raise SystemExit(
+                f"unknown detector(s): {', '.join(unknown)}\n"
+                f"Run --list to see the {len(known)} that exist."
+            )
+
+    report = analyze(a.video, AnalyzeOptions(
+        workdir=a.project, detectors=wanted, evidence_dir=a.evidence))
+    data = report.to_json()
+    findings = data.get("findings", [])
+    errors = [f for f in findings if f.get("severity") == "error"]
+
+    if a.json:
+        print(json.dumps(data, indent=2, default=str))
+    else:
+        for f in findings:
+            sev = (f.get("severity") or "info").upper()
+            print(f"{sev:8} {f.get('id','?')}: {f.get('message','')}")
+        skipped = data.get("detectorsSkipped") or []
+        ran = data.get("detectorsRun") or []
+        print(f"\n{len(ran)} detector(s) ran, {len(findings)} finding(s), "
+              f"{len(errors)} at error severity.")
+        if skipped:
+            # A skip is not a pass. Saying which checks did not happen is the
+            # difference between "clean" and "clean as far as we looked".
+            missing = [s for s in skipped if s.get("code") == "missing_extra"]
+            if missing:
+                print(f"{len(missing)} check(s) did NOT run for want of an extra: "
+                      + ", ".join(f"{s['name']} ({s.get('extra') or s.get('detail')})"
+                                  for s in missing))
+            other = [s for s in skipped if s.get("code") != "missing_extra"]
+            for s in other:
+                print(f"skipped {s['name']}: {s.get('code')}")
+        print("This reads the picture, not the point. Pull frames and look at them too.")
+
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/video_studio/qc/report/__init__.py
+++ b/src/video_studio/qc/report/__init__.py
@@ -1,0 +1,5 @@
+"""Report contract: dataclasses, stable ids, comparison."""
+
+from video_studio.qc.report.model import Finding, Report, SceneTiming, Severity, Skip
+
+__all__ = ["Finding", "Report", "SceneTiming", "Severity", "Skip"]

--- a/src/video_studio/qc/report/compare.py
+++ b/src/video_studio/qc/report/compare.py
@@ -1,0 +1,143 @@
+"""Run-over-run comparison: did a generator change actually improve the output?
+
+A direct port of video-analysis/src/compare.ts. The verdict semantics are load-
+bearing — they are what the fix loop uses to decide whether to keep a change or
+roll it back — so they are reproduced exactly, including the precedence order.
+
+One deliberate extension over the TypeScript original: findings can be matched by
+`fingerprint` instead of `id`. The v1 id embedded positional disambiguation, so a
+new finding sorting earlier renamed later ones and the diff filled with phantom
+fixes. Fingerprints are content-derived and stable (see report.ids), so matching
+on them is strictly more accurate. `match_on="id"` reproduces v1 behaviour for
+parity checks against the rescued corpus.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+Verdict = Literal["improved", "regressed", "unchanged", "mixed"]
+MatchOn = Literal["id", "fingerprint"]
+
+
+@dataclass(frozen=True)
+class MetricDelta:
+    key: str
+    before: float | None
+    after: float | None
+    delta: float | None
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "before": self.before,
+            "after": self.after,
+            "delta": self.delta,
+        }
+
+
+@dataclass
+class FindingsDiff:
+    fixed: list[dict[str, Any]] = field(default_factory=list)
+    introduced: list[dict[str, Any]] = field(default_factory=list)
+    persisting: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "fixed": self.fixed,
+            "introduced": self.introduced,
+            "persisting": self.persisting,
+        }
+
+
+def compare_metrics(before: dict[str, Any], after: dict[str, Any]) -> list[MetricDelta]:
+    """Union of metric keys, sorted, with a delta where both sides have a value.
+
+    `delta` stays None when either side is absent — a metric that only exists in
+    one run has no meaningful difference, and reporting 0 would read as "no
+    change" when the truth is "not measured".
+    """
+    before_metrics: dict[str, float] = before.get("metrics", {})
+    after_metrics: dict[str, float] = after.get("metrics", {})
+
+    deltas: list[MetricDelta] = []
+    for key in sorted(set(before_metrics) | set(after_metrics)):
+        b = before_metrics.get(key)
+        a = after_metrics.get(key)
+        delta = round(a - b, 4) if b is not None and a is not None else None
+        deltas.append(MetricDelta(key=key, before=b, after=a, delta=delta))
+    return deltas
+
+
+def _match_key(finding: dict[str, Any], match_on: MatchOn) -> str:
+    if match_on == "fingerprint":
+        # Fall back to id for v1 reports, which predate fingerprints.
+        return str(finding.get("fingerprint") or finding["id"])
+    return str(finding["id"])
+
+
+def compare_findings(
+    before: dict[str, Any],
+    after: dict[str, Any],
+    *,
+    match_on: MatchOn = "fingerprint",
+) -> FindingsDiff:
+    """Set-diff findings into fixed / introduced / persisting.
+
+    `persisting` returns the AFTER copy, matching the TypeScript original — the
+    caller wants the current measurement, not the stale one.
+    """
+    before_map = {_match_key(f, match_on): f for f in before.get("findings", [])}
+    after_map = {_match_key(f, match_on): f for f in after.get("findings", [])}
+
+    return FindingsDiff(
+        fixed=[f for k, f in before_map.items() if k not in after_map],
+        introduced=[f for k, f in after_map.items() if k not in before_map],
+        persisting=[f for k, f in after_map.items() if k in before_map],
+    )
+
+
+def _count_errors(findings: list[dict[str, Any]]) -> int:
+    return sum(1 for f in findings if f.get("severity") == "error")
+
+
+def summarize_comparison(
+    before: dict[str, Any],
+    after: dict[str, Any],
+    *,
+    match_on: MatchOn = "fingerprint",
+) -> dict[str, Any]:
+    """Verdict + diff + changed metrics.
+
+    Verdict precedence, in order — this is a faithful port and the order matters:
+
+    1. More net-new ERROR-severity findings than fixed ones -> ``regressed``.
+       Checked first, so a change that fixes ten warnings while introducing one
+       new error is still a regression.
+    2. Fixed something and introduced nothing -> ``improved``.
+    3. Neither fixed nor introduced anything -> ``unchanged``.
+    4. Otherwise -> ``mixed``.
+
+    Note what falls out of this: warning-only churn can *never* produce
+    ``regressed``. Trading warnings for warnings lands in ``mixed``.
+    """
+    diff = compare_findings(before, after, match_on=match_on)
+    changed_metrics = [
+        d for d in compare_metrics(before, after) if d.delta is not None and d.delta != 0
+    ]
+
+    if _count_errors(diff.introduced) > _count_errors(diff.fixed):
+        verdict: Verdict = "regressed"
+    elif diff.fixed and not diff.introduced:
+        verdict = "improved"
+    elif not diff.fixed and not diff.introduced:
+        verdict = "unchanged"
+    else:
+        verdict = "mixed"
+
+    return {
+        "verdict": verdict,
+        "findings": diff.to_json(),
+        "changedMetrics": [d.to_json() for d in changed_metrics],
+    }

--- a/src/video_studio/qc/report/ids.py
+++ b/src/video_studio/qc/report/ids.py
@@ -1,0 +1,189 @@
+"""Stable, content-derived finding identifiers.
+
+Why this module exists
+----------------------
+The v1 analyzer built ids as ``<detector>.<code_lower>[:<sceneId>]`` and
+disambiguated collisions **by position in the sorted finding list**: the second
+occurrence became ``<id>:2``, the third ``<id>:3``.
+
+That silently breaks the one thing the ids exist for. Run-over-run diffing
+classifies findings as fixed / introduced / persisting by id, so if a *new*
+finding appears that happens to sort earlier, every later duplicate shifts by
+one suffix and the diff reports a cascade of phantom "fixed" and "introduced"
+findings that nothing in the video actually changed.
+
+The v2 grammar removes position from the id entirely::
+
+    <detector>.<code_lower>[@<sceneId>][#<key>][~<hash6>]
+
+- ``key`` is a *content-derived discriminator supplied by the detector* — the
+  clipped string, the timestamp bucket, the object class. Two findings of the
+  same code in the same scene are told apart by what they are about, not by
+  what order they came out in.
+- ``~hash6`` appears only when a key still collides, and is derived from that
+  finding's *own* canonical content, so it does not depend on which other
+  findings exist.
+
+Every finding also carries an opaque ``fingerprint`` so consumers can diff
+without parsing the id grammar at all.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+# Keys go in an id, so they must be filesystem/URL/grep-safe and stable across
+# runs. Anything outside this set collapses to a hyphen.
+_UNSAFE = re.compile(r"[^a-z0-9]+")
+
+KEY_MAX_LEN = 24
+
+
+def slug_key(text: str, max_len: int = KEY_MAX_LEN) -> str:
+    """Normalize arbitrary text into a short, stable id fragment.
+
+    Truncation is by *character count after normalization*, so a long string and
+    its prefix collapse together — that is intentional: two OCR readings of the
+    same clipped headline should share a key even if one caught trailing glyphs.
+    """
+    lowered = _UNSAFE.sub("-", text.strip().lower()).strip("-")
+    if not lowered:
+        return "none"
+    return lowered[:max_len].rstrip("-")
+
+
+def text_key(text: str) -> str:
+    """Discriminator for a finding about a specific piece of text."""
+    return slug_key(text)
+
+
+def time_key(seconds: float, bucket_sec: float = 0.5) -> str:
+    """Discriminator for a finding at a point in time.
+
+    Quantized so that a detector that re-measures the same event a few
+    milliseconds off across runs still produces the same key. Pick ``bucket_sec``
+    to match the detector's own sampling resolution — too fine and the key
+    flickers between runs, too coarse and distinct events merge.
+    """
+    return f"t{round(seconds / bucket_sec)}"
+
+
+def class_key(name: str) -> str:
+    """Discriminator for a finding about an object/entity class."""
+    return slug_key(name)
+
+
+def word_key(word: str) -> str:
+    """Discriminator for a finding about a single caption/transcript word."""
+    return slug_key(word)
+
+
+def pane_key(rect: tuple[float, float, float, float]) -> str:
+    """Discriminator for a finding about a layout pane.
+
+    Rect is fractional (x, y, w, h). Quantized to 5% of the frame so a pane
+    whose detected bounds wobble slightly keeps its identity.
+    """
+    x, y, w, h = (round(v * 20) for v in rect)
+    return f"p{x}x{y}x{w}x{h}"
+
+
+def track_key(track_id: int | str) -> str:
+    """Discriminator for a finding about a tracked entity."""
+    return f"k{track_id}"
+
+
+def _canonical(payload: dict[str, Any]) -> str:
+    """Deterministic JSON for hashing: sorted keys, no incidental whitespace."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _digest(payload: dict[str, Any], length: int) -> str:
+    return hashlib.blake2s(_canonical(payload).encode("utf-8")).hexdigest()[:length]
+
+
+def base_id(detector: str, code: str, scene_id: str | None, key: str | None) -> str:
+    """The id without any collision suffix."""
+    out = f"{detector}.{code.lower()}"
+    if scene_id:
+        out += f"@{scene_id}"
+    if key:
+        out += f"#{key}"
+    return out
+
+
+def fingerprint(detector: str, code: str, scene_id: str | None, key: str | None) -> str:
+    """Opaque stable token for diffing without parsing the id grammar."""
+    return _digest(
+        {"d": detector, "c": code.lower(), "s": scene_id or "", "k": key or ""},
+        8,
+    )
+
+
+def collision_suffix(
+    *,
+    message: str,
+    span_sec: tuple[float, float] | None,
+    metrics: dict[str, float] | None,
+) -> str:
+    """Content-derived tiebreaker for findings that still share a base id.
+
+    Derived only from *this* finding's content, never from its position or from
+    what else is in the report — which is the whole point. The span is rounded
+    to 0.1s so a re-measurement that lands a few ms away keeps the same suffix.
+    """
+    span = None
+    if span_sec is not None:
+        span = [round(span_sec[0], 1), round(span_sec[1], 1)]
+    return _digest(
+        {
+            "m": message,
+            "s": span,
+            "x": {k: round(v, 4) for k, v in sorted((metrics or {}).items())},
+        },
+        6,
+    )
+
+
+def resolve_ids(findings: list[Any]) -> dict[int, str]:
+    """Assign a final id to every finding, adding ``~hash6`` only on collision.
+
+    Takes objects exposing ``detector``/``code``/``scene_id``/``key``/``message``
+    /``span_sec``/``metrics``. Returns ``{id(finding_object): final_id}``.
+
+    Note the collision suffix is applied to *every* member of a colliding group,
+    not just the second onward — otherwise removing the first member would
+    rename the survivor.
+    """
+    groups: dict[str, list[Any]] = {}
+    for finding in findings:
+        base = base_id(finding.detector, finding.code, finding.scene_id, finding.key)
+        groups.setdefault(base, []).append(finding)
+
+    resolved: dict[int, str] = {}
+    for base, group in groups.items():
+        if len(group) == 1:
+            resolved[id(group[0])] = base
+            continue
+        for finding in group:
+            suffix = collision_suffix(
+                message=finding.message,
+                span_sec=finding.span_sec,
+                metrics=finding.metrics,
+            )
+            resolved[id(finding)] = f"{base}~{suffix}"
+
+    # Two findings with identical content in the same scene are genuinely
+    # indistinguishable; de-duplicating them here would hide a detector bug, so
+    # append an ordinal and let the contract test flag it.
+    used: dict[str, int] = {}
+    for finding in findings:
+        current = resolved[id(finding)]
+        count = used.get(current, 0) + 1
+        used[current] = count
+        if count > 1:
+            resolved[id(finding)] = f"{current}.{count}"
+    return resolved

--- a/src/video_studio/qc/report/model.py
+++ b/src/video_studio/qc/report/model.py
@@ -1,0 +1,319 @@
+"""Report dataclasses — the JSON contract every consumer reads.
+
+This is v2 of the contract first defined in video-analysis/analyzer/report.py.
+Behavioural changes from v1:
+
+  - Finding ids are content-derived rather than positionally disambiguated
+    (see report.ids for why that mattered).
+  - Findings carry a `key` discriminator and an opaque `fingerprint`.
+  - `detectorsSkipped` entries are typed (`missing_extra` vs `crashed` vs
+    `requires_workdir` ...) instead of a free-text reason string, so a caller
+    can tell "install this extra" apart from "this detector has a bug".
+
+`to_legacy_json()` emits the exact v1 shape, which is what the parity harness
+diffs against the rescued corpus.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from video_studio.qc import LEGACY_SCHEMA_VERSION, SCHEMA_VERSION, __version__
+from video_studio.qc.report import ids as _ids
+
+Severity = Literal["error", "warning", "info"]
+
+SkipCode = Literal[
+    "missing_extra",  # optional dependency absent — actionable, has an install hint
+    "requires_workdir",  # needs generator ground truth that wasn't supplied
+    "not_applicable",  # deliberately inert for this format/taxonomy
+    "no_data",  # ran, but the input had nothing to measure
+    "crashed",  # a bug — carries a traceback
+    "unknown",  # name passed to --detectors that doesn't exist
+]
+
+SEVERITY_ORDER: dict[str, int] = {"error": 0, "warning": 1, "info": 2}
+
+
+@dataclass
+class Finding:
+    """One QC observation.
+
+    `key` is the content-derived discriminator that keeps ids stable when a
+    detector emits several findings of the same code within one scene. Build it
+    with the helpers in report.ids (`text_key`, `time_key`, `class_key`, ...).
+    A detector that can emit more than one finding per (code, scene) and leaves
+    `key` as None is a bug — tests/test_report_ids.py enforces it.
+    """
+
+    detector: str
+    code: str
+    severity: Severity
+    message: str
+    scene_id: str | None = None
+    key: str | None = None
+    span_sec: tuple[float, float] | None = None
+    metrics: dict[str, float] = field(default_factory=dict)
+    evidence: dict[str, str] = field(default_factory=dict)
+    rubric_dimension: str | None = None
+    confidence: float | None = None
+    taxonomy_targets: list[str] = field(default_factory=list)
+
+    @property
+    def base_id(self) -> str:
+        return _ids.base_id(self.detector, self.code, self.scene_id, self.key)
+
+    @property
+    def fingerprint(self) -> str:
+        return _ids.fingerprint(self.detector, self.code, self.scene_id, self.key)
+
+    @property
+    def legacy_id(self) -> str:
+        """The v1 id, before positional disambiguation is applied."""
+        suffix = f":{self.scene_id}" if self.scene_id else ""
+        return f"{self.detector}.{self.code.lower()}{suffix}"
+
+    def to_json(self, resolved_id: str) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "id": resolved_id,
+            "fingerprint": self.fingerprint,
+            "detector": self.detector,
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+        }
+        if self.scene_id is not None:
+            out["sceneId"] = self.scene_id
+        if self.key is not None:
+            out["key"] = self.key
+        if self.span_sec is not None:
+            out["spanSec"] = [round(self.span_sec[0], 3), round(self.span_sec[1], 3)]
+        if self.metrics:
+            out["metrics"] = self.metrics
+        if self.evidence:
+            out["evidence"] = self.evidence
+        if self.rubric_dimension is not None:
+            out["rubricDimension"] = self.rubric_dimension
+        if self.confidence is not None:
+            out["confidence"] = round(self.confidence, 3)
+        if self.taxonomy_targets:
+            out["taxonomyTargets"] = list(self.taxonomy_targets)
+        return out
+
+    def to_legacy_json(self, resolved_id: str) -> dict[str, Any]:
+        """Exactly the v1 field set, in v1 order — nothing added, nothing dropped."""
+        out: dict[str, Any] = {
+            "id": resolved_id,
+            "detector": self.detector,
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+        }
+        if self.scene_id is not None:
+            out["sceneId"] = self.scene_id
+        if self.span_sec is not None:
+            out["spanSec"] = [round(self.span_sec[0], 3), round(self.span_sec[1], 3)]
+        if self.metrics:
+            out["metrics"] = self.metrics
+        if self.evidence:
+            out["evidence"] = self.evidence
+        if self.rubric_dimension is not None:
+            out["rubricDimension"] = self.rubric_dimension
+        return out
+
+
+@dataclass
+class SceneTiming:
+    """Per-scene spine: planned bounds plus whatever each detector measured."""
+
+    id: str
+    index: int
+    planned_start_sec: float
+    planned_end_sec: float
+    narration: str
+    detected_cut_sec: float | None = None
+    audio_offset_ms: float | None = None
+    caption_offset_ms: float | None = None
+    av_offset_ms: float | None = None
+    lip_sync_offset_ms: float | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        def ms(value: float | None) -> float | None:
+            return None if value is None else round(value, 1)
+
+        out = self.to_legacy_json()
+        out["avOffsetMs"] = ms(self.av_offset_ms)
+        out["lipSyncOffsetMs"] = ms(self.lip_sync_offset_ms)
+        return out
+
+    def to_legacy_json(self) -> dict[str, Any]:
+        def ms(value: float | None) -> float | None:
+            return None if value is None else round(value, 1)
+
+        return {
+            "id": self.id,
+            "index": self.index,
+            "plannedStartSec": round(self.planned_start_sec, 3),
+            "plannedEndSec": round(self.planned_end_sec, 3),
+            "detectedCutSec": (
+                None if self.detected_cut_sec is None else round(self.detected_cut_sec, 3)
+            ),
+            "audioOffsetMs": ms(self.audio_offset_ms),
+            "captionOffsetMs": ms(self.caption_offset_ms),
+            "narration": self.narration,
+        }
+
+
+@dataclass
+class Skip:
+    """A detector or service that did not run, and why."""
+
+    name: str
+    code: SkipCode
+    kind: Literal["detector", "service"] = "detector"
+    extra: str | None = None
+    detail: str | None = None
+
+    @property
+    def hint(self) -> str | None:
+        if self.code == "missing_extra" and self.extra:
+            return f"uv sync --extra {self.extra}"
+        return None
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"name": self.name, "kind": self.kind, "code": self.code}
+        if self.extra:
+            out["extra"] = self.extra
+        if self.detail:
+            out["detail"] = self.detail
+        if self.hint:
+            out["hint"] = self.hint
+        return out
+
+    def to_legacy_json(self) -> dict[str, str]:
+        """v1 collapsed everything into one free-text `reason` string."""
+        if self.code == "missing_extra":
+            missing = self.detail or "dependency"
+            hint = f" ({self.hint})" if self.hint else ""
+            reason = f"missing dependency: {missing}{hint}"
+        elif self.code == "requires_workdir":
+            reason = "requires --workdir (showrunner ground truth)"
+        elif self.code == "crashed":
+            reason = f"crashed: {self.detail or 'unknown error'}"
+        elif self.code == "unknown":
+            reason = "unknown or not installed"
+        else:
+            reason = self.detail or self.code
+        return {"name": self.name, "reason": reason}
+
+
+@dataclass
+class Report:
+    video: dict[str, Any]
+    workdir: dict[str, Any] | None = None
+    inputs: dict[str, Any] = field(default_factory=dict)
+    taxonomy: dict[str, Any] | None = None
+    scenes: list[SceneTiming] = field(default_factory=list)
+    detectors_run: list[str] = field(default_factory=list)
+    services_run: list[dict[str, Any]] = field(default_factory=list)
+    skipped: list[Skip] = field(default_factory=list)
+    metrics: dict[str, float] = field(default_factory=dict)
+    findings: list[Finding] = field(default_factory=list)
+    scorecards: list[dict[str, Any]] = field(default_factory=list)
+    rubric: dict[str, Any] | None = None
+    artifacts: dict[str, str] = field(default_factory=dict)
+    timings: dict[str, Any] = field(default_factory=dict)
+    generated_at: str | None = None
+
+    def add(self, finding: Finding) -> None:
+        self.findings.append(finding)
+
+    def set_metric(self, key: str, value: float) -> None:
+        self.metrics[key] = round(float(value), 4)
+
+    def scene(self, scene_id: str) -> SceneTiming | None:
+        for scene in self.scenes:
+            if scene.id == scene_id:
+                return scene
+        return None
+
+    def _sorted_findings(self) -> list[Finding]:
+        return sorted(self.findings, key=lambda f: (SEVERITY_ORDER[f.severity], f.base_id))
+
+    def _summary(self) -> dict[str, int]:
+        return {
+            "errors": sum(1 for f in self.findings if f.severity == "error"),
+            "warnings": sum(1 for f in self.findings if f.severity == "warning"),
+            "info": sum(1 for f in self.findings if f.severity == "info"),
+        }
+
+    def _timestamp(self) -> str:
+        return self.generated_at or datetime.now(UTC).isoformat(timespec="seconds")
+
+    def to_json(self) -> dict[str, Any]:
+        findings = self._sorted_findings()
+        resolved = _ids.resolve_ids(findings)
+        out: dict[str, Any] = {
+            "schemaVersion": SCHEMA_VERSION,
+            "analyzerVersion": __version__,
+            "findingIdScheme": "v2-content",
+            "generatedAt": self._timestamp(),
+            "inputs": self.inputs,
+            "video": self.video,
+            "workdir": self.workdir,
+            "taxonomy": self.taxonomy,
+            "scenes": [s.to_json() for s in self.scenes],
+            "detectorsRun": self.detectors_run,
+            "servicesRun": self.services_run,
+            "detectorsSkipped": [s.to_json() for s in self.skipped],
+            "metrics": self.metrics,
+            "findings": [f.to_json(resolved[id(f)]) for f in findings],
+            "summary": self._summary(),
+        }
+        if self.scorecards:
+            out["scorecards"] = self.scorecards
+        if self.rubric is not None:
+            out["rubric"] = self.rubric
+        if self.artifacts:
+            out["artifacts"] = self.artifacts
+        if self.timings:
+            out["timings"] = self.timings
+        return out
+
+    def to_legacy_json(self) -> dict[str, Any]:
+        """Emit the v1 contract, positional id disambiguation included.
+
+        This is what the parity harness compares against the rescued corpus, so
+        it reproduces v1's quirks deliberately — including the positional `:2`
+        suffix that v2 exists to eliminate.
+        """
+        findings = sorted(self.findings, key=lambda f: (SEVERITY_ORDER[f.severity], f.legacy_id))
+        seen: dict[str, int] = {}
+        finding_dicts: list[dict[str, Any]] = []
+        for finding in findings:
+            legacy_id = finding.legacy_id
+            count = seen.get(legacy_id, 0) + 1
+            seen[legacy_id] = count
+            if count > 1:
+                legacy_id = f"{legacy_id}:{count}"
+            finding_dicts.append(finding.to_legacy_json(legacy_id))
+        return {
+            "schemaVersion": LEGACY_SCHEMA_VERSION,
+            "analyzerVersion": __version__,
+            "generatedAt": self._timestamp(),
+            "video": self.video,
+            "workdir": self.workdir,
+            "scenes": [s.to_legacy_json() for s in self.scenes],
+            "detectorsRun": self.detectors_run,
+            "detectorsSkipped": [s.to_legacy_json() for s in self.skipped],
+            "metrics": self.metrics,
+            "findings": finding_dicts,
+            "summary": self._summary(),
+        }
+
+    def dumps(self, *, legacy: bool = False) -> str:
+        payload = self.to_legacy_json() if legacy else self.to_json()
+        return json.dumps(payload, indent=2)

--- a/src/video_studio/qc/services/__init__.py
+++ b/src/video_studio/qc/services/__init__.py
@@ -1,0 +1,6 @@
+"""Services: the only code that touches media. Detectors are pure over
+the artifacts these produce (see showwatcher.context)."""
+
+from video_studio.qc.services.frame_services import run_frame_services
+
+__all__ = ["run_frame_services"]

--- a/src/video_studio/qc/services/frame_services.py
+++ b/src/video_studio/qc/services/frame_services.py
@@ -1,0 +1,395 @@
+"""Frame-consuming services over the ONE shared decode.
+
+Each service declares its sample rate, owns exactly one artifact on
+`ctx.artifacts`, and subscribes one callback to the FramePipeline. The
+pipeline unions the schedules so a single sequential decode serves them all —
+the decode-count regression test (`CvFrameSource.open_count == 1`) is the
+guard that this stays true.
+
+Extracted from engine.py's closure pile; behavior is byte-identical (the
+corpus parity gate is the check).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from video_studio.qc.context import Context, FrameStats, PaneStats
+from video_studio.qc.media.pipeline import CvFrameSource, FramePipeline
+
+VISUAL_SAMPLE_FPS = 1.0
+MOTION_SAMPLE_FPS = 10.0
+ENERGY_SAMPLE_FPS = 25.0
+PANES_SAMPLE_FPS = 2.0
+MOUTH_SAMPLE_FPS = 10.0
+FLOW_SIZE = (320, 180)
+
+
+@dataclass(frozen=True)
+class ServiceSpec:
+    """What a service asks of the shared decode."""
+
+    name: str
+    fps: float
+
+
+class VisualService:
+    """Blur/banding/palette per ~1s frame — feeds the `visual` detector."""
+
+    spec = ServiceSpec("visual", VISUAL_SAMPLE_FPS)
+
+    def __init__(self, ctx: Context) -> None:
+        import numpy as np
+
+        from video_studio.qc.ground_truth import load_palette
+
+        self._np = np
+        gt = ctx.ground_truth
+        fmt = gt.format if gt else None
+        graphics = fmt in {"faceless-explainer", "manim-explainer"}
+        self.palette = load_palette(gt.workdir) if (gt and graphics) else None
+        self.stats = FrameStats(palette_checked=self.palette is not None)
+        ctx.artifacts.frame_stats = self.stats
+
+    def on_frame(self, view: Any) -> None:
+        import cv2
+
+        np = self._np
+        stats = self.stats
+        gray = view.gray
+        blur = float(cv2.Laplacian(gray, cv2.CV_64F).var())
+        stats.blur_scores.append(blur)
+        if stats.worst_blur is None or blur < stats.worst_blur[0]:
+            stats.worst_blur = (blur, view.t_sec)
+
+        small = view.resized((320, 180), gray=True)
+        lap = np.abs(cv2.Laplacian(small.astype(np.float64), cv2.CV_64F))
+        smooth = lap < 1.0
+        gx = cv2.Sobel(small, cv2.CV_64F, 1, 0, ksize=5)
+        gy = cv2.Sobel(small, cv2.CV_64F, 0, 1, ksize=5)
+        grad = np.sqrt(gx**2 + gy**2)
+        gradient_region = (grad > 1.0) & (grad < 40.0)
+        stats.banding_scores.append(float((smooth & gradient_region).mean()))
+
+        if self.palette is not None:
+            tiny = view.resized((160, 90))
+            lab = cv2.cvtColor(tiny, cv2.COLOR_BGR2Lab).reshape(-1, 3).astype(np.float64)
+            dists = np.linalg.norm(lab[:, None, :] - self.palette[None, :, :], axis=2)
+            stats.off_palette_fractions.append(float((dists.min(axis=1) > 25.0).mean()))
+
+
+class MotionService:
+    """Farneback optical-flow speed at 10fps — feeds the `motion` detector."""
+
+    spec = ServiceSpec("motion", MOTION_SAMPLE_FPS)
+
+    def __init__(self, ctx: Context) -> None:
+        self.samples: list[tuple[float, float, float]] = []
+        ctx.artifacts.motion_samples = self.samples
+        self._prev: dict[str, Any] = {}
+
+    def on_frame(self, view: Any) -> None:
+        import cv2
+        import numpy as np
+
+        gray = view.resized(FLOW_SIZE, gray=True)
+        prev = self._prev
+        if "frame" in prev:
+            flow = cv2.calcOpticalFlowFarneback(  # type: ignore[call-overload]
+                prev["frame"], gray, None, 0.5, 3, 15, 3, 5, 1.2, 0
+            )
+            speed = float(np.linalg.norm(flow, axis=2).mean())
+            self.samples.append((prev["t"], view.t_sec, speed))
+        prev["frame"] = gray
+        prev["t"] = view.t_sec
+
+
+class EnergyService:
+    """Frame-diff energy at 25fps — feeds `av_sync`'s motion side."""
+
+    spec = ServiceSpec("energy", ENERGY_SAMPLE_FPS)
+
+    def __init__(self, ctx: Context) -> None:
+        self.energy: list[tuple[float, float]] = []
+        ctx.artifacts.energy_samples = self.energy
+        self._prev: dict[str, Any] = {}
+
+    def on_frame(self, view: Any) -> None:
+        import cv2
+
+        gray = view.resized(FLOW_SIZE, gray=True)
+        prev = self._prev
+        if "frame" in prev:
+            diff = cv2.absdiff(prev["frame"], gray)
+            self.energy.append((view.t_sec, float(diff.mean())))
+        prev["frame"] = gray
+
+
+class PaneService:
+    """Column edge profiles + block motion + chroma coverage — `composition`."""
+
+    spec = ServiceSpec("panes", PANES_SAMPLE_FPS)
+    BLOCKS_X = 16
+
+    def __init__(self, ctx: Context) -> None:
+        self.stats = PaneStats()
+        ctx.artifacts.pane_stats = self.stats
+        self._prev: dict[str, Any] = {}
+
+    def on_frame(self, view: Any) -> None:
+        import cv2
+        import numpy as np
+
+        stats = self.stats
+        prev = self._prev
+        gray = view.resized((480, 270), gray=True).astype(np.float64)
+        sobel_x = np.abs(cv2.Sobel(gray, cv2.CV_64F, 1, 0, ksize=3))
+        stats.column_profiles.append(sobel_x.mean(axis=0))
+        if "frame" in prev:
+            diff = np.abs(gray - prev["frame"])
+            cols = np.array_split(diff, self.BLOCKS_X, axis=1)
+            stats.block_energies.append(np.array([c.mean() for c in cols]))
+        prev["frame"] = gray
+        # Chroma-key hue coverage (green screen residue / spill).
+        hsv = cv2.cvtColor(view.resized((160, 90)), cv2.COLOR_BGR2HSV)
+        hue, sat = hsv[..., 0].astype(int), hsv[..., 1].astype(int)
+        green = ((hue > 35) & (hue < 85) & (sat > 100)).mean()
+        stats.key_hue_fractions.append(float(green))
+
+
+class MouthService:
+    """Face-tracked mouth-openness series at 10fps — feeds `lip_sync`.
+
+    Backend resolution order:
+      1. mediapipe FaceMesh ([face] extra) — real inner-lip aperture
+         (landmarks 13/14) normalized by inter-ocular distance (33/263).
+         lip_sync treats this as non-degraded (confidence 0.9).
+      2. classic Haar cascade (OpenCV < 5 only — 5.0 removed
+         CascadeClassifier) — mouth-ROI frame-diff proxy, degraded mode.
+      3. none — empty series + a service skip; NEVER crashes the analysis.
+    """
+
+    spec = ServiceSpec("mouth", MOUTH_SAMPLE_FPS)
+
+    def __init__(self, ctx: Context) -> None:
+        self.mouth: list[tuple[float, float]] = []
+        ctx.artifacts.mouth_series = self.mouth
+        self._prev: dict[str, Any] = {}
+        self._mesh = _mediapipe_face_mesh()
+        self._haar = _haar_face_backend() if self._mesh is None else None
+        self.mode = "mediapipe" if self._mesh else "haar" if self._haar else "none"
+        ctx.artifacts.mouth_mode = self.mode
+        if self.mode == "none":
+            from video_studio.qc.report.model import Skip
+
+            ctx.report.skipped.append(
+                Skip(
+                    "face",
+                    "missing_extra",
+                    kind="service",
+                    extra="face",
+                    detail="no face backend (OpenCV 5 removed the Haar "
+                    "CascadeClassifier — install the [face] extra for mediapipe)",
+                )
+            )
+
+    @property
+    def available(self) -> bool:
+        return self.mode != "none"
+
+    def on_frame(self, view: Any) -> None:
+        if self._mesh is not None:
+            self._on_frame_mediapipe(view)
+        else:
+            self._on_frame_haar(view)
+
+    def _on_frame_mediapipe(self, view: Any) -> None:
+        import mediapipe as mp
+        import numpy as np
+
+        small = view.resized((480, max(2, int(480 * view.bgr.shape[0] / view.bgr.shape[1]))))
+        rgb = np.ascontiguousarray(small[:, :, ::-1])
+        assert self._mesh is not None
+        image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb)
+        result = self._mesh.detect(image)
+        faces = getattr(result, "face_landmarks", None)
+        if not faces:
+            return
+        lm = faces[0]
+        # Inner-lip aperture over inter-ocular distance: scale-invariant.
+        aperture = abs(lm[13].y - lm[14].y)
+        ocular = ((lm[33].x - lm[263].x) ** 2 + (lm[33].y - lm[263].y) ** 2) ** 0.5
+        if ocular < 1e-6:
+            return
+        self.mouth.append((view.t_sec, float(aperture / ocular)))
+
+    def _on_frame_haar(self, view: Any) -> None:
+        import cv2
+
+        assert self._haar is not None  # subscribed only when available
+        gray = view.resized(
+            (640, max(2, int(640 * view.bgr.shape[0] / view.bgr.shape[1]))), gray=True
+        )
+        faces = self._haar.detectMultiScale(gray, 1.2, 4, minSize=(60, 60))
+        if len(faces) == 0:
+            self._prev.pop("mouth", None)
+            return
+        x, y, w, h = max(faces, key=lambda f: f[2] * f[3])
+        roi = gray[y + 2 * h // 3 : y + h, x : x + w]
+        if roi.size == 0:
+            return
+        roi = cv2.resize(roi, (64, 32), interpolation=cv2.INTER_AREA)
+        if "mouth" in self._prev:
+            self.mouth.append((view.t_sec, float(cv2.absdiff(self._prev["mouth"], roi).mean())))
+        self._prev["mouth"] = roi
+
+
+_FACE_MODEL_URL = (
+    "https://storage.googleapis.com/mediapipe-models/face_landmarker/"
+    "face_landmarker/float16/1/face_landmarker.task"
+)
+
+
+def _mediapipe_face_mesh() -> Any | None:
+    """FaceLandmarker via mediapipe's Tasks API, or None.
+
+    Recent mediapipe wheels (incl. all py3.11/arm64 builds installed here)
+    ship ONLY the Tasks API — the legacy `mp.solutions` FaceMesh is gone.
+    The landmark model (~3.7 MB) is not bundled; it downloads once into
+    ~/.cache/showwatcher. Defensive on every layer — a broken face backend
+    must degrade, not crash."""
+    try:
+        from pathlib import Path
+
+        from mediapipe.tasks.python import BaseOptions, vision
+
+        model = Path.home() / ".cache" / "showwatcher" / "face_landmarker.task"
+        if not model.exists():
+            import urllib.request
+
+            model.parent.mkdir(parents=True, exist_ok=True)
+            urllib.request.urlretrieve(_FACE_MODEL_URL, model)
+        options = vision.FaceLandmarkerOptions(
+            base_options=BaseOptions(model_asset_path=str(model)),
+            num_faces=1,
+        )
+        return vision.FaceLandmarker.create_from_options(options)
+    except Exception:
+        return None
+
+
+class SceneFrameService:
+    """Small color frames per scene (≤ MAX_PER_SCENE, spread across the scene)
+    for CLIP prompt-fit scoring — feeds `prompt_visual`.
+
+    Frames are stored at 256px width: scenes x 3 x 256x144x3 bytes is a few MB
+    for a normal short-form video, not a decode-buffer explosion.
+    """
+
+    spec = ServiceSpec("scene_frames", 1.0)
+    MAX_PER_SCENE = 3
+
+    def __init__(self, ctx: Context) -> None:
+        self.frames: dict[str, list[Any]] = {}
+        ctx.artifacts.scene_frames = self.frames
+        gt = ctx.ground_truth
+        self._bounds = (
+            [(s.id, s.start_sec, s.end_sec) for s in gt.scenes] if gt is not None else []
+        )
+
+    def on_frame(self, view: Any) -> None:
+        for sid, start, end in self._bounds:
+            if start <= view.t_sec < end:
+                bucket = self.frames.setdefault(sid, [])
+                # One frame per third of the scene, not the first N seconds.
+                slot = (end - start) / self.MAX_PER_SCENE
+                if len(bucket) < self.MAX_PER_SCENE and view.t_sec >= start + len(bucket) * slot:
+                    h = view.bgr.shape[0]
+                    w = view.bgr.shape[1]
+                    small = view.resized((256, max(2, int(256 * h / w))))
+                    bucket.append(small.copy())
+                return
+
+
+def _haar_face_backend() -> Any | None:
+    """Best-effort classic face detector. Returns None when unavailable."""
+    import cv2
+
+    if not hasattr(cv2, "CascadeClassifier"):
+        return None
+    try:
+        return cv2.CascadeClassifier(
+            cv2.data.haarcascades + "haarcascade_frontalface_default.xml"  # type: ignore[attr-defined]
+        )
+    except Exception:
+        return None
+
+
+def run_frame_services(
+    ctx: Context,
+    *,
+    want_visual: bool,
+    want_motion: bool,
+    want_energy: bool = False,
+    want_panes: bool = False,
+    want_mouth: bool = False,
+    want_scene_frames: bool = False,
+    want_caption_ocr: bool = False,
+    want_layout_ocr: bool = False,
+    want_objects: bool = False,
+    source: Any | None = None,
+) -> None:
+    """One decode serving every frame-consuming service the run selected.
+
+    The model-backed wants (caption_ocr/layout_ocr/objects) must only be set
+    when the engine has verified their extra is importable — constructing
+    those services imports easyocr/ultralytics."""
+    if not (
+        want_visual
+        or want_motion
+        or want_energy
+        or want_panes
+        or want_mouth
+        or want_scene_frames
+        or want_caption_ocr
+        or want_layout_ocr
+        or want_objects
+    ):
+        return
+
+    pipeline = FramePipeline(source or CvFrameSource(ctx.video_path))
+
+    if want_visual:
+        visual = VisualService(ctx)
+        pipeline.subscribe(visual.spec.name, visual.spec.fps, visual.on_frame)
+    if want_motion:
+        motion = MotionService(ctx)
+        pipeline.subscribe(motion.spec.name, motion.spec.fps, motion.on_frame)
+    if want_energy:
+        energy = EnergyService(ctx)
+        pipeline.subscribe(energy.spec.name, energy.spec.fps, energy.on_frame)
+    if want_panes:
+        panes = PaneService(ctx)
+        pipeline.subscribe(panes.spec.name, panes.spec.fps, panes.on_frame)
+    if want_mouth:
+        mouth = MouthService(ctx)
+        if mouth.available:
+            pipeline.subscribe(mouth.spec.name, mouth.spec.fps, mouth.on_frame)
+    if want_scene_frames:
+        scenes = SceneFrameService(ctx)
+        pipeline.subscribe(scenes.spec.name, scenes.spec.fps, scenes.on_frame)
+    if want_caption_ocr or want_layout_ocr or want_objects:
+        from video_studio.qc.services import model_services as ms
+
+        if want_caption_ocr:
+            cap = ms.CaptionOcrService(ctx)
+            pipeline.subscribe(cap.spec.name, cap.spec.fps, cap.on_frame)
+        if want_layout_ocr:
+            lay = ms.LayoutOcrService(ctx)
+            pipeline.subscribe(lay.spec.name, lay.spec.fps, lay.on_frame)
+        if want_objects:
+            obj = ms.ObjectService(ctx)
+            pipeline.subscribe(obj.spec.name, obj.spec.fps, obj.on_frame)
+
+    pipeline.run()

--- a/src/video_studio/qc/services/model_services.py
+++ b/src/video_studio/qc/services/model_services.py
@@ -1,0 +1,118 @@
+"""Model-backed frame services: OCR (easyocr) and object detection (YOLO)
+riding the SAME shared decode as the pure-CV services.
+
+This closes the last of the v1 self-decoding: caption_sync, layout, and
+objects are now pure functions over these artifacts. The model inference cost
+is unchanged (it always dominated); what's gone is their three extra
+sequential decodes of the video.
+
+Availability is decided by the ENGINE before subscribing (find_spec on the
+extra's module) so the detectors themselves never import model packages.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from video_studio.qc.context import Context
+from video_studio.qc.media.sampling import caption_band
+from video_studio.qc.services.frame_services import ServiceSpec
+
+CAPTION_OCR_FPS = 5.0  # caption_sync's v1 rate — band crop only, cheap-ish
+LAYOUT_OCR_FPS = 1.0  # layout's v1 rate — full frame
+OBJECTS_FPS = 1.0
+
+_reader: Any = None
+
+
+def get_ocr_reader() -> Any:
+    """Module-singleton easyocr reader (shared by both OCR streams)."""
+    global _reader
+    if _reader is None:
+        import easyocr
+
+        _reader = easyocr.Reader(["en"], verbose=False)
+    return _reader
+
+
+class CaptionOcrService:
+    """(t_ms, {normalized words on screen}) from the caption band — feeds
+    caption_sync. Confidence filter and normalization applied here so the
+    artifact is compact and the detector stays pure."""
+
+    spec = ServiceSpec("caption_ocr", CAPTION_OCR_FPS)
+    MIN_OCR_CONFIDENCE = 0.3
+
+    def __init__(self, ctx: Context) -> None:
+        from video_studio.qc.analysis.textmatch import normalize_word
+
+        self._normalize = normalize_word
+        gt = ctx.ground_truth
+        self._aspect = gt.aspect_ratio if gt else "9:16"
+        self.sightings: list[tuple[float, set[str]]] = []
+        ctx.artifacts.caption_sightings = self.sightings
+
+    def on_frame(self, view: Any) -> None:
+        crop, _y0 = caption_band(view.bgr, self._aspect)
+        words: set[str] = set()
+        for _bbox, text, conf in get_ocr_reader().readtext(crop):
+            if conf < self.MIN_OCR_CONFIDENCE:
+                continue
+            for token in str(text).split():
+                w = self._normalize(token)
+                if w:
+                    words.add(w)
+        self.sightings.append((view.t_sec * 1000.0, words))
+
+
+class LayoutOcrService:
+    """Full-frame OCR boxes per ~1s frame — feeds layout. The raw frame is
+    retained ONLY when an evidence dir is configured (annotated stills)."""
+
+    spec = ServiceSpec("layout_ocr", LAYOUT_OCR_FPS)
+
+    def __init__(self, ctx: Context) -> None:
+        self._keep_frames = ctx.evidence_dir is not None
+        self.samples: list[dict[str, Any]] = []
+        ctx.artifacts.ocr_boxes = self.samples
+
+    def on_frame(self, view: Any) -> None:
+        img = view.bgr
+        raw = [
+            (bbox, str(text), float(conf)) for bbox, text, conf in get_ocr_reader().readtext(img)
+        ]
+        self.samples.append(
+            {
+                "t_sec": view.t_sec,
+                "shape": (img.shape[0], img.shape[1]),
+                "results": raw,
+                "frame": img.copy() if self._keep_frames else None,
+            }
+        )
+
+
+class ObjectService:
+    """YOLOv8n class detections per ~1s frame — feeds objects."""
+
+    spec = ServiceSpec("objects", OBJECTS_FPS)
+    CONFIDENCE = 0.35
+
+    def __init__(self, ctx: Context) -> None:
+        from ultralytics import YOLO
+
+        self._model = YOLO("yolov8n.pt")
+        self._names = self._model.names
+        self.detections: list[tuple[float, set[str], int]] = []
+        ctx.artifacts.detections = self.detections
+
+    def on_frame(self, view: Any) -> None:
+        results = self._model.predict(view.bgr, conf=self.CONFIDENCE, verbose=False)
+        detected: set[str] = set()
+        persons = 0
+        for res in results:
+            for cls_id in res.boxes.cls.tolist():
+                cls_name = self._names[int(cls_id)]
+                detected.add(cls_name)
+                if cls_name == "person":
+                    persons += 1
+        self.detections.append((view.t_sec, detected, persons))


### PR DESCRIPTION
Groundwork for bringing the remaining detectors across one at a time.

The estimate I gave earlier — "a ~2,600-line reimplementation" — was wrong in a useful direction. The decode layer, report model, and detectors were never coupled to showrunner; **only the ground truth was**. So this is a port with one new seam.

## The seam

`ground_truth.py` replaces `showrunner/workdir.py`:

| showwatcher read | this reads |
|---|---|
| `plan.json` + `checkpoint_*.json` in a work_dir | `<project>/plan.json` |
| a generated Remotion token file | `storyboard.json` (size, palette) |
| `captions.ass` | `audio/<scene>.timings.json` |

Two of those fit better here than they did there. `timings.json` is *already* `{text, startMs, endMs}` per scene — which is a `CaptionWord` once the scene offset is folded in. And `load_palette` reads colours from the storyboard rather than a token file, because `styles.py` **expands** a preset into the storyboard rather than leaving a name to resolve at render time, making the storyboard the most truthful record of what the video should look like.

## Status: 11 of 18 detectors run

**Running:** container, black_freeze, visual, motion, av_sync, audio_sync, audio_quality, composition, lip_sync, transcript, prompt_fit.

**One extra away:** scene_sync (`scenedetect`, in the new `[qc]` extra), caption_sync + layout (`[qc-ocr]`), objects + entity_tracking (`[qc-yolo]`), prompt_visual (`[qc-clip]`). One extra per model, so no single install drags in all of them. `[all]` includes `[qc]` but deliberately not the model extras.

**Needs rewriting, not porting:** `timeline` — it resolves three clocks artifact-first from `concat.txt` / `captions.ass` / `Root.tsx`, none of which exist here. Next piece of work.

## Two bugs found while verifying

Both the same failure: **a check that reports success because it never ran.**

**The detector loader still named the old package** in an f-string, so every detector raised `ImportError('showwatcher')` — and the handler filed that as "you didn't install the model." The engine reported **zero findings on a video with a 1.2s black tail and 1.2s of duration drift**. It looked like a clean pass.

The loader fix is one line. The important change is the handler: treating *every* `ImportError` as a missing extra is what made a broken port indistinguishable from an uninstalled one. It now separates our own package's import failures from a user's absent model.

**Cut detection imported `scenedetect` unconditionally**, so one absent optional dependency took down the whole run — including the eleven detectors that need no models at all. Now gated like any other extra.

## Honesty in the output

`qc_analyze` reports which checks did *not* run and why:

```
11 detector(s) ran, 5 finding(s), 2 at error severity.
7 check(s) did NOT run for want of an extra: caption_sync (ocr), layout (ocr), ...
This reads the picture, not the point. Pull frames and look at them too.
```

A skip is not a pass, and "clean" and "clean as far as we looked" are different claims.

## Relationship to `qc_render.py`

They are deliberately different sizes. The bundled `qc_render.py` (in #13) needs no install and answers "does this file match its plan" from ffprobe plus one ffmpeg pass. This is the heavier gate that decodes frames. The bundled one stays the default because a gate that needs an install is a gate that gets skipped.

## Verification

Detects correctly on the fixtures that matter: a welded 1.2s black tail is reported at 5.00s alongside the drift it causes, and a matching render reports zero findings. Wheel builds; `verify-skills` passes.

> **Note:** #13 currently also contains this commit, since the work was done on that branch before being split out. Trimming it there needs a force-push — say the word and I'll do it, or merge #13 first and this rebases cleanly.