### PR TITLE
qc: the remaining detectors — all eighteen now run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,9 @@ qc = [
 # Model-backed QC, one extra per model so no single install drags in every one.
 # Each maps to detectors the engine skips cleanly when the extra is absent.
 qc-ocr = ["video-studio-engine[qc]", "easyocr>=1.7"]        # caption_sync, layout
-qc-yolo = ["video-studio-engine[qc]", "ultralytics>=8.2"]   # objects, entity_tracking
+qc-yolo = ["video-studio-engine[qc]", "ultralytics>=8.2", "supervision>=0.22"]
+  # objects (YOLO detections) and entity_tracking (those detections through
+  # ByteTrack, which is supervision — without it entity_tracking alone skips)
 qc-face = ["video-studio-engine[qc]", "mediapipe>=0.10"]    # lip_sync's real backend
 qc-clip = ["video-studio-engine[qc]", "fastembed>=0.3"]     # prompt_visual
 

--- a/src/video_studio/qc/detectors/audio_sync.py
+++ b/src/video_studio/qc/detectors/audio_sync.py
@@ -39,6 +39,24 @@ def run(ctx: Context) -> None:
         )
         return
 
+    # The rendered file may carry no audio at all — a titled-video or a stock
+    # supercut with no voiceover is a legitimate output here, where in
+    # showrunner every render had narration welded in. Reaching for the mix
+    # envelope in that case runs `ffmpeg -map 0:a:0` against a video with no
+    # audio stream, which exits 234 and took the whole detector down as a
+    # crash. Say what is true instead, the way av_sync already does.
+    if ctx.video.audio is None:
+        r.add(
+            Finding(
+                "audio_sync",
+                "NO_AUDIO_STREAM",
+                "info",
+                "Rendered video has no audio stream, so per-scene narration cannot "
+                "be aligned against the mix — audio sync analysis skipped",
+            )
+        )
+        return
+
     mix_env = ctx.audio.envelope
     offsets: dict[str, float] = {}
 

--- a/src/video_studio/qc/detectors/caption_sync.py
+++ b/src/video_studio/qc/detectors/caption_sync.py
@@ -1,4 +1,4 @@
-"""On-screen caption timing vs captions/*.json ground truth. [ocr]
+"""On-screen caption timing vs audio/<scene>.timings.json ground truth. [ocr]
 
 v1 port, now PURE over Artifacts.caption_sightings — the OCR pass rides the
 shared decode (services.model_services.CaptionOcrService, 5 fps caption-band
@@ -32,7 +32,9 @@ def run(ctx: Context) -> None:
                 "caption_sync",
                 "NO_CAPTION_DATA",
                 "info",
-                "No captions/*.json in the workdir (captions disabled?) — caption sync skipped",
+                "No audio/<scene>.timings.json in the project — narration was never "
+                "synthesised or transcribed, so there is nothing to compare the "
+                "on-screen words against",
             )
         )
         return

--- a/src/video_studio/qc/detectors/objects.py
+++ b/src/video_studio/qc/detectors/objects.py
@@ -16,7 +16,7 @@ from video_studio.qc.report.model import Finding
 
 SAMPLE_FPS = 1.0
 CONFIDENCE = 0.35
-FOOTAGE_FORMATS = {"ai-video", "composite"}
+FOOTAGE_FORMATS = {"ai-video", "composite", "video-studio-footage"}
 
 # prompt keyword (regex, word-boundary) -> COCO class name
 KEYWORD_CLASSES: list[tuple[str, str]] = [

--- a/src/video_studio/qc/detectors/timeline.py
+++ b/src/video_studio/qc/detectors/timeline.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from video_studio.qc.context import Context
 from video_studio.qc.report import ids
 from video_studio.qc.report.model import Finding
-from video_studio.qc.showrunner.timeline import (
+from video_studio.qc.timelines import (
     CLOCK_SKEW_ERROR_SEC,
     detect_generation,
     resolve_timelines,
@@ -59,11 +59,43 @@ def run(ctx: Context) -> None:
                     f"The visual and audio timelines diverge by {skew:.2f}s at scene "
                     f"'{scene_id}' (video clock ends {video_end:.2f}s, audio clock "
                     f"{audio_end:.2f}s) — narration and visuals are built on different "
-                    "clocks and drift apart scene by scene. Detected from the workdir's own "
-                    "concat manifests, before any video decoding.",
+                    "clocks and drift apart scene by scene. Detected from plan.json and "
+                    "the measured narration WAVs, before any video decoding.",
                     scene_id=scene_id,
                     metrics={
                         "maxSkewSec": round(skew, 3),
+                        "videoClockSec": round(video_end, 3),
+                        "audioClockSec": round(audio_end, 3),
+                    },
+                    rubric_dimension="audio",
+                )
+            )
+
+    # Start-skew is blind to the final scene: a scene that overruns its plan
+    # pushes every LATER scene late, and the last one has nothing after it to
+    # push. A two-scene video whose second scene runs two seconds long therefore
+    # scores a perfect zero skew while the narration outlasts the picture. So
+    # compare the totals too, and only when the per-scene check stayed quiet —
+    # otherwise the same drift is reported twice.
+    if timelines.video and timelines.audio:
+        video_end = timelines.video[-1].end_sec
+        audio_end = timelines.audio[-1].end_sec
+        total_gap = abs(video_end - audio_end)
+        already_reported = worst is not None and worst[1] > CLOCK_SKEW_ERROR_SEC
+        if total_gap > CLOCK_SKEW_ERROR_SEC and not already_reported:
+            longer = "narration" if audio_end > video_end else "picture"
+            r.add(
+                Finding(
+                    "timeline",
+                    "TIMELINE_TOTAL_MISMATCH",
+                    "error",
+                    f"The visual timeline runs {video_end:.2f}s and the narration "
+                    f"{audio_end:.2f}s — a {total_gap:.2f}s gap, with the {longer} "
+                    f"outlasting the other. Every scene starts where the plan says, so "
+                    f"the drift is all in the last one: re-run build_props so the plan "
+                    f"picks up the measured audio.",
+                    metrics={
+                        "totalGapSec": round(total_gap, 3),
                         "videoClockSec": round(video_end, 3),
                         "audioClockSec": round(audio_end, 3),
                     },

--- a/src/video_studio/qc/ground_truth.py
+++ b/src/video_studio/qc/ground_truth.py
@@ -130,6 +130,42 @@ def _aspect(width: int, height: int) -> str:
     return f"{width // g}:{height // g}"
 
 
+#: Layer source prefixes that put real or generated footage on screen. A
+#: `prompt:` clip counts: a generated shot of a person still contains a person,
+#: which is what the object detectors are looking for.
+_FOOTAGE_PREFIXES = ("file:", "find:", "url:", "prompt:")
+
+#: What this repo calls its two shapes. showwatcher's vocabulary was
+#: showrunner's format plugins ("ai-video", "faceless-explainer"); reusing those
+#: names here would be a lie that happens to work, so the detector-side sets
+#: were widened to accept these instead.
+FOOTAGE_FORMAT = "video-studio-footage"
+GRAPHICS_FORMAT = "video-studio-graphics"
+
+
+def _infer_format(storyboard: dict) -> str:
+    """Footage-bearing, or motion graphics?
+
+    Four separate behaviours hang off this — whether object and entity
+    detection run at all, how tolerant the cut check is, which blur threshold
+    applies, and whether frames are measured against the style palette. A
+    project here can be either kind, unlike a showrunner format which was fixed
+    when the video was created, so it has to be read off the storyboard.
+
+    The rule: any layer that names a footage source makes the whole video
+    footage. Cards, effects and drawn marks alone make it graphics. A video
+    that mixes them is treated as footage, because a wrong "no footage here"
+    silently disables the object checks, while a wrong "footage" only costs a
+    detection pass that finds nothing.
+    """
+    for scene in storyboard.get("scenes") or []:
+        for layer in scene.get("layers") or []:
+            source = str(layer.get("source", ""))
+            if source.startswith(_FOOTAGE_PREFIXES):
+                return FOOTAGE_FORMAT
+    return GRAPHICS_FORMAT
+
+
 def load_ground_truth(project: str | Path) -> GroundTruth:
     """Build a GroundTruth from a video_studio project directory."""
     root = Path(project)
@@ -193,10 +229,7 @@ def load_ground_truth(project: str | Path) -> GroundTruth:
 
     return GroundTruth(
         workdir=root,
-        # video_studio has no pluggable "format" the way showrunner did; the
-        # storyboard's own name is the closest true answer, and detectors that
-        # branch on format treat an unknown one as "no format-specific rule".
-        format=str(storyboard.get("format", "video-studio")),
+        format=_infer_format(storyboard),
         aspect_ratio=_aspect(width or 0, height or 0),
         style=storyboard.get("styleApplied") or storyboard.get("style"),
         topic=plan.get("title") or storyboard.get("title"),

--- a/src/video_studio/qc/services/frame_services.py
+++ b/src/video_studio/qc/services/frame_services.py
@@ -47,7 +47,7 @@ class VisualService:
         self._np = np
         gt = ctx.ground_truth
         fmt = gt.format if gt else None
-        graphics = fmt in {"faceless-explainer", "manim-explainer"}
+        graphics = fmt in {"faceless-explainer", "manim-explainer", "video-studio-graphics"}
         self.palette = load_palette(gt.workdir) if (gt and graphics) else None
         self.stats = FrameStats(palette_checked=self.palette is not None)
         ctx.artifacts.frame_stats = self.stats

--- a/src/video_studio/qc/timelines.py
+++ b/src/video_studio/qc/timelines.py
@@ -1,0 +1,185 @@
+"""Three clocks, never one.
+
+Ported in spirit from showwatcher's `showrunner/timeline.py`, which resolved a
+video, audio and caption timeline independently and treated their disagreement
+as the signal. The idea survives the move; the artifacts do not. That module
+read `concat.txt`, `_audio_concat.txt`, `captions.ass` and `Root.tsx` — files
+showrunner wrote and this repo has never heard of.
+
+The three clocks here:
+
+  video    `plan.json` scene durations — the composition timeline, what
+           build_props told the renderer each scene would occupy.
+  audio    the MEASURED length of `audio/<scene>.wav`, via ffprobe.
+  caption  the last word to leave the screen in `audio/<scene>.timings.json`.
+
+Why comparing plan against audio is not circular, given build_props sets each
+scene's duration FROM the measured WAV: because they can fall out of step
+afterwards, and nothing else notices. Re-synthesise one scene's narration
+without re-running build_props and the plan still claims the old length; edit a
+duration by hand and the audio disagrees. In both cases the render is built on
+one clock and the narration on another, and every scene after the divergence
+inherits it. That is the failure this catches, and it is invisible to a check
+that only ever consults one timeline.
+
+A clock with no artifact behind it stays empty rather than being guessed at —
+an absent WAV means "no audio clock", not "an audio clock of zero".
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from video_studio.qc.ground_truth import GroundTruth
+
+#: Video/audio divergence past this is a real desync, not rounding.
+CLOCK_SKEW_ERROR_SEC = 0.25
+
+
+@dataclass(frozen=True)
+class ClockSpan:
+    scene_id: str
+    start_sec: float
+    end_sec: float
+    source: str  # "plan" | "audio_probe" | "timings"
+
+    @property
+    def duration_sec(self) -> float:
+        return self.end_sec - self.start_sec
+
+
+@dataclass
+class TimelineSet:
+    video: list[ClockSpan] = field(default_factory=list)
+    audio: list[ClockSpan] = field(default_factory=list)
+    caption: list[ClockSpan] = field(default_factory=list)
+
+    def max_clock_skew(self) -> tuple[str, float] | None:
+        """Largest |video start - audio start| across scenes present in both."""
+        audio_by_id = {s.scene_id: s for s in self.audio}
+        worst: tuple[str, float] | None = None
+        for vs in self.video:
+            a = audio_by_id.get(vs.scene_id)
+            if a is None:
+                continue
+            skew = abs(vs.start_sec - a.start_sec)
+            if worst is None or skew > worst[1]:
+                worst = (vs.scene_id, skew)
+        return worst
+
+
+_probe_cache: dict[str, float | None] = {}
+
+
+def probe_duration(path: Path) -> float | None:
+    """Measured duration in seconds, or None. Cached — the same WAV is asked
+    about once per clock and there may be dozens of scenes."""
+    key = str(path)
+    if key in _probe_cache:
+        return _probe_cache[key]
+    value: float | None = None
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=noprint_wrappers=1:nokey=1", key],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        value = float(out)
+    except (OSError, subprocess.CalledProcessError, ValueError):
+        value = None
+    _probe_cache[key] = value
+    return value
+
+
+def clear_probe_cache() -> None:
+    _probe_cache.clear()
+
+
+def _cumulative(ids_durations: list[tuple[str, float]], source: str) -> list[ClockSpan]:
+    """Lay durations end to end. The running total is the authority, matching
+    how build_props snaps scene boundaries — rounding each span on its own is
+    how a timeline drifts a frame per scene."""
+    spans: list[ClockSpan] = []
+    cursor = 0.0
+    for scene_id, duration in ids_durations:
+        start, end = cursor, cursor + duration
+        cursor = end
+        spans.append(ClockSpan(scene_id, start, end, source))
+    return spans
+
+
+def _plan_video_clock(gt: GroundTruth) -> list[ClockSpan]:
+    """The composition timeline, straight off the plan."""
+    return [ClockSpan(s.id, s.start_sec, s.end_sec, "plan") for s in gt.scenes]
+
+
+def _wav_audio_clock(gt: GroundTruth) -> list[ClockSpan]:
+    """Measured narration, scene by scene.
+
+    Returns empty unless EVERY scene has a readable WAV: a partial audio clock
+    would put later scenes at the wrong offset and manufacture a skew that is
+    an artefact of the missing file, not of the video.
+    """
+    measured: list[tuple[str, float]] = []
+    for scene in gt.scenes:
+        wav = gt.scene_wav(scene.id)
+        if wav is None:
+            return []
+        duration = probe_duration(wav)
+        if duration is None:
+            return []
+        measured.append((scene.id, duration))
+    return _cumulative(measured, "audio_probe")
+
+
+def _timings_caption_clock(gt: GroundTruth) -> list[ClockSpan]:
+    """When each scene's captions actually start and stop.
+
+    Built from the words themselves rather than from scene boundaries, so a
+    scene whose captions run past its own end is visible as an overlap.
+    """
+    by_scene: dict[str, list] = {}
+    for word in gt.caption_words:
+        by_scene.setdefault(word.scene_id, []).append(word)
+    spans: list[ClockSpan] = []
+    for scene in gt.scenes:
+        words = by_scene.get(scene.id)
+        if not words:
+            continue
+        spans.append(ClockSpan(
+            scene.id,
+            min(w.start_ms for w in words) / 1000.0,
+            max(w.end_ms for w in words) / 1000.0,
+            "timings",
+        ))
+    return spans
+
+
+def resolve_timelines(gt: GroundTruth) -> TimelineSet:
+    """Artifact-first clock resolution; an empty clock means no artifact."""
+    return TimelineSet(
+        video=_plan_video_clock(gt),
+        audio=_wav_audio_clock(gt),
+        caption=_timings_caption_clock(gt),
+    )
+
+
+def detect_generation(gt: GroundTruth) -> str:
+    """showrunner had two work_dir generations — plan-sized and audio-sized —
+    and an auto-fix editing a scene duration was a no-op on one of them. This
+    repo has one shape, so there is nothing to branch on."""
+    return "n/a"
+
+
+__all__ = [
+    "CLOCK_SKEW_ERROR_SEC",
+    "ClockSpan",
+    "TimelineSet",
+    "clear_probe_cache",
+    "detect_generation",
+    "probe_duration",
+    "resolve_timelines",
+]


### PR DESCRIPTION
Follows #14. Every detector now runs against a video_studio project, each verified against a fixture built to trigger it rather than assumed working because it imported.

## `timeline` — the one true rewrite

showwatcher resolved its three clocks artifact-first from `concat.txt`, `_audio_concat.txt`, `captions.ass`, `Root.tsx`. None of those exist here. `timelines.py` resolves them from what this repo writes: **video** from `plan.json` durations, **audio** from the measured length of `audio/<scene>.wav`, **caption** from `audio/<scene>.timings.json`.

Comparing plan against audio isn't circular even though `build_props` sets durations *from* the measured WAV — because they fall out of step afterwards and nothing else notices. Re-synthesise one scene without re-running `build_props`, and the render is built on one clock while narration runs on another; every later scene inherits it.

**Testing found a hole in the check itself, not just the port.** Skew is measured between scene *start* times, so a scene overrunning its plan pushes every *later* scene late — and the last scene has nothing after it to push. A two-scene video whose second scene ran 2s long scored a perfect zero skew while the narration outlasted the picture. It now compares total clock lengths too, and only when the per-scene check stayed quiet, so one drift is never reported twice.

## Format inference unlocked the model-backed detectors

Four behaviours hang off `gt.format`: whether object/entity detection run, cut tolerance, blur threshold, and whether frames are checked against the style palette. showrunner fixed its format at creation; a project here can be either kind, so it's read off the storyboard — any layer naming a footage source makes it footage, cards and effects alone make it graphics. Mixed counts as footage, because a wrong "no footage" silently disables the object checks while a wrong "footage" only costs a pass that finds nothing.

Before this, every project reported `format: "video-studio"`, which is in no `FOOTAGE_FORMATS` set — so `objects` and `entity_tracking` self-skipped as "motion graphics, not footage" on videos full of footage.

## Three bugs, all found by fixtures

**`audio_sync` crashed on any render with no audio stream.** It reached for the mix envelope unguarded, running `ffmpeg -map 0:a:0` against a video with no audio — exit 234, detector down. In showrunner every render had narration welded in; here a `titled-video` or stock supercut with no voiceover is legitimate output.

**`entity_tracking` needs `supervision`** for ByteTrack, which `qc-yolo` didn't declare — so it would have skipped for anyone installing that extra expecting both YOLO detectors.

**`caption_sync`'s message named showrunner's `captions/*.json`.** It reads `gt.caption_words`, which this repo fills from `timings.json` — the logic was right, only the wording lied.

## Verification

| detector | fixture | result |
|---|---|---|
| `timeline` | drift in first of three / last of two / matching / missing WAV | reports at the pushed scene, as a total mismatch, silent, silent |
| `scene_sync` | cuts at 1.0s & 3.5s vs plan 2.0s & 4.0s | per-scene drift **and** the ~500ms/scene cumulative pattern |
| `objects`, `entity_tracking` | plan names dog/person/bicycle, render is colour bars | all reported absent |
| `caption_sync`, `layout` | OCR over a real burnt-caption video | 400ms median offset vs timings |
| `prompt_visual` | CLIP, each scene vs its own prompt | scene 'b' matches 'c's prompt better |

Matching inputs stay silent in every case. **18/18 run; the only skip is `face`** — a service, not a detector.

## Deliberately not installed

`mediapipe` (`qc-face`). showwatcher's own notes call it a footgun: it drags in `opencv-contrib-python`, a second `cv2` provider, which is why that project excluded it from `all` too. `lip_sync` runs without it on the degraded backend and says so.