### PR TITLE
Port the three tutorials, and make tutor able to find them

### DIFF
--- a/skills/studio-setup/SKILL.md
+++ b/skills/studio-setup/SKILL.md
@@ -20,6 +20,8 @@ Two questions, two scripts. *What can I use right now* is the bundled `scripts/d
 
 Doctor reports per category — public-domain archives, stock, generated video, generated images, generated audio, voice — plus the required binaries. It checks that a key is *present*, not that it works; a key can still be rejected at call time for spent quota or a withdrawn model, and the individual scripts report that.
 
+To teach the workflow rather than describe it, `video-studio tutor --list` names the shipped tutorials; `--step <name> <n>` serves ONE step, and that is the design. A tutorial pasted whole is a document, not a lesson — nobody reads the middle and you cannot tell what landed. Serve a step, let them try it, ask whether it worked, then move. `--show` is for you to plan with, never to paste. Start with `getting-started`; it says up front which steps need a composer this repo does not ship.
+
 Run it **before** offering sourcing options. Offering a source that turns out to have no key makes the estimate wrong as well as the offer.
 
 ## Fixing a Broken One

--- a/src/video_studio/project/studio.py
+++ b/src/video_studio/project/studio.py
@@ -37,6 +37,7 @@ import json
 import os
 import socket
 import subprocess
+import sys
 from pathlib import Path
 
 from video_studio.paths import studio_root
@@ -147,8 +148,13 @@ def main() -> None:
 
     # Rebuild THIS project's props before opening, or the editor shows whichever
     # project was built last — the same global-file trap the exporter hit.
+    # Invoke the installed module, not a path. This used to run
+    # `uv run $SKILL_ROOT/scripts/build_props.py`, which is where the script sat
+    # BEFORE the engine was packaged — a path that exists in the old studio tree
+    # and in no pip install, so opening the editor failed for every installed
+    # copy. sys.executable keeps it in the interpreter already running.
     r = subprocess.run(
-        ["uv", "run", str(SKILL_ROOT / "scripts" / "build_props.py"),
+        [sys.executable, "-m", "video_studio.cli", "build_props",
          "--storyboard", str(project / "storyboard.json"), "--project", str(project),
          "--placeholders"],
         capture_output=True, text=True,

--- a/src/video_studio/project/tutor.py
+++ b/src/video_studio/project/tutor.py
@@ -44,11 +44,22 @@ SKILL_ROOT = studio_root()
 USER_TUTORIALS = Path.home() / ".config" / "video-studio" / "tutorials"
 
 
+#: Tutorials shipped inside the installed package. Lowest precedence, so a user
+#: or a project can shadow one by name.
+PACKAGE_TUTORIALS = Path(__file__).resolve().parent.parent / "tutorials"
+
+
 def roots() -> list[Path]:
     out = []
     if os.environ.get("VIDEO_STUDIO_TUTORIALS"):
         out.append(Path(os.environ["VIDEO_STUDIO_TUTORIALS"]))
     out += [USER_TUTORIALS, SKILL_ROOT / "tutorials"]
+    # SKILL_ROOT is the studio tree, which an installed copy does not have: with
+    # no marker directory to find, studio_root() falls back to the cwd, so the
+    # tier above means <wherever you are standing>/tutorials. That is why
+    # `tutor --list` printed "no tutorials found" and exited 0 for everyone who
+    # pip installed — the same trap styles.py had, and the same fix.
+    out.append(PACKAGE_TUTORIALS)
     return out
 
 

--- a/src/video_studio/tutorials/getting-started.md
+++ b/src/video_studio/tutorials/getting-started.md
@@ -1,0 +1,116 @@
+---
+name: getting-started
+description: Walk the whole workflow and understand why each step is there (see the note on rendering)
+minutes: 15
+audience: someone who has never used this
+---
+
+# Getting started
+
+Teaches the shape of the workflow by making something. Do not summarise this
+tutorial and skip to the end — the whole point is that they touch each step.
+
+**Before you start, know where this stops.** Steps 1 to 3 work today: the
+interview, the format choice, and the storyboard are all conversation, and they
+need nothing installed. From step 4 onward — the placeholder preview, the
+editor, and every render — the pipeline draws on a Remotion composer that this
+repo does not ship. If you do not have one, read steps 4 to 7 as a description
+of the shape rather than instructions to follow, and skip the TRY lines.
+
+Do not promise a learner a finished video and then discover this with them at
+step 4. Say it at the start, the way this tutorial does.
+
+## Step 1 — What this actually is
+
+You describe a video in conversation and get a finished vertical `.mp4`. There
+is no timeline to drag and no commands to memorise.
+
+The part worth understanding up front: **you are asked questions at the points
+where your taste matters, and nowhere else.** Which format, what it should feel
+like, where footage comes from, and whether the layout looks right. Everything
+between those is handled.
+
+TRY: Say "let's make a video" and stop there. See what you get asked.
+CHECK: Did you get a list of formats to choose from?
+
+## Step 2 — The format decides the questions
+
+A format is not a skin. It sets the interview you get, the shape of the edit,
+and the rules the scenes are built by. An Explainer asks about your topic and
+takeaway; a Cinematic asks about mood and arc and asks for the music FIRST,
+because the cut is built around the track's energy.
+
+So picking the format is the highest-leverage decision in the whole process,
+and it is the first one for a reason.
+
+TRY: Pick Cinematic, and notice the first thing it asks about is the score.
+CHECK: Can you say why a music-led format asks for the track before anything else?
+
+## Step 3 — Answer the interview specifically
+
+Rounds of at most four questions, each with an escape hatch for anything the
+options miss. Vague answers here produce a vague video, and no amount of
+re-rendering later fixes a fuzzy brief.
+
+"Something upbeat about cities" gets you a generic montage. "Joy, dawn to
+night, one city waking up, ending on a rooftop wide" gets you a piece with a
+shape.
+
+TRY: Answer the mood and arc questions with something specific enough that a
+stranger could picture the first and last shot.
+CHECK: Can you name your opening shot and your closing shot?
+
+## Step 4 — Approve the layout before anything costs money
+
+You get a preview where every clip is a labelled coloured rectangle. No footage
+exists yet, nothing has been fetched, nothing has been spent.
+
+This is the cheapest moment to change your mind, and the only one where
+changing your mind is free. Check the pacing and whether text collides with
+anything. If you want to move things yourself, ask to open the editor — you get
+a live preview you can drag and retime, and your edits win over the plan.
+
+REQUIRES A COMPOSER. The preview and the editor are both Remotion, which this
+repo does not ship. Without one there is nothing to look at, and the rest of
+this tutorial describes the shape rather than something you can do. Say so now
+rather than at step 7.
+
+TRY: Look at the placeholder preview and ask for one timing change.
+CHECK: Does the shape of it feel right before any footage exists?
+
+## Step 5 — Footage and audio get sourced
+
+Now it spends. Narration is recorded first if there is any, because everything
+else is timed from it. Then footage per the sourcing choice you made, then the
+score.
+
+You are told what anything costs before it is spent, not after. Much of it is
+free: two public archives need no account at all, the stock libraries are free
+with a key, and the narration voice runs on your own machine.
+
+TRY: Ask "what will this cost?" before approving the spend.
+CHECK: Do you know which parts of your video were free and which were not?
+
+## Step 6 — It gets checked, and so should you
+
+Two automatic passes: one on what the providers returned (duplicate clips,
+monochrome footage, clips too short for their scene, silent audio) and one on
+the finished render (sync, captions, text off-frame, loudness).
+
+Neither replaces looking. Ask to see frames from the finished video. Every
+shipped-broken render in this project's history would have been caught by
+opening a single frame.
+
+TRY: Ask to see 4-6 frames from across your finished video.
+CHECK: Did you actually look at them?
+
+## Step 7 — Change it by saying what is wrong
+
+The project folder is the document. "The third scene drags." "Drop the subtitle
+on the end card." "Replace the workshop clip with something tighter."
+
+Footage you already paid for is never re-fetched — clips are cached per scene
+and layer, so rewording a whole video costs narration time and nothing else.
+
+TRY: Change one line of copy and re-render.
+CHECK: Did only the thing you changed get rebuilt?

--- a/src/video_studio/tutorials/tools-and-keys.md
+++ b/src/video_studio/tutorials/tools-and-keys.md
@@ -1,0 +1,78 @@
+---
+name: tools-and-keys
+description: Which third-party tools exist, what each unlocks, and what to turn on
+minutes: 8
+audience: someone deciding what to sign up for
+---
+
+# Tools and keys
+
+Teach this when someone asks "what do I need?" or hits a wall because a source
+was not available. Run the `doctor` script bundled in the studio-setup skill first, and teach against what is
+ACTUALLY on their machine — do not describe a tool they already have as though
+it were missing, and never recommend one they cannot use.
+
+Full inventory and triage: `references/third-party.md`.
+
+## Step 1 — You need less than you think
+
+Three things must exist: `ffmpeg`, `node`, and `uv`. Everything else is
+optional.
+
+With zero keys and zero accounts you can still make a complete video: two
+public archives need no key at all, and the narration voice runs on your own
+machine. That is not a degraded mode — it is a real video.
+
+TRY: Run `python3 scripts/doctor.py` from the studio-setup skill folder and read
+the `tools:` section.
+CHECK: Are ffmpeg, node and uv all showing OK?
+
+## Step 2 — If you add one key, add Pexels
+
+Free, no billing, thirty seconds at pexels.com/api. It is the difference
+between "find me footage of a city street" usually working and usually not.
+
+The archives are deep on space, science, history and nature, and thin on
+staged or everyday consumer subjects. Pexels covers exactly that gap.
+
+TRY: Add PEXELS_API_KEY to `.env`, re-run doctor.
+CHECK: Does the stock section now say OK?
+
+## Step 3 — Paid generation, and when it is worth it
+
+Generation is for things that cannot be filmed: an unreleased product, an
+abstract idea, a place that does not exist. It is not a better way to get a
+city street — real footage is free and does not warp faces.
+
+The money lever worth knowing: a generated still with slow camera drift costs
+a few cents; the equivalent generated clip costs around thirty-six. Prefer the
+still unless the MOTION itself carries meaning.
+
+TRY: Ask what your next video would cost with generation versus stock.
+CHECK: Can you name a shot that genuinely needs generating?
+
+## Step 4 — The music rights split, which matters more than the price
+
+Two music backends generate happily. One has clean commercial terms. The other
+works without billing — so it is the path of least resistance — and its output
+rights are unsettled, making it fine for internal or demo use and not for
+anything you publish.
+
+You should be told which is in use before you choose, not after. The reason is
+practical: the whole edit gets cut to the track's energy, so discovering a
+rights problem later means re-cutting the video, not relabelling it.
+
+TRY: Ask "which music backend would this use, and what are its terms?"
+CHECK: Do you know whether your last video's score can be published?
+
+## Step 5 — What is missing, and what that costs you
+
+`showwatcher` is the automated quality gate and is usually not installed. When
+it is absent, verification happens by hand — frames pulled and actually looked
+at, duration and loudness confirmed.
+
+That works, and it is the only step whose guarantee depends on someone
+remembering. If a video ever ships broken, this is the step that was skipped.
+
+TRY: Check whether `showwatcher` shows OK in doctor.
+CHECK: If it is missing, do you know what has to happen instead?

--- a/src/video_studio/tutorials/what-it-can-do.md
+++ b/src/video_studio/tutorials/what-it-can-do.md
@@ -1,0 +1,92 @@
+---
+name: what-it-can-do
+description: Tour of the abilities, including the ones people never find on their own
+minutes: 10
+audience: someone who has made a video and suspects there is more
+---
+
+# What it can do
+
+The abilities that exist but are rarely discovered, because nothing in a normal
+session mentions them. Teach these to anyone who is past their first video.
+
+## Step 1 — Ten video formats, not one template
+
+Explainer, Cinematic, TalkingHead, TitledVideo, PipStory, ProductLaunch,
+BrandOrigin, TimelineExplainer, PointerPopups, Boil. Each carries its own
+interview, scene grammar and pacing rules.
+
+Boil is the unusual one: hand-drawn wobbling line art, synthesised rather than
+generated. It costs nothing, has no licence attached to anything on screen, and
+is deterministic. Reach for it when the subject cannot be photographed — an
+unreleased product, a service, an abstract idea.
+
+TRY: Ask "what formats are there?" and read the one-line descriptions.
+CHECK: Which one fits something you actually need to make this month?
+
+## Step 2 — Looks are reusable across every video you make
+
+A look — caption size and colour, the outline that keeps words readable over
+footage, the colours and positions of labels and end cards — is a **preset**,
+stored in a file, and it belongs to you rather than to one video.
+
+Three ship: `tourism`, `loud-social`, `documentary`. Yours are saved to
+`~/.config/video-studio/styles/`, outside the skill folder, so they survive
+reinstalling or moving it.
+
+TRY: Say "use the loud-social look", then "make the captions bigger and drop
+the pink", then "save that as mine".
+CHECK: Is there a file in ~/.config/video-studio/styles/ with your name on it?
+
+## Step 3 — Cuts can be driven by the music, not a stopwatch
+
+For music-led pieces the score's energy is measured — every point where it
+jumps or drops at least 3 dB — and scene boundaries are placed on those events.
+
+This is the difference between a montage that feels edited and one that feels
+timed. Cutting on a grid drifts out of phase with a track within about twenty
+seconds. It also finds where a track actually resolves, so a piece can end on
+the music's own ending instead of a fade you imposed.
+
+TRY: Ask "map the energy of this track" with any music file.
+CHECK: Can you point at where the drop is, in seconds?
+
+## Step 4 — Effects, and putting someone where they never were
+
+Beyond footage and type: `grain`, `breath`, `lightLeak`, `clock`, `glow` and
+`vignette` layers for atmosphere over the picture.
+
+And a compositor that segments a filmed person out of their real surroundings,
+places them over replacement footage, and puts a drawn prop in front — for
+"him in a spaceship / a clown car / on the moon" shots where no such footage
+exists and none can be generated convincingly.
+
+TRY: Ask what a grain or light-leak layer would do to your last video.
+CHECK: Can you name a shot you have wanted that this makes possible?
+
+## Step 5 — It leaves, if you want it to
+
+Nothing here is a lock-in. A finished project exports to Premiere Pro and
+DaVinci Resolve natively, to Final Cut with the cards as real editable titles
+and camera moves as real keyframes, and to CapCut as a draft.
+
+Be clear-eyed about what travels: every cut on its true frame, each clip linked
+to its real source, and the narration in sync. What does not travel is the
+effects — camera moves, fades and cards — because no interchange format carries
+them. Cards arrive as labelled markers saying what belonged where.
+
+TRY: Ask to export your last project to your editor of choice.
+CHECK: Did the cuts land where you expected when you opened it?
+
+## Step 6 — Thumbnails and publishing
+
+It picks poster frames — a ranked shortlist plus a labelled contact sheet —
+because a feed reads as coherent when its thumbnails do, and the default
+alternative is frame one, which is usually a title card fading up from black.
+
+The ranking measures colour and contrast, not meaning. It once ranked an
+underwater reef top for a Mexico spot, above a marigold market that would have
+sold the video far better. Look at the sheet.
+
+TRY: Ask for poster frames from your last video and open the contact sheet.
+CHECK: Did the top-ranked frame turn out to be the right one?


### PR DESCRIPTION
The engine has shipped `tutor` since the consolidation — a program that serves a tutorial **one step at a time**, deliberately, because a tutorial pasted whole is a document rather than a lesson. It had nothing to serve.

`tutor --list` printed `no tutorials found` and **exited 0**. The quiet kind of broken: no error, no signal, just a feature that looks empty.

## Two failures behind that

**The content never came across.** Three files sat in the `video-studio` tree — `getting-started` (101 lines), `tools-and-keys` (77), `what-it-can-do` (92).

**`tutor` couldn't have found them anyway.** `roots()` resolved its shipped tier through `studio_root()`, which finds no marker directory in an installed copy and falls back to the cwd — so the tier meant `<wherever you are standing>/tutorials`. Exactly the trap `styles.py` had, and the same fix: a tier that travels with the package. Verified from `/tmp`, outside any checkout.

## `getting-started` needed an honesty pass to ship

It promised *"make one real video end to end."* Steps 4 through 7 all run through a Remotion composer this repo does not ship, so **nobody following it can finish.**

That's now stated in three places, and the third is the one that matters:

- the frontmatter description
- the intro
- **inside step 4 itself** — because `--step` serves one step in isolation (`deliverOneStepOnly: true`), so a learner reaching step 4 alone would otherwise meet the wall with no warning

Steps 1–3 are conversation and work exactly as written. The tutorial now teaches the shape honestly instead of promising a render it can't deliver.

`tools-and-keys` pointed at `scripts/doctor.py`, from before doctor became a bundled skill script.

## A fix the tutorial leans on

`video-studio studio` shelled out to `uv run $SKILL_ROOT/scripts/build_props.py` — a pre-packaging path, present in the old studio tree and in **no pip install**. Opening the editor failed for every installed copy. It invokes the module via `sys.executable` now.

It still needs a composer to show anything, and **still reports a working URL when there is none** — a separate silent failure I've left alone but flagged.

## Verification

All three discovered and served from outside the repo; step 1 of each renders standalone; wheel ships all three; `verify-skills` green. `studio` now reaches `build_props` and fails on data rather than on a missing path.

## Note

This is the closest thing in the repo to an answer for the onboarding problem — `getting-started` is headed *"audience: someone who has never used this."* It's worth reading with that in mind, because what it can honestly teach today stops at step 3.