### PR TITLE
Take showrunner out of everything a user reads

### DIFF
--- a/skills/video-formats/references/formats/explainer.md
+++ b/skills/video-formats/references/formats/explainer.md
@@ -1,8 +1,8 @@
 # Explainer — narrated concept walkthrough
 
 Voiceover explains a concept over a sequence of illustrative visuals: b-roll
-cuts, text cards, big-number stat beats. No on-camera host. (Descends from
-showrunner's faceless-explainer, minus the LLM planner — the agent plans.)
+cuts, text cards, big-number stat beats. No on-camera host. The agent plans the
+storyboard; nothing here plans it for you.
 
 ## Composition
 Vertical 1080x1920 @30fps (ask if landscape 1920x1080 wanted for YouTube).

--- a/src/video_studio/styles/3b1b-dark.md
+++ b/src/video_studio/styles/3b1b-dark.md
@@ -5,13 +5,15 @@ description: Navy/blue/gold, math education inspired by 3Blue1Brown
 
 # 3b1b-dark
 
-Navy/blue/gold, math education inspired by 3Blue1Brown. Ported from the showrunner style set, which described a whole design
-system — a six-step type scale, a spacing scale, motion curves. Only the parts
-this studio renders survived the translation: caption styling, three card roles,
-and the music mood so `music_catalog --pick` can choose a bed that matches.
+Navy/blue/gold, math education inspired by 3Blue1Brown. This preset carries
+only what the composer actually renders: caption styling, three card roles, and
+the music mood, so `music_catalog --pick` can choose a bed that matches the
+look rather than fighting it.
 
-Motion curves and the spacing scale were dropped rather than faked; nothing here
-reads them, and a value nothing reads is a value that drifts.
+It began as a fuller design system — a six-step type scale, a spacing scale,
+motion curves. Those were dropped rather than translated into keys nothing
+reads, because a value nothing reads is a value that drifts: it stays in the
+file, stops matching the render, and misleads whoever edits it next.
 
 ```json
 {

--- a/src/video_studio/styles/bold-neon.md
+++ b/src/video_studio/styles/bold-neon.md
@@ -5,13 +5,15 @@ description: Black/cyan/pink, gaming and tech energy
 
 # bold-neon
 
-Black/cyan/pink, gaming and tech energy. Ported from the showrunner style set, which described a whole design
-system — a six-step type scale, a spacing scale, motion curves. Only the parts
-this studio renders survived the translation: caption styling, three card roles,
-and the music mood so `music_catalog --pick` can choose a bed that matches.
+Black/cyan/pink, gaming and tech energy. This preset carries only what the
+composer actually renders: caption styling, three card roles, and the music
+mood, so `music_catalog --pick` can choose a bed that matches the look rather
+than fighting it.
 
-Motion curves and the spacing scale were dropped rather than faked; nothing here
-reads them, and a value nothing reads is a value that drifts.
+It began as a fuller design system — a six-step type scale, a spacing scale,
+motion curves. Those were dropped rather than translated into keys nothing
+reads, because a value nothing reads is a value that drifts: it stays in the
+file, stops matching the render, and misleads whoever edits it next.
 
 ```json
 {

--- a/src/video_studio/styles/clean-corporate.md
+++ b/src/video_studio/styles/clean-corporate.md
@@ -5,13 +5,15 @@ description: White/blue, professional business presentations
 
 # clean-corporate
 
-White/blue, professional business presentations. Ported from the showrunner style set, which described a whole design
-system — a six-step type scale, a spacing scale, motion curves. Only the parts
-this studio renders survived the translation: caption styling, three card roles,
-and the music mood so `music_catalog --pick` can choose a bed that matches.
+White/blue, professional business presentations. This preset carries only what
+the composer actually renders: caption styling, three card roles, and the music
+mood, so `music_catalog --pick` can choose a bed that matches the look rather
+than fighting it.
 
-Motion curves and the spacing scale were dropped rather than faked; nothing here
-reads them, and a value nothing reads is a value that drifts.
+It began as a fuller design system — a six-step type scale, a spacing scale,
+motion curves. Those were dropped rather than translated into keys nothing
+reads, because a value nothing reads is a value that drifts: it stays in the
+file, stops matching the render, and misleads whoever edits it next.
 
 ```json
 {

--- a/src/video_studio/styles/dramatic-story.md
+++ b/src/video_studio/styles/dramatic-story.md
@@ -5,13 +5,15 @@ description: Black/gold/red, cinematic storytelling
 
 # dramatic-story
 
-Black/gold/red, cinematic storytelling. Ported from the showrunner style set, which described a whole design
-system — a six-step type scale, a spacing scale, motion curves. Only the parts
-this studio renders survived the translation: caption styling, three card roles,
-and the music mood so `music_catalog --pick` can choose a bed that matches.
+Black/gold/red, cinematic storytelling. This preset carries only what the
+composer actually renders: caption styling, three card roles, and the music
+mood, so `music_catalog --pick` can choose a bed that matches the look rather
+than fighting it.
 
-Motion curves and the spacing scale were dropped rather than faked; nothing here
-reads them, and a value nothing reads is a value that drifts.
+It began as a fuller design system — a six-step type scale, a spacing scale,
+motion curves. Those were dropped rather than translated into keys nothing
+reads, because a value nothing reads is a value that drifts: it stays in the
+file, stops matching the render, and misleads whoever edits it next.
 
 ```json
 {

--- a/src/video_studio/styles/forest-breath.md
+++ b/src/video_studio/styles/forest-breath.md
@@ -5,13 +5,15 @@ description: Sage green + off-white, grounded and calm
 
 # forest-breath
 
-Sage green + off-white, grounded and calm. Ported from the showrunner style set, which described a whole design
-system — a six-step type scale, a spacing scale, motion curves. Only the parts
-this studio renders survived the translation: caption styling, three card roles,
-and the music mood so `music_catalog --pick` can choose a bed that matches.
+Sage green + off-white, grounded and calm. This preset carries only what the
+composer actually renders: caption styling, three card roles, and the music
+mood, so `music_catalog --pick` can choose a bed that matches the look rather
+than fighting it.
 
-Motion curves and the spacing scale were dropped rather than faked; nothing here
-reads them, and a value nothing reads is a value that drifts.
+It began as a fuller design system — a six-step type scale, a spacing scale,
+motion curves. Those were dropped rather than translated into keys nothing
+reads, because a value nothing reads is a value that drifts: it stays in the
+file, stops matching the render, and misleads whoever edits it next.
 
 ```json
 {

--- a/src/video_studio/styles/minty-fresh.md
+++ b/src/video_studio/styles/minty-fresh.md
@@ -5,13 +5,15 @@ description: Mint green + cream, cheerful product marketing
 
 # minty-fresh
 
-Mint green + cream, cheerful product marketing. Ported from the showrunner style set, which described a whole design
-system — a six-step type scale, a spacing scale, motion curves. Only the parts
-this studio renders survived the translation: caption styling, three card roles,
-and the music mood so `music_catalog --pick` can choose a bed that matches.
+Mint green + cream, cheerful product marketing. This preset carries only what
+the composer actually renders: caption styling, three card roles, and the music
+mood, so `music_catalog --pick` can choose a bed that matches the look rather
+than fighting it.
 
-Motion curves and the spacing scale were dropped rather than faked; nothing here
-reads them, and a value nothing reads is a value that drifts.
+It began as a fuller design system — a six-step type scale, a spacing scale,
+motion curves. Those were dropped rather than translated into keys nothing
+reads, because a value nothing reads is a value that drifts: it stays in the
+file, stops matching the render, and misleads whoever edits it next.
 
 ```json
 {

--- a/src/video_studio/styles/paper-press.md
+++ b/src/video_studio/styles/paper-press.md
@@ -5,13 +5,15 @@ description: Cream + black + red, newspaper editorial
 
 # paper-press
 
-Cream + black + red, newspaper editorial. Ported from the showrunner style set, which described a whole design
-system — a six-step type scale, a spacing scale, motion curves. Only the parts
-this studio renders survived the translation: caption styling, three card roles,
-and the music mood so `music_catalog --pick` can choose a bed that matches.
+Cream + black + red, newspaper editorial. This preset carries only what the
+composer actually renders: caption styling, three card roles, and the music
+mood, so `music_catalog --pick` can choose a bed that matches the look rather
+than fighting it.
 
-Motion curves and the spacing scale were dropped rather than faked; nothing here
-reads them, and a value nothing reads is a value that drifts.
+It began as a fuller design system — a six-step type scale, a spacing scale,
+motion curves. Those were dropped rather than translated into keys nothing
+reads, because a value nothing reads is a value that drifts: it stays in the
+file, stops matching the render, and misleads whoever edits it next.
 
 ```json
 {

--- a/src/video_studio/styles/pastel-gradient.md
+++ b/src/video_studio/styles/pastel-gradient.md
@@ -5,13 +5,15 @@ description: Lavender/purple, wellness and lifestyle
 
 # pastel-gradient
 
-Lavender/purple, wellness and lifestyle. Ported from the showrunner style set, which described a whole design
-system — a six-step type scale, a spacing scale, motion curves. Only the parts
-this studio renders survived the translation: caption styling, three card roles,
-and the music mood so `music_catalog --pick` can choose a bed that matches.
+Lavender/purple, wellness and lifestyle. This preset carries only what the
+composer actually renders: caption styling, three card roles, and the music
+mood, so `music_catalog --pick` can choose a bed that matches the look rather
+than fighting it.
 
-Motion curves and the spacing scale were dropped rather than faked; nothing here
-reads them, and a value nothing reads is a value that drifts.
+It began as a fuller design system — a six-step type scale, a spacing scale,
+motion curves. Those were dropped rather than translated into keys nothing
+reads, because a value nothing reads is a value that drifts: it stays in the
+file, stops matching the render, and misleads whoever edits it next.
 
 ```json
 {

--- a/src/video_studio/styles/sunny-editorial.md
+++ b/src/video_studio/styles/sunny-editorial.md
@@ -5,13 +5,15 @@ description: Warm yellow + cream + charcoal, inviting long-form content
 
 # sunny-editorial
 
-Warm yellow + cream + charcoal, inviting long-form content. Ported from the showrunner style set, which described a whole design
-system — a six-step type scale, a spacing scale, motion curves. Only the parts
-this studio renders survived the translation: caption styling, three card roles,
-and the music mood so `music_catalog --pick` can choose a bed that matches.
+Warm yellow + cream + charcoal, inviting long-form content. This preset carries
+only what the composer actually renders: caption styling, three card roles, and
+the music mood, so `music_catalog --pick` can choose a bed that matches the
+look rather than fighting it.
 
-Motion curves and the spacing scale were dropped rather than faked; nothing here
-reads them, and a value nothing reads is a value that drifts.
+It began as a fuller design system — a six-step type scale, a spacing scale,
+motion curves. Those were dropped rather than translated into keys nothing
+reads, because a value nothing reads is a value that drifts: it stays in the
+file, stops matching the render, and misleads whoever edits it next.
 
 ```json
 {

--- a/src/video_studio/styles/tech-startup.md
+++ b/src/video_studio/styles/tech-startup.md
@@ -5,13 +5,15 @@ description: Dark/indigo/pink, modern SaaS aesthetic
 
 # tech-startup
 
-Dark/indigo/pink, modern SaaS aesthetic. Ported from the showrunner style set, which described a whole design
-system — a six-step type scale, a spacing scale, motion curves. Only the parts
-this studio renders survived the translation: caption styling, three card roles,
-and the music mood so `music_catalog --pick` can choose a bed that matches.
+Dark/indigo/pink, modern SaaS aesthetic. This preset carries only what the
+composer actually renders: caption styling, three card roles, and the music
+mood, so `music_catalog --pick` can choose a bed that matches the look rather
+than fighting it.
 
-Motion curves and the spacing scale were dropped rather than faked; nothing here
-reads them, and a value nothing reads is a value that drifts.
+It began as a fuller design system — a six-step type scale, a spacing scale,
+motion curves. Those were dropped rather than translated into keys nothing
+reads, because a value nothing reads is a value that drifts: it stays in the
+file, stops matching the render, and misleads whoever edits it next.
 
 ```json
 {

--- a/src/video_studio/styles/warm-minimal.md
+++ b/src/video_studio/styles/warm-minimal.md
@@ -5,13 +5,15 @@ description: Cream/brown, lifestyle and editorial
 
 # warm-minimal
 
-Cream/brown, lifestyle and editorial. Ported from the showrunner style set, which described a whole design
-system — a six-step type scale, a spacing scale, motion curves. Only the parts
-this studio renders survived the translation: caption styling, three card roles,
-and the music mood so `music_catalog --pick` can choose a bed that matches.
+Cream/brown, lifestyle and editorial. This preset carries only what the
+composer actually renders: caption styling, three card roles, and the music
+mood, so `music_catalog --pick` can choose a bed that matches the look rather
+than fighting it.
 
-Motion curves and the spacing scale were dropped rather than faked; nothing here
-reads them, and a value nothing reads is a value that drifts.
+It began as a fuller design system — a six-step type scale, a spacing scale,
+motion curves. Those were dropped rather than translated into keys nothing
+reads, because a value nothing reads is a value that drifts: it stays in the
+file, stops matching the render, and misleads whoever edits it next.
 
 ```json
 {


### PR DESCRIPTION
Goal 2, read literally: the skills should not use showrunner, and nothing a user reads should reference it.

## The skills

Down to **one** mention — `skills/video-formats/references/formats/explainer.md:5`:

> (Descends from showrunner's faceless-explainer, minus the LLM planner — the agent plans.)

Accurate provenance, but it pointed a reader at a tool this repo replaced and they cannot use, inside the document telling them how to build the thing. The replacement keeps the part that matters to someone reading a format spec: the agent plans the storyboard, and nothing here plans it for them.

## The 11 style presets

Each opened by attributing itself to "the showrunner style set." They're package data rather than skills, but a user meets them through `video-studio styles --show <name>` — so it was a user-facing reference either way.

**The attribution goes; the reasoning stays**, because the reasoning is the useful half. A preset holds only what the composer renders — caption styling, three card roles, and the music mood that lets `music_catalog --pick` choose a bed matching the look. It began as a fuller design system with a type scale, a spacing scale and motion curves, and those were dropped rather than translated into keys nothing reads:

> A value nothing reads is a value that drifts: it stays in the file, stops matching the render, and misleads whoever edits it next.

Prose reflowed to 79 columns — the description prefix varies per preset and was pushing the first line long.

## Verification

All 11 still parse. `styles --list` shows all 11; `styles --show paper-press` returns intact JSON; `music_catalog.load_preset` still reads moods and bpm off one — that last one matters, since `music.moods` and `rhythm.bpm` are keys `styles.py` itself ignores and only the picker consumes. Wheel ships 11 presets, none naming showrunner.

## Where it still appears, deliberately

`MIGRATION-NOTES.md`, `scripts/verify-skills.sh`, and `qc/` source docstrings explaining where the ported code came from. That's engineering history, not something a user reads — and deleting it would make the port's provenance unrecoverable.

## Companion

scrollmark/scrollmarkgithubio#11 removes the last site reference. Between them, `grep -i showrunner` returns nothing across the skills, the presets, the README, or any page of the site.