### PR TITLE
Say what a composer must do with the ducking envelope

### DIFF
--- a/skills/audio-acquisition/references/voice-landmines.md
+++ b/skills/audio-acquisition/references/voice-landmines.md
@@ -52,6 +52,12 @@ quietly.
   and writes a per-frame volume envelope into the props so the bed drops under
   speech and returns in the gaps. Run it after build_props and before rendering —
   build_props owns the clock, so re-running it overwrites the envelope.
+- **Check the composer actually reads it.** `duck_music` writes `music.envelope`
+  into the props and prints a successful summary whether or not anything consumes
+  it. A composer that ignores that key plays the bed flat and reports nothing
+  wrong. So if ducking looks like it ran and the render still competes with the
+  narration, the envelope is being written and dropped: confirm the renderer
+  reads `music.envelope`, not only `music.volume`.
 - Adding any music track halves everything (see the 6 dB note in the SKILL).
   Normalise after every render that has music.
 

--- a/src/video_studio/audio/duck_music.py
+++ b/src/video_studio/audio/duck_music.py
@@ -9,6 +9,24 @@ Usage:
       --base 0.16 --depth 0.65          # louder bed / deeper dip
   uv run scripts/duck_music.py ... --dry-run    # report, write nothing
 
+WHAT THE COMPOSER MUST DO WITH THIS. The envelope is written into the props as
+`music.envelope` — one value per COMPOSITION frame — alongside `music.baseVolume`.
+It does nothing on its own. A composer has to read it, and read it the right way:
+
+  <Audio src={...} volume={(f) => envelope[Math.min(f, envelope.length - 1)]} />
+
+Two details are load-bearing. The music element must sit ABOVE the per-scene
+sequences, because Remotion hands a volume callback a frame relative to its
+enclosing sequence — inside one, the ducking follows the wrong scene and nothing
+errors. And the lookup must clamp at the last entry, because re-running
+build_props can lengthen the composition without duck_music running again, and an
+undefined volume silences the bed rather than failing.
+
+A composer that ignores `music.envelope` plays the bed flat, and this program
+still prints a successful-looking summary. That is exactly what happened when
+this was ported: the envelope was computed correctly and consumed by nobody for
+as long as it took someone to read the renderer.
+
 RUN THIS AFTER build_props AND BEFORE rendering. It reads the props file that
 build_props wrote, adds a per-frame volume envelope to `props.music`, and writes
 the file back. build_props is the authority on the clock, so re-running it


### PR DESCRIPTION
`duck_music` computes a per-frame volume envelope and writes it into the props as `music.envelope`. Nothing in this repo renders, so whether that envelope does anything depends on a composer this repo does not control — and the program prints the same successful summary either way.

**That is not hypothetical.** The composer this pipeline was built against reads `props.music.volume`, a scalar, and mentions neither `envelope` nor `baseVolume` anywhere. Every render since the port has played the bed flat while `duck_music` reported `"ducked": 2, "floor": 0.0566`.

Measured on a real render, same fixture, loud-narration scene vs silent scene:

| composer | scene A (loud) | scene B (silent) | delta |
|---|---|---|---|
| reads only `music.volume` | −22.3 dB | −22.5 dB | **0.2 dB** — noise |
| reads `music.envelope` | −30.4 dB | −28.1 dB | **2.3 dB**, bed ~8 dB quieter overall |

The computation was always right. It was consumed by nobody.

## What changed here

The `duck_music` docstring now states the contract, including the two details that are load-bearing *and silent when wrong*:

- **The music element must sit above the per-scene sequences.** Remotion hands a volume callback a frame relative to its enclosing sequence — inside one, the ducking follows the wrong scene and nothing errors.
- **The lookup must clamp at the last entry.** Re-running `build_props` can lengthen a composition without `duck_music` running again, and an undefined volume silences the bed rather than failing.

`voice-landmines.md` gains the symptom, since that's where someone will look: *if ducking appears to have run and the render still competes with the narration, the envelope is being written and dropped.*

## What this does not do

This repo cannot enforce any of it. The props file is a contract with no schema and no test spanning both halves, so either side can drift into disagreement without an error — which is exactly how this shipped. Stating the contract is the most the public side can do.

The corresponding renderer fix lives in the private composer and is not part of this PR.