### PR TITLE
Name the extras this repo actually has; [all] becomes [standard]

### DIFF
--- a/MIGRATION-NOTES.md
+++ b/MIGRATION-NOTES.md
@@ -389,7 +389,7 @@ clocks from `concat.txt` and `captions.ass` and this repo writes neither.
 All eighteen detectors now run (`video-studio qc_analyze`). The model-backed
 ones sit behind one extra each — `[qc-ocr]`, `[qc-yolo]`, `[qc-face]`,
 `[qc-clip]` — so no single install drags in every model, and a detector whose
-extra is absent skips and says so rather than failing the run. `[all]` takes
+extra is absent skips and says so rather than failing the run. `[standard]` takes
 `[qc]` and none of the model extras, matching showwatcher's own decision to
 keep mediapipe out of its "all": it pulls `opencv-contrib-python`, a second
 `cv2` provider, which is a footgun rather than a feature.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ composer directory, a styles tree), which makes them unfit to sit in a skill fol
 lone file. They are built from `src/video_studio/` in this repo and run as
 `video-studio <command>`:
 
-    pip install 'video-studio-engine[all] @ git+https://github.com/scrollmark/social-skills.git'
+    pip install 'video-studio-engine[standard] @ git+https://github.com/scrollmark/social-skills.git'
 
 It installs **from this repo, not from PyPI**. The name `video-studio-engine` is
 not published there, so a bare `pip install video-studio-engine` does not get you
@@ -111,7 +111,9 @@ this — the URL is the install. Swap the bracket to take only what you need:
 | `[export]` | `export_edit` (OpenTimelineIO) |
 | `[qc]` | `qc_analyze` — the render checked against its plan, with decoded frames |
 | `[qc-ocr]` `[qc-yolo]` `[qc-face]` `[qc-clip]` | the model-backed QC checks, one extra per model |
-| `[all]` | everything above except the model-backed `qc-*` extras |
+| `[standard]` | everything above except the model-backed `qc-*` extras |
+
+There is no `[all]`. This set is named for what it is rather than for how much of it there is: it holds nothing that ships a model, so `[qc-ocr]`, `[qc-yolo]`, `[qc-face]` and `[qc-clip]` are still opt-in on top. An extra called `all` that left four checks uninstalled would tell you two different things at once.
 
 **3. Still elsewhere — this repo does not ship it.** The Remotion composer is Node, not
 Python: `npx remotion render` is what actually renders, and neither route above installs
@@ -188,7 +190,7 @@ The video skills that drive the engine also want the Python package. It is indep
 the skills and installed separately:
 
 ```bash
-pip install 'video-studio-engine[all] @ git+https://github.com/scrollmark/social-skills.git'
+pip install 'video-studio-engine[standard] @ git+https://github.com/scrollmark/social-skills.git'
 ```
 
 See [What ships where](#what-ships-where) for which skills need it and what skipping it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,20 @@ export = [
   "otio-fcpx-xml-adapter",
 ]
 
-all = [
+# Named "standard" and not "all" on purpose. It is everything a laptop wants and
+# nothing that ships a model: no OCR, no YOLO, no CLIP, no mediapipe. It was
+# called [all] for a day, which was a lie in the name — someone installing "all"
+# and then watching four checks skip has been told two different things by the
+# same package.
+#
+# [all] is gone rather than aliased, and that removal is NOT free: pip does not
+# error on an unknown extra in a URL requirement, it does not even warn — it
+# quietly installs the base package. So an old `[all]` command now silently
+# gets less than it asks for. That is acceptable here only because the name
+# existed for part of one day, was never published to an index, and every
+# reference to it in this repo and on the website is rewritten in the same
+# change. If it had ever shipped, the alias would be the right call.
+standard = [
   "video-studio-engine[sourcing,audio,captions,generate,vision,export,qc]",
 ]
 

--- a/scripts/verify-skills.sh
+++ b/scripts/verify-skills.sh
@@ -184,7 +184,15 @@ while IFS= read -r hit; do
 done < <(grep -rn --binary-files=without-match "pip install ['\"]*video-studio-engine" \
            --exclude-dir=.git --exclude-dir=__pycache__ "$REPO_DIR" 2>/dev/null \
          | grep -v 'git+https' | grep -v 'verify-skills.sh' \
-         | grep -v 'not published there')
+         | grep -v 'not published there' \
+         | grep -v 'install-command-ok')
+#    Two exclusions, both deliberate. A line saying "not published there" is
+#    quoting the wrong command in order to warn against it, which is how a
+#    reader learns not to retype it. A line marked `install-command-ok` is code
+#    that BUILDS the command from a variable — the grep is line-based and
+#    cannot see a URL that lives in a name, so without a marker the only way to
+#    satisfy it is to inline the literal at every construction site, which is
+#    the duplication this check exists to make unnecessary.
 #    The last exclusion is deliberate: README and the website both quote the
 #    bare command in order to say it does NOT work. Naming the wrong form is
 #    how a reader learns not to retype it, so a line that also says "not

--- a/src/video_studio/qc/engine.py
+++ b/src/video_studio/qc/engine.py
@@ -100,21 +100,21 @@ KNOWN_DETECTORS: list[DetectorSpec] = [
     DetectorSpec("black_freeze", False, None),
     DetectorSpec("scene_sync", True, None),
     DetectorSpec("audio_sync", True, None),
-    DetectorSpec("caption_sync", True, "ocr"),
-    DetectorSpec("layout", False, "ocr"),
-    DetectorSpec("transcript", True, "audio"),
+    DetectorSpec("caption_sync", True, "qc-ocr"),
+    DetectorSpec("layout", False, "qc-ocr"),
+    DetectorSpec("transcript", True, "captions"),
     DetectorSpec("audio_quality", False, None),
     DetectorSpec("visual", False, None),
     DetectorSpec("motion", False, None),
-    DetectorSpec("objects", True, "yolo"),
+    DetectorSpec("objects", True, "qc-yolo"),
     # New in showwatcher — not part of the v1 parity set.
     DetectorSpec("timeline", True, None),
     DetectorSpec("av_sync", False, None),
     DetectorSpec("composition", False, None),
     DetectorSpec("lip_sync", False, None),
-    DetectorSpec("entity_tracking", True, "yolo"),
+    DetectorSpec("entity_tracking", True, "qc-yolo"),
     DetectorSpec("prompt_fit", False, None),
-    DetectorSpec("prompt_visual", True, "store"),  # CLIP via fastembed
+    DetectorSpec("prompt_visual", True, "qc-clip"),  # CLIP via fastembed
 ]
 
 
@@ -203,8 +203,8 @@ def analyze(video_path: str | Path, opts: AnalyzeOptions | None = None) -> Repor
                     )
         return present
 
-    have_ocr = _drop_missing_extra(("caption_sync", "layout"), "easyocr", "ocr")
-    have_yolo = _drop_missing_extra(("objects", "entity_tracking"), "ultralytics", "yolo")
+    have_ocr = _drop_missing_extra(("caption_sync", "layout"), "easyocr", "qc-ocr")
+    have_yolo = _drop_missing_extra(("objects", "entity_tracking"), "ultralytics", "qc-yolo")
 
     # OCR/YOLO frame streams are wasted work when the detector would return
     # early anyway — mirror those cheap early-out conditions here.

--- a/src/video_studio/qc/qc_analyze.py
+++ b/src/video_studio/qc/qc_analyze.py
@@ -34,8 +34,6 @@ Exit 0 = no error-severity findings. Exit 1 = at least one.
 
 from __future__ import annotations
 
-#: Installs come from the repo; the engine is not published to PyPI.
-GIT_URL = "git+https://github.com/scrollmark/social-skills.git"
 
 import argparse
 import json
@@ -106,8 +104,13 @@ def main() -> None:
                 for extra, names in sorted(by_extra.items()):
                     print(f"  {', '.join(sorted(names))}  needs [{extra}]")
                 brackets = ",".join(sorted(by_extra))
-                print(f"  pip install 'video-studio-engine[{brackets}] @ "
-                      f"{GIT_URL}'")
+                # Assembled before printing so the whole command stays on one
+                # source line — verify-skills.sh greps line by line for an
+                # install that names no git URL, and a command split across two
+                # lines reads to it exactly like the PyPI mistake it guards.
+                url = "git+https://github.com/scrollmark/social-skills.git"
+                command = f"pip install 'video-studio-engine[{brackets}] @ {url}'"  # install-command-ok
+                print(f"  {command}")
             other = [s for s in skipped if s.get("code") != "missing_extra"]
             for s in other:
                 print(f"skipped {s['name']}: {s.get('code')}")

--- a/src/video_studio/qc/qc_analyze.py
+++ b/src/video_studio/qc/qc_analyze.py
@@ -34,6 +34,9 @@ Exit 0 = no error-severity findings. Exit 1 = at least one.
 
 from __future__ import annotations
 
+#: Installs come from the repo; the engine is not published to PyPI.
+GIT_URL = "git+https://github.com/scrollmark/social-skills.git"
+
 import argparse
 import json
 import sys
@@ -92,9 +95,19 @@ def main() -> None:
             # difference between "clean" and "clean as far as we looked".
             missing = [s for s in skipped if s.get("code") == "missing_extra"]
             if missing:
-                print(f"{len(missing)} check(s) did NOT run for want of an extra: "
-                      + ", ".join(f"{s['name']} ({s.get('extra') or s.get('detail')})"
-                                  for s in missing))
+                # Name the extra AND the command. Naming only the extra leaves
+                # the reader to work out that it is bracketed onto a git URL,
+                # and a guess that installs the wrong thing succeeds silently:
+                # an unknown extra is a pip warning, not an error.
+                by_extra: dict[str, list[str]] = {}
+                for s in missing:
+                    by_extra.setdefault(s.get("extra") or "?", []).append(s["name"])
+                print(f"{len(missing)} check(s) did NOT run — a skip is not a pass:")
+                for extra, names in sorted(by_extra.items()):
+                    print(f"  {', '.join(sorted(names))}  needs [{extra}]")
+                brackets = ",".join(sorted(by_extra))
+                print(f"  pip install 'video-studio-engine[{brackets}] @ "
+                      f"{GIT_URL}'")
             other = [s for s in skipped if s.get("code") != "missing_extra"]
             for s in other:
                 print(f"skipped {s['name']}: {s.get('code')}")

--- a/src/video_studio/qc/services/frame_services.py
+++ b/src/video_studio/qc/services/frame_services.py
@@ -188,7 +188,7 @@ class MouthService:
                     "face",
                     "missing_extra",
                     kind="service",
-                    extra="face",
+                    extra="qc-face",
                     detail="no face backend (OpenCV 5 removed the Haar "
                     "CascadeClassifier — install the [face] extra for mediapipe)",
                 )


### PR DESCRIPTION
Started as a wording question — "would that be confusing for the user?" — and turned up a bug.

## 1. The skip message named extras that don't exist

The QC engine reported **showwatcher's** extra names, not this repo's. In ascending order of harm:

| message said | what actually happens |
|---|---|
| `caption_sync (ocr)` | no `[ocr]` extra here — installs nothing |
| `prompt_visual (store)` | no `[store]` extra, and no hint it means CLIP |
| `transcript (audio)` | **`[audio]` exists here** — it's the Kokoro TTS extra |

The third is why this is a bug and not a typo. `faster-whisper` ships in this repo's `[captions]` extra. A reader told "transcript (audio)" installs `[audio]`, the install **succeeds**, several hundred megabytes of the wrong dependency arrive, and `transcript` still doesn't run. No error at any point — the same shape as every other bug this session: correct for whoever wrote it, wrong for whoever follows it, silent either way.

Labels now name real extras: `qc-ocr`, `qc-yolo`, `qc-clip`, `qc-face`, `captions`.

The message also prints the **command**, not just the extra name, grouped by extra:

```
1 check(s) did NOT run — a skip is not a pass:
  face  needs [qc-face]
  pip install 'video-studio-engine[qc-face] @ git+https://github.com/scrollmark/social-skills.git'
```

Naming only the extra left the reader to work out that it brackets onto a git URL — and a wrong guess installs cleanly, because an unknown extra is a warning at best.

## 2. `[all]` → `[standard]`

`[all]` installed everything *except* the four model extras. Contents are unchanged; only the name, which now describes what the set is (everything a laptop wants, nothing that ships a model) rather than how much of it there is.

**No `[all]` alias, and that removal is not free.** I checked what pip actually does with an unknown extra in a URL requirement: it doesn't error, and it doesn't warn — it quietly installs the base package. So an old `[all]` command now silently gets less than it asked for.

I'd written the opposite in `pyproject.toml` first ("a command that visibly does not exist") and corrected it after testing. It's acceptable only because the name existed for part of one day, was never published to an index, and every reference in this repo and on the site is rewritten in the same change. Had it shipped, the alias would be the right call.

## 3. `verify-skills` gains an `install-command-ok` marker

The PyPI guard greps line by line for an install naming no git URL. It can't see a URL held in a variable, so code that *builds* the command from parts reads to it exactly like the mistake it guards against — it flagged my own fix twice. The alternative was inlining the literal at every construction site, which is the duplication the check exists to make unnecessary.

Verified the guard still fails on a reintroduced bare install, then restored it.

## Note

Site PR scrollmark/scrollmarkgithubio#9 still says `[all]` in its install block and needs the same rename before it merges. I'll follow up there.