### PR TITLE
One cv2 provider, and a rationale that survives checking

### DIFF
--- a/MIGRATION-NOTES.md
+++ b/MIGRATION-NOTES.md
@@ -389,10 +389,23 @@ clocks from `concat.txt` and `captions.ass` and this repo writes neither.
 All eighteen detectors now run (`video-studio qc_analyze`). The model-backed
 ones sit behind one extra each — `[qc-ocr]`, `[qc-yolo]`, `[qc-face]`,
 `[qc-clip]` — so no single install drags in every model, and a detector whose
-extra is absent skips and says so rather than failing the run. `[standard]` takes
-`[qc]` and none of the model extras, matching showwatcher's own decision to
-keep mediapipe out of its "all": it pulls `opencv-contrib-python`, a second
-`cv2` provider, which is a footgun rather than a feature.
+extra is absent skips and says so rather than failing the run. `[standard]`
+takes `[qc]` and none of the model extras.
+
+That last part came with a rationale that did not survive checking. It was
+written as "mediapipe is kept out because it pulls `opencv-contrib-python`, a
+second `cv2` provider" — borrowed from showwatcher, where it was true. Here it
+was not: `[standard]` includes `[vision]`, `[vision]` requires mediapipe, and
+mediapipe requires contrib, so the thing supposedly being kept out arrived
+anyway. Worse, `[vision]` also named `opencv-python` and `[qc]` named
+`opencv-python-headless`, putting THREE providers of the same `cv2` module in
+the default install with the winner decided by installation order.
+
+Resolved by naming one distribution everywhere: `[qc]` takes
+`opencv-contrib-python`, the same one mediapipe forces, and `[vision]` names no
+opencv at all. `[qc-face]` still exists and still matters — it is what makes
+`lip_sync` work for someone who installed `[qc]` without `[vision]` — but it is
+not a quarantine, and the notes no longer claim it is.
 
 ### What step 8 actually needed
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ this — the URL is the install. Swap the bracket to take only what you need:
 | `[qc-ocr]` `[qc-yolo]` `[qc-face]` `[qc-clip]` | the model-backed QC checks, one extra per model |
 | `[standard]` | everything above except the model-backed `qc-*` extras |
 
-There is no `[all]`. This set is named for what it is rather than for how much of it there is: it holds nothing that ships a model, so `[qc-ocr]`, `[qc-yolo]`, `[qc-face]` and `[qc-clip]` are still opt-in on top. An extra called `all` that left four checks uninstalled would tell you two different things at once.
+There is no `[all]`. This set is named for what it is rather than for how much of it there is, because an extra called `all` that left four checks uninstalled would tell you two different things at once. What `[standard]` leaves out is the four model-backed QC extras — `[qc-ocr]`, `[qc-yolo]`, `[qc-face]`, `[qc-clip]` — which are opt-in on top. It is not model-free: `[vision]` requires mediapipe for hand tracking, so that one arrives either way.
 
 **3. Still elsewhere — this repo does not ship it.** The Remotion composer is Node, not
 Python: `npx remotion render` is what actually renders, and neither route above installs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,13 @@ audio = [
 # stays installable on a laptop.
 qc = [
   "numpy>=1.26",
-  "opencv-python-headless>=4.9",
+  # opencv-contrib-python, not -headless and not plain opencv-python. All three
+  # ship a module called cv2; installing more than one leaves whichever landed
+  # last in charge, which is not a thing pip resolves or warns about. mediapipe
+  # hard-requires opencv-contrib-python, and [vision] hard-requires mediapipe,
+  # so contrib is already present in any environment that has [vision]. Naming
+  # the same distribution here is what keeps [standard] down to one provider.
+  "opencv-contrib-python>=4.9",
   "scenedetect>=0.6.4",
   "rapidfuzz>=3.9",
   "scipy>=1.14,<1.18",
@@ -68,7 +74,11 @@ qc-ocr = ["video-studio-engine[qc]", "easyocr>=1.7"]        # caption_sync, layo
 qc-yolo = ["video-studio-engine[qc]", "ultralytics>=8.2", "supervision>=0.22"]
   # objects (YOLO detections) and entity_tracking (those detections through
   # ByteTrack, which is supervision — without it entity_tracking alone skips)
-qc-face = ["video-studio-engine[qc]", "mediapipe>=0.10"]    # lip_sync's real backend
+# lip_sync's real mouth backend. Note this is NOT a quarantine for mediapipe:
+# [vision] already requires it, so anything installing [standard] has it
+# regardless. This extra is what makes lip_sync work for someone who took
+# [qc] on its own.
+qc-face = ["video-studio-engine[qc]", "mediapipe>=0.10"]
 qc-clip = ["video-studio-engine[qc]", "fastembed>=0.3"]     # prompt_visual
 
 # Word timings for narration this studio did not synthesise. Optional because
@@ -86,7 +96,10 @@ generate = [
 vision = [
   "mediapipe>=0.10",
   "numpy>=1.26",
-  "opencv-python>=4.9",
+  # No opencv named here on purpose. mediapipe hard-requires
+  # opencv-contrib-python, so declaring opencv-python alongside it put two
+  # providers of the same cv2 module in one environment and left the winner to
+  # installation order. [qc] names contrib for the same reason.
 ]
 
 # Timeline interchange. CapCut and FCPXML need nothing; OTIO is only for


### PR DESCRIPTION
Found by asking whether we had both `[all]` and `[standard]`. We don't — but checking turned this up.

## Three cv2 providers in the default install

```
[standard] → [vision] → opencv-python  +  mediapipe → opencv-contrib-python
           → [qc]     → opencv-python-headless
```

All three ship a module called `cv2`. pip neither resolves nor warns about this; whichever landed last is in charge, and which one that is depends on installation order.

**Two of the three predate this session** — `[vision]` has named `opencv-python` alongside mediapipe all along. `[qc]` added the third, so today's work made an existing latent conflict actively worse rather than creating it.

## Fix: name one distribution everywhere

mediapipe hard-requires `opencv-contrib-python`, and `[vision]` hard-requires mediapipe — so contrib is already present in any environment with `[vision]`. `[qc]` now names that same distribution instead of headless, and `[vision]` names no opencv at all.

Every combination resolves to one provider: `[qc]` alone, `[vision]` alone, `[standard]`.

The cost is that a `[qc]`-only user gets contrib rather than headless — slightly larger, GUI-capable. That's the price of not having to reason about which `cv2` won.

## The rationale was wrong too, in a way that mattered

I documented `[qc-face]` as excluded from the default set because mediapipe drags in a second cv2 provider. That's true in showwatcher and **false here**: `[standard]` includes `[vision]`, which requires mediapipe, which requires contrib. The thing supposedly being quarantined was in the default install the whole time — so the exclusion bought nothing except making `lip_sync` skip while its dependency sat installed.

`[qc-face]` stays, because it's what makes `lip_sync` work for someone who took `[qc]` without `[vision]`. It just isn't a quarantine, and `pyproject.toml`, `MIGRATION-NOTES.md` and the README no longer claim it is.

The README also said `[standard]` "holds nothing that ships a model," which mediapipe contradicts. Corrected.

## Verification

Wheel builds; metadata resolves for `[standard]` against the local tree; `verify-skills` passes with its one pre-existing warning. Dependency sets checked by expanding `[standard]` and listing every opencv-providing requirement — one, now.