### PR TITLE
Port the six references and three style presets

### DIFF
--- a/references/api-landmines.md
+++ b/references/api-landmines.md
@@ -1,0 +1,120 @@
+# API landmines (all paid for in real money or afternoons)
+
+## MiniMax (Hailuo)
+- 1080P generates ONLY 6s clips; requesting 10s → error 2013. 768P allows 10s.
+- Application errors arrive inside HTTP 200: check `base_resp.status_code != 0`
+  or you'll poll a bogus task id for 10 minutes (e.g. 1008 = out of balance).
+- Landscape-only output; vertical = center-crop downstream. Keep subjects centered.
+- ~$0.06/s observed ($0.36 per 6s clip).
+- Submitted jobs bill even if you never download — don't kill a poll loop mid-run.
+
+## Veo (Gemini API)
+- Durations {4,6,8} ONLY — docs say "4 to 8 inclusive" but 5 and 7 are rejected.
+- `generate_audio` is rejected outright on plain API-key auth (Enterprise-only).
+- Same GEMINI_API_KEY as text, but separate (much smaller) video quota — probe
+  with one 4s clip before planning a batch. Preview pricing ≈ $0.40/s.
+
+## Gemini text
+- Use `gemini-flash-latest` alias; pinned names (gemini-2.5-flash) 404
+  intermittently on generateContent despite appearing in the models list.
+
+## Kokoro TTS
+- Empty text raises "returned no audio" — write real silence instead
+  (tts_kokoro.py --silence N).
+- Token timestamps: trailing punctuation arrives as its own token stamped at
+  the NEXT word's start — merge punctuation-only tokens onto the previous word
+  or captions lead with stray marks.
+- Word timings only exist at synthesis time; a resumed/cached WAV has none
+  (fall back to whisper or proportional estimation).
+- Short interjection lines ("Mhm.") garble both synthesis and downstream ASR
+  checks — keep spoken lines ≥3 real words.
+
+## Generation content rules
+- NO readable text in prompts: models render pseudo-text (garbled signage was
+  the #1 QC error class across three rounds). Real text = composer typography.
+- Exact digits especially unreliable (asked for $260, got "250/month").
+- Identity across scenes: repeated verbatim descriptors REDUCE drift but do
+  not eliminate it; the only guarantee is reusing the same actual footage
+  (take pools). Separate generations of the same descriptor can produce a
+  visibly different person (~1 in 4 observed).
+- Unprompted background text still appears sometimes (storefronts, labels) —
+  QC catches it; reframe or regenerate that clip only.
+
+## Clocks (the #1 systemic bug class)
+- Scene duration = MEASURED narration WAV duration. Using planned durations
+  desyncs audio/video/captions cumulatively (was 20-30 findings per video
+  before the fix; 0-6 after).
+
+## Remotion composer (4.0.x)
+- `<OffthreadVideo>` has NO `loop` prop — passing one is silently ignored, so a
+  clip shorter than its scene freezes on its last frame. Wrap in `<Loop
+  durationInFrames={srcFrames}>`; build_props probes the source length into
+  `srcDurationInFrames`. This is the common case, not the exotic one: generated
+  footage caps at 6s while narration-driven scenes often run longer.
+- Ken Burns pan: a `translate(%)` inside `scale()` shifts by scale x percent,
+  while the hidden overflow per side is only (scale-1)/2. A fixed shift
+  therefore outgrows its margin exactly when `zoom:"out"` returns the scale to
+  1, exposing a background sliver at the frame edge. Derive the shift from the
+  live headroom — (scale-1)/(2*scale) — not from a constant reserve.
+- JPEG intermediate frames tag the output `yuvj420p` (full range), which the
+  quality check flags as a platform-compatibility risk. `--pixel-format` does
+  NOT override it; `Config.setVideoImageFormat("png")` does. PNG frames render
+  a little slower and produce a smaller file here.
+- `props.json` is global to the composer, not per project. Always rebuild it
+  immediately before rendering — otherwise a second project's props silently
+  render into the first project's output filename.
+
+
+
+## Music silently costs 6 dB
+
+Adding a music track drops EVERYTHING — narration included — by 6 dB. Measured
+on brand-origin-brick: voice at -17.3 dB without music, -23.5 dB with, and the
+whole video -14.4 LUFS -> -20.3 LUFS.
+
+The number is the diagnosis: 20*log10(2) = 6.02 dB. Audio tracks are summed
+with ffmpeg's `amix`, which divides by the number of inputs. One music track
+turns 1 input into 2 and halves the lot.
+
+Nothing about this looks wrong. The render succeeds, the mix balance is
+CORRECT (both were scaled equally), captions and cuts are untouched — it is
+simply quiet, and quiet is the one defect that survives every visual check.
+
+**Therefore: run `normalize_audio.py (bundled in audio-acquisition) --in <render>` after any render
+that has music.** It restores -14 LUFS and, because both sources were scaled
+equally, the voice/music balance is preserved. Verified: -20.3 -> -14.1 LUFS,
+voice back to -17.5 dB against the no-music original's -17.3 dB.
+
+Two related notes:
+- The composer plays music at a FIXED volume (0.25) and does NOT duck under
+  narration. Balance is set once, not per-phrase.
+- Generated music can arrive peaking at 0 dBFS (MiniMax did). That leaves no
+  headroom, so normalising afterwards is doing real work rather than cosmetics.
+
+
+## Backticks in a commit message are executed
+
+`git commit -m "... the `subtext` key ..."` runs `subtext` as a shell command
+and substitutes its (empty) output. The commit succeeds, the push succeeds, and
+the words are simply gone from the message — no error anywhere.
+
+This bit the moon-explainer commit: "sub", "subtext", "lines" and "untilMs" all
+vanished, leaving sentences like *the storyboard said  where the component
+reads ,* which reads as a rendering bug rather than a shell one.
+
+Same family as the $0-substitution trap in SKILL.md: shell metacharacters in
+prose destroy the prose silently.
+
+**Use `-F -` with a quoted heredoc** (`<<'MSGEOF'`), which passes the body
+through untouched:
+
+    git commit -F - <<'MSGEOF'
+    Title
+    ... `backticks` and $dollars survive verbatim ...
+    MSGEOF
+
+And note the repair is NOT `--amend` + `--force-with-lease` once the commit is
+pushed to a shared branch. Another session may be committing to the same
+branch, and rewriting its history to fix your own typo is not a fair trade —
+add a follow-up commit instead. (This is what happened here: the force push was
+correctly refused, the local amend was dropped, and this note is the fix.)

--- a/references/daily-loop.md
+++ b/references/daily-loop.md
@@ -1,0 +1,45 @@
+# The daily loop (internal)
+
+A tight review cycle: produce a video most days, quality-check it, and hand
+the team a paste-ready update. Distribution is a human step — the loop
+produces and reports, John posts.
+
+## Each day
+
+1. **Pick the day's subject.** Whatever is most useful, and say why in the
+   note. Rough priority when nothing is urgent:
+   - unblock something the pipeline can't do yet (a new format, a composer
+     gap) — these teach us the most per render
+   - a reference-mining candidate (`reference-mining.md`)
+   - a format we haven't exercised recently — doubles as a smoke test
+   - real Scrollmark content when there's a backlog item
+2. **Produce it** through the normal skill workflow: placeholder preview
+   before any spend, sources resolved, rendered.
+3. **Quality-check it**, and keep the report next to the video.
+4. **File it** in `runs/<YYYY-MM-DD>/`:
+   - `<slug>.mp4` — the video
+   - `<slug>.qc.json` — the quality-check report (enables scores in the digest)
+   - `<slug>.note.txt` — one line: what it demonstrates or what it's testing
+5. **Draft the digest** and hand it over:
+   ```bash
+   video-studio daily_digest --next "what's queued tomorrow" --out digest.txt
+   ```
+6. **Report honestly.** A regression, a wasted spend, or a day with nothing
+   shipped goes in the digest as-is. The loop is only worth having if its
+   output can be trusted without re-checking.
+
+## Conventions
+
+- `runs/` is gitignored (videos are large). The digest reads it locally; the
+  repo keeps the *record*, not the media.
+- Cost belongs in the note whenever it's non-trivial, so spend stays visible
+  day to day rather than surfacing in a monthly bill.
+- The digest names no vendor — it gets forwarded. A test enforces this.
+
+## What "most useful" has meant so far
+
+Kept as a running log, because the pattern is informative: nearly every
+format has needed a real fix once actual footage exercised it — a zoom that
+cropped text, a crash on silent scenes, popups placed over the presenter, a
+frozen clip that never looped. Rendering one video a day is what surfaces
+those; reading the code does not.

--- a/references/providers.md
+++ b/references/providers.md
@@ -1,0 +1,280 @@
+# Provider options (internal) — opinionated
+
+Researched 2026-08. Prices move; re-check before a big batch. Vendor names
+here are internal — see the house-vocabulary table in `SKILL.md`.
+
+**Status legend:** ✅ wired up · 🟡 recommended next · ⛔ deliberately avoided
+
+**Wiring status (2026-08-05):** scripts now exist for every category —
+`stock_pexels.py`, `stock_pixabay.py`, `stock_freesound.py`, `gen_image.py`,
+`gen_minimax.py`, `gen_veo.py`, `gen_replicate.py` (aggregator: flux /
+ideogram / kling / wan / musicgen / stable-audio behind one key),
+`gen_music.py`. Run `doctor.py` (bundled in studio-setup) to see which have credentials.
+The stock and aggregator scripts are written from documented API shapes but
+have NOT been exercised against a live key yet — treat the first call of each
+as a smoke test, not a guarantee.
+
+---
+
+## How to be opinionated (the decision rule)
+
+A ranked list is not an opinion — it still leaves the choice open. An opinion
+is a rule that **resolves to exactly one answer** for a given shot, and can be
+argued with. This is ours; apply it per SHOT, not per project.
+
+```
+1. Does the subject exist in the real world?
+   NO  -> generate (fictional product, invented scene, stylised abstraction)
+   YES -> 2
+
+2. Is it public, historical, scientific, civic, or natural?
+   YES -> ARCHIVE tier (free, no key, real, permanently licensed)
+          e.g. space, weather, wildlife, infrastructure, historical record
+   NO  -> 3
+
+3. Is it everyday/commercial — interiors, people at work, food, cities?
+   YES -> STOCK tier (free with a key, huge catalogues, modern look)
+   NO  -> 4   (i.e. it exists but nobody has filmed it for you)
+
+4. GENERATE. Then one more question:
+   Does the MOTION carry meaning?
+   YES -> generate video   (a person acting, a process, a camera move)
+   NO  -> generate a STILL + camera drift  (~18x cheaper, and steadier:
+          stills cannot warp faces, drift identity, or cut mid-clip)
+```
+
+**Why this order and not "best quality first":** every failure this project has
+actually shipped came from generated footage — invented pseudo-text on a prop,
+an unplanned cut inside a clip, a presenter whose face changed between scenes.
+Real footage has none of those failure modes, costs nothing, and is already
+licensed. Generation is the *fallback*, not the default, and the ladder above
+is ordered by how likely the result is to be wrong rather than by how
+impressive the vendor sounds.
+
+**The tie-breaker, when two sources both fit:** prefer the one whose licence
+covers the whole catalogue over one that varies per item. An agent choosing
+hundreds of assets cannot do per-item rights reasoning reliably, and a single
+bad pick is a real liability. This is why Pexels outranks Videvo, and why the
+Freesound and Wikimedia scripts filter by licence rather than trusting a
+search rank.
+
+**What would change our mind:** a generator that reliably renders legible text
+and holds identity across shots would collapse steps 2–4 into "just generate".
+Re-run the ladder when that lands; it is a claim about today's failure rates,
+not a principle.
+
+---
+
+## Public-domain archives (free, mostly no key)
+
+The tier we were missing. No credential, no billing, no quota — these work on
+a machine with nothing configured.
+
+| Archive | What | Key | Status |
+|---|---|---|---|
+| **NASA Image and Video Library** | 140k+ space/earth/science images, video, audio | none | ✅ wired + verified (`stock_archive.py --source nasa`) |
+| **Wikimedia Commons** | Vast; images, some video/audio, per-item licences | none | ✅ wired + verified (`--source wikimedia`, licence-filtered) |
+| Internet Archive | Huge; film, stock-footage collection, audio | none | 🟡 next — deepest historical film, but quality varies wildly |
+| Library of Congress | US historical photography, film, audio | none | 🟡 strong for archival/period looks |
+| Smithsonian Open Access | 4M+ CC0 items, objects and specimens | free key | 🟡 excellent for objects on clean backgrounds |
+| Met Museum Open Access | ~500k CC0 artworks | none | 🟡 art/history subjects |
+| NOAA / USGS | Weather, ocean, geology, satellite | none | 🟡 natural-world b-roll, US Gov public domain |
+| Openverse | Aggregator across CC sources | none | 🟡 one query, many libraries — good discovery, verify licence per hit |
+| Flickr Commons | Institutional photo archives, no known restrictions | free key | 🟡 historical photography |
+
+**Opinion:** NASA and Wikimedia first because they need no credential at all —
+which means they are the only sources guaranteed to work in a fresh
+environment. Internet Archive is the highest-value addition next (deepest
+film archive), but its quality floor is low enough that `--list` review
+before use is mandatory rather than optional.
+
+**Honest limit:** archives are deep in science, space, history, nature and
+civic life, and thin-to-absent on staged modern subjects — a lamp on a desk,
+a person using an app, a product on white. Do not promise a scene from these
+without checking with `--list` first. The step-3 stock tier exists precisely
+to cover that gap.
+
+---
+
+## The headline: stop buying video for static b-roll
+
+A generated 6s clip costs **~$0.36**. A generated still costs **$0.02–0.04**.
+Now that the composer has eased Ken Burns drift, a still with `ken` reads as
+footage for any b-roll that isn't intrinsically motion (an object, a document,
+a place, a product). That is a **~10x cost reduction on the most common b-roll
+slot**, and it removes a whole class of generation defects at the same time —
+stills don't warp faces, drift identity, or invent motion you didn't ask for.
+
+**Rule of thumb:** generate video only when the *motion itself* carries meaning
+(a person acting, a process happening, a camera move through space). Otherwise
+generate a still and move the camera in the composer.
+
+This alone would have taken the coffee demo (17 clips, $8.76) to roughly $2.50.
+
+---
+
+## Stock (free, licensed, zero marginal cost)
+
+| Source | What | Terms | Limits | Verdict |
+|---|---|---|---|---|
+| **Pexels** | Video + images, to 4K | Own licence, commercial OK, **no attribution required** | 200/hr, 20k/mo; lifted free if you display attribution | 🟡 **Primary pick.** Cleanest terms of any free source; one licence for the whole catalogue means the agent can pick without a per-item legal check. |
+| **Pixabay** | Video + images, 230k+ clips | Own licence, commercial OK, no attribution | 100/60s; **must cache 24h** | 🟡 Second source — different catalogue, so it widens coverage. The cache rule is a real constraint: store results, don't re-query per render. |
+| **Freesound** | Sound effects, field recordings | ⚠️ **Per-sound** CC0 / CC-BY / CC-BY-NC | Throttled, 429s on burst | 🟡 Good for SFX, but licence varies *per item* — filter to CC0 first, CC-BY only if we emit credits. Same discipline as our CC-only footage rule. |
+| Videvo / Videezy | Video | Mixed per-clip; some require attribution | — | ⛔ **Avoid for automation.** Per-clip licence variation is fine for a human picking one clip, and a liability when a machine picks hundreds. |
+
+**Opinion:** wire Pexels first and make it the default answer to "find free
+online". It is the only source where an agent can choose freely without
+per-item licence reasoning, which is exactly what automation needs.
+
+### Subject is not the predictor — shot type is
+
+The rule above keys on the SUBJECT ("real + everyday -> stock"). That is not
+enough, and a measured failure shows why.
+
+The brand-origin-brick video was re-sourced from stock on the reasoning that a
+plastic toy brick is real, everyday and mass-produced, so stock must cover it.
+Stock lost all four brick scenes to the paid generated takes:
+
+| Scene | Needed | Stock returned |
+|---|---|---|
+| hook | single brick, studio-lit, isolated | a child with WOODEN cubes |
+| era-3 | underside macro showing the hollow tubes | a family on a living-room rug |
+| era-4 | two bricks engaging, macro | a Jenga tower reading "MAKE MONEY" |
+| landing | brick in fingertips, plain ground | the same Jenga tower again |
+
+Stock catalogues are built for lifestyle and editorial use — *people using
+things in rooms*. They are not built for **isolated studio product macro**,
+which is commissioned work nobody uploads for free. So:
+
+> **Stock is strong on subjects in context, and a desert for objects in
+> isolation.** A studio hero shot, a product macro, or a mechanism close-up is
+> a generation job even when the object is utterly ordinary.
+
+Two corollaries worth keeping:
+
+- **Generation's known weaknesses did not apply here.** Its failure modes are
+  faces, legible text, and identity continuity. A rigid, untextured, unbranded
+  object has none of those, which is exactly why it won this comparison. Judge
+  generation per shot, not per video.
+- **Real footage can carry worse text than generated footage.** The Jenga clip
+  had "NARCISSISM" and "MAKE MONEY" burned into the blocks — legible, on-screen
+  and wildly off-message. Pseudo-text at least reads as texture; real text reads
+  as a statement. Screen stock frames for unwanted text the same way you would
+  screen a generated frame.
+
+**Vocabulary matters more than expected.** "block" biases toward wooden cubes
+and Jenga; "plastic building bricks" returns masonry walls, because *brick* is
+ambiguous. The trademarked term "lego" is well tagged (2,060 video results) and
+was the single best query. An earlier note here claimed trademark suppresses
+tagging — that was inferred from a 401 with no key, and is wrong.
+
+**Endpoints rot.** `gen_image.py` targeted Imagen's `:predict` endpoint, which
+now answers `404 ... no longer available to new users` for every imagen-4.0
+model — fast, standard and ultra alike. The script was dead against a current
+key and nobody knew, because nothing had called it since. Two lessons encoded
+in the script: a model listed by ListModels may still be uncallable (all three
+imagen models are listed and all three 404), and the published cURL examples
+can be wrong for your API version (they show
+`responseFormat.image.aspectRatio`, which takes an enum and rejects every
+string form; the working field is `imageConfig.aspectRatio`). Verified
+2026-08-05.
+
+**Gemini image models have no free tier.** A 429 on them is not an exhausted
+daily budget that will come back tomorrow — it is the absence of any allowance.
+All three quota metrics report `limit=None`, and waiting a full day changed
+nothing. Text models on the same key answer fine, which makes this easy to
+misread as a transient outage; it is a billing gate. Do not tell someone to
+"wait for the reset". Verified across 2026-08-05 and 2026-08-06.
+
+**Single-provider categories are a trap.** Generated images had exactly one
+wired provider, so when it turned out to be billing-gated the whole category
+went to zero with no fallback. Categories with a free, keyless floor (archives)
+or two independent sources (stock) degraded gracefully; this one did not.
+
+**Pexels needs a key from request one** — free, no billing, 30 seconds at
+pexels.com/api. Do not be misled into thinking otherwise: a handful of popular
+queries answer *without* a key, which briefly looked like a free anonymous
+tier. They are Cloudflare cache hits — `query=sky` came back
+`cf-cache-status: HIT` with `age: 17118`, i.e. a 4.75-hour-old copy of somebody
+else's authenticated request. Any query that actually reaches Pexels 401s.
+Verified 2026-08-05.
+
+---
+
+## Generated video
+
+| Provider | Price | Notes | Verdict |
+|---|---|---|---|
+| **Veo 3.1 Lite** | ~$0.05/s | Cheapest credible tier. **We already have the key and `gen_veo.py`.** | 🟡 Make this the default generator; MiniMax becomes the fallback. |
+| MiniMax (Hailuo) | ~$0.06/s | 1080P is 6s-only; landscape-only output | ✅ Wired. Fine, but no longer the cheapest. |
+| Wan 2.6 | ~$0.05/s | Native 1080p, budget-oriented | 🟡 Worth a bake-off against Veo Lite. |
+| Kling 3.0 | ~$0.10/s | Reported to punch above its price | 🟡 Quality tier when a hero shot matters. |
+| Runway Gen-4.5 | ~$0.15/s | Best creative-control tooling | 🟡 Reserve for shots needing real direction. |
+| Veo 3.1 Standard | ~$0.40/s | Includes native audio | ⛔ For our formats — we supply our own voice and music, so we'd be paying 8x for audio we discard. |
+
+**Opinion:** a three-tier ladder, chosen per shot rather than per project —
+**Veo Lite** for ordinary b-roll, **Kling** when a shot is the hero, **Runway**
+only when a shot needs directing. Most projects should never leave tier one.
+
+---
+
+## Generated audio
+
+| Provider | Price | Licence | Verdict |
+|---|---|---|---|
+| **Lyria 3** (Gemini API) | billed per clip | Clean terms; Google-trained on licensed music | 🟡 **The pick when billing is on.** Same `GEMINI_API_KEY` as Veo and the image models, so no new account. ⚠️ **Free tier quota is literally `limit: 0`** — an unbilled project gets a 429 that reads like rate limiting and never clears. Duration is a PROMPT HINT, not a parameter; measure what comes back. |
+| **ElevenLabs Music** | ~$0.15/min (API) | Clean commercial terms, settled before launch | 🟡 **The pick when an exact length matters** — it takes `music_length_ms`, the only one here that does. |
+| Stable Audio | ~$0.20/generation | Clean commercial terms | 🟡 Viable third source (via the aggregator key). |
+| MiniMax music | free tier works unbilled (RPM 3) | ⚠️ Training-data position not established | 🟠 **Internal/experimental only — never under client work.** Deliberately excluded from the `auto` provider chain so it can only be chosen by name. Landmine: `lyrics` is REQUIRED even for an instrumental (omitting it returns status 2013 "invalid params"); pass `"[instrumental]"`. Ignores requested duration — returned ~115s for a 35s ask. |
+| Suno / Udio | $10–30/mo | ⚠️ Training-data litigation unresolved; **Suno has no public API, Udio none at all** | ⛔ **Avoid.** Best-sounding output, but we cannot ship client work on unsettled rights, and there's no API to automate anyway. |
+| Kokoro (voice) | free, local | — | ✅ Wired. Keep for narration. |
+
+**Opinion:** this is the one category where the quality leader is the wrong
+choice. Rights beat sound: Lyria or ElevenLabs on clean terms beats a
+better-sounding track we might have to pull later. Revisit if the litigation
+settles.
+
+**Mixing a bed (learned by shipping an inaudible one):** measure, do not guess.
+A bed generated at −15 LUFS with a −17dB gain and `sidechaincompress
+threshold=0.02:ratio=9` came out **completely inaudible** — every level probe
+read ±0.2dB against the un-bedded mix, and nothing in the logs said so.
+Working values against −14 LUFS dialogue: `volume=-5dB` with
+`threshold=0.1:ratio=4:attack=10:release=350`. Verify by probing RMS in a
+speech gap versus under loud speech — a bed should lift the gaps by ~6dB and
+vanish (~0dB) under the loudest line.
+
+---
+
+## Generated images
+
+| Provider | Price | Notes | Verdict |
+|---|---|---|---|
+| **Gemini image models** | ~$0.01–0.13 | Same key as Veo | 🟡 **Default still generator** — one credential, clean licence. Needs billing enabled — there is NO free allowance for image models, so this is not a zero-cost option however small the per-still price. |
+| Flux 1.1 Pro | ~$0.04 | Strong general quality | 🟡 Second source. Note `[dev]` weights are non-commercial without a licence. |
+| Ideogram 3.0 | ~$0.03 | Best at *readable text inside images* | 🟢 Interesting but mostly moot for us: we render text as composer typography precisely because generated text is unreliable. Useful only for signage/props that must look printed. |
+| Midjourney | — | More restrictive commercial terms | ⛔ Not for client-facing work. |
+
+---
+
+## Suggested integration order
+
+1. **`gen_image.py` (Gemini image models)** — biggest win per hour of work. Unlocks
+   the still+Ken Burns path and the 10x b-roll saving. Existing key.
+2. **`stock_pexels.py`** — makes "find free online" genuinely useful and free.
+   Replaces the fragile CC-filtered video search as the default.
+3. **Default generator → Veo Lite** — a config change plus a bake-off render.
+4. **`gen_music.py` (ElevenLabs Music)** — closes the last "supply your own
+   file" gap in the cinematic format.
+5. Kling / Runway as opt-in quality tiers, once tiering is worth the code.
+
+Each is a script plus a row in the sourcing question — no composer changes,
+because every one of them lands as an existing layer type.
+
+## Sources
+
+- [Pexels API](https://www.pexels.com/api/documentation/) · [rate limits](https://help.pexels.com/hc/en-us/articles/900005852323-How-do-I-get-unlimited-requests)
+- [Pixabay API](https://pixabay.com/api/docs/)
+- [Freesound APIv2](https://freesound.org/docs/api/overview.html) · [terms](https://freesound.org/docs/api/terms_of_use.html)
+- [AI video API pricing, July 2026](https://www.buildmvpfast.com/api-costs/ai-video) · [comparison](https://rangy.ai/blog/ai-video-generators-compared-2026/)
+- [AI music platforms compared](https://www.digitalapplied.com/blog/ai-music-generation-platforms-suno-udio-elevenlabs-2026) · [music API comparison](https://musicapi.ai/blog/best-ai-music-api-2026)
+- [Image API pricing](https://www.buildmvpfast.com/api-costs/ai-image) · [12 providers compared](https://www.digitalapplied.com/blog/ai-image-generation-api-pricing-comparison-2026)

--- a/references/reference-mining.md
+++ b/references/reference-mining.md
@@ -1,0 +1,92 @@
+# Mining reference galleries for format definitions (internal)
+
+A plan for turning public "made with X" galleries into new `formats/*.md`
+entries. Written against the Motion community gallery
+(`motion.so/community`), but the method generalises to any gallery that
+publishes prompt + result together.
+
+## Why this gallery specifically
+
+Inspected 2026-08. It publishes, for each item: **the user's full prompt, the
+author, the date, an engagement count, and the resulting video.** That pairing
+is unusual and valuable — most galleries show only output. We get to see what
+people actually asked for *and* what the tool made of it, which is exactly the
+input needed to write a format's `## Interview` and `## Grammar` sections.
+
+Roughly 48 items per gallery page; videos render on the item page rather than
+inline, so extraction is per-item, not a single scrape.
+
+Observed prompt archetypes on page one alone, each a plausible format:
+- **Documentary-graphics overlay** — "talking head of Naval, add documentary
+  style motion graphics in the middle"
+- **Product launch spot** — "40 second launch video for AI retail management"
+- **Threaded explainer** — the Apple-CEO-history thread, numbered beats with
+  emoji section markers
+- **News explainer, house style** — "vox style explainer, 2 minutes"
+- **Branded series episode** — the chalkboard-animation piece, with palette,
+  canvas, audience, and tone all specified
+
+That last one is the tell: the strongest prompts read like **briefs**, not
+sentences. They pin canvas, duration, palette, audience, and emotional goal.
+That is the same shape as our format files, which is encouraging — it suggests
+our interview questions are asking for roughly the right things.
+
+## Boundary (read first)
+
+Study the **grammar**, don't clone the **content**. We reproduce structural
+patterns — beat ordering, shot vocabulary, pacing, how text is used — and then
+write original scripts and subjects, exactly as we did for the native-ad format
+(analysed a real ad, shipped an original pet-insurance script; never reused
+the source's script or footage). Do not re-render someone's specific creative
+piece and present it as ours, and don't republish their videos.
+
+## Phases
+
+**1 — Harvest (cheap, no rendering).** Per item: prompt text, author, date,
+engagement, item URL, video URL. Engagement is a weak but free quality signal;
+use it to rank candidates, not to conclude anything. Store as
+`corpus/reference/<gallery>/<slug>.json`. Ranking heuristic: prefer prompts
+that specify canvas + duration + audience, and outputs whose structure is
+legible in under three viewings.
+
+**2 — Characterise (our own tooling, free).** Run the quality check over each
+downloaded video for scene count, cut cadence, caption density, motion
+profile. Sample frames at scene boundaries. The goal is a one-page grammar per
+candidate: how many beats, how long, what changes at each cut, where text
+appears, whether the camera moves. This is the same read we did on the
+Cybertruck ad — and it caught the shrinking-host PIP mechanic that a casual
+viewing missed entirely.
+
+**3 — Draft a format file.** Turn each grammar into `formats/<name>.md`:
+composition settings, interview questions (derived from what the strong
+prompts specify), slots, grammar rules, render notes. No code, by design.
+
+**4 — Re-create as an original.** New subject, new script, our own footage.
+Placeholder preview first, then resolve sources. Budget: aim under $3 per
+candidate using the still+Ken Burns path from `providers.md`.
+
+**5 — Compare and record.** Quality-check ours, and note honestly where the
+reference does something we structurally cannot yet (that's the interesting
+part — it becomes the next composer feature, the way the PIP mechanic did).
+Log per candidate in the format file's own notes.
+
+## Suggested first three
+
+Chosen for structural distance from what we already have:
+
+1. **Documentary-graphics overlay** — closest to a gap we know we have: text
+   and graphics *over* talking-head footage, timed to speech. Reuses the
+   pointer-popups timing machinery.
+2. **Threaded explainer** — numbered beats with strong section markers; tests
+   whether our card layers can carry a whole video rather than accent it.
+3. **Branded series episode** — palette/tone/audience-driven, single visual
+   idiom throughout. Tests whether a format file can carry a *brand*, not just
+   a shape.
+
+## Unknowns to settle before phase 1
+
+- Whether item pages expose a stable video URL, or need a browser session.
+- Whether the gallery has pagination / an internal JSON endpoint (48 items on
+  page one suggests paging).
+- Their terms on automated access — check before any bulk harvesting; a slow,
+  small, manual-scale pass is the safe default regardless.

--- a/references/stack.md
+++ b/references/stack.md
@@ -1,0 +1,32 @@
+# Internal stack (maintainers only)
+
+Everything here is an implementation detail. It is deliberately absent from
+user-facing prose — see the house-vocabulary table in `SKILL.md`. Keep this
+file the single place these names live outside of executable code.
+
+| Role | What we actually use | Notes |
+|---|---|---|
+| Composer / editor | Remotion 4.0.x | Original compositions, no vendored third-party code. `npx remotion studio` = "the editor"; `npx remotion render` = rendering. **Not in this repo** — the composer is a separate, externally licensed tree, so nothing here can render on its own. |
+| Quality gate | `qc_render.py` (bundled) + `video-studio qc_analyze` | Two sizes. The bundled one needs no install and checks a render against its plan; `qc_analyze` decodes frames and needs `[qc]`. Both = "the quality check". Superseded showwatcher, which was never published. |
+| Clip generation | MiniMax (Hailuo), Google Veo | `video-studio gen_minimax`, `video-studio gen_veo`. Quirks in `api-landmines.md`. |
+| Voice | Kokoro (local, free) | `video-studio tts_kokoro` = "the built-in voice". |
+| Planning LLM | Gemini (text) | Agent-side; no dedicated script. |
+| Free footage search | yt-dlp, Creative-Commons filtered | `video-studio source_clips` = "free footage libraries". |
+| Gesture analysis | MediaPipe Tasks (HandLandmarker) | `video-studio track_pointing`. |
+| Media probing / keying | ffmpeg + ffprobe | `measure.py` (bundled in audio-acquisition), `prekey.py` (bundled in media-acquisition). |
+| Optional asset library | OpenMontage (external, AGPLv3) | Invoked as an external tool only — never vendored, to keep this repo's licence clean. |
+
+## Why the abstraction
+
+Two reasons, both practical rather than cosmetic:
+
+1. **Product surface.** What the user experiences is "a video studio", not a
+   list of third-party dependencies. Naming vendors invites questions we do
+   not want to field ("why MiniMax?", "is my footage going to Google?") in the
+   middle of a creative session.
+2. **Swappability.** Every row above is expected to change — see
+   `references/providers.md` for the evaluation of alternatives. If users
+   learned the stack by name, each swap becomes a support event.
+
+If a user asks directly, answer honestly. This is about not volunteering
+implementation detail, not about concealing it.

--- a/references/third-party.md
+++ b/references/third-party.md
@@ -1,0 +1,149 @@
+# Third-party tools — inventory, triage, and how to switch each on
+
+`providers.md` answers "which source should this SHOT use". This answers
+"what exists, what is on, and what should I turn on next". Run
+`doctor.py` (bundled in studio-setup) for live status on the current machine; this file is the
+map, not the state.
+
+Every entry below is something a bundled script actually calls. Nothing here is
+aspirational.
+
+---
+
+## Triage
+
+**Tier 0 — without these, nothing works.**
+
+| Tool | Why | Activate |
+|---|---|---|
+| `ffmpeg` + `ffprobe` | Every duration measured, every clip trimmed, all loudness and keying. 19 call sites | `brew install ffmpeg` |
+| `node` 18+ | The composer renders and previews through it | `brew install node` |
+| `uv` | Runs every bundled script with its own pinned dependencies | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+
+**Tier 1 — free, no billing, and the single biggest jump in quality.**
+
+| Tool | Gives you | Activate |
+|---|---|---|
+| **Pexels** | Modern everyday footage and stills. The one key that converts "find me footage of that" from a coin-flip into the normal answer | `PEXELS_API_KEY` — free at pexels.com/api |
+| NASA archive | Space, earth, science. Public domain | nothing — no key at all |
+| Wikimedia Commons | History, places, artefacts. Licence varies per item; the script filters | nothing — no key at all |
+| Local voice | Narration, generated on your own machine | nothing — runs locally |
+
+**If you add exactly one thing on this whole page, add Pexels.**
+
+**Tier 2 — free keys, worth having, narrower use.**
+
+| Tool | Gives you | Activate |
+|---|---|---|
+| Pixabay | Second stock library. Useful when Pexels is thin on a subject | `PIXABAY_API_KEY` |
+| Freesound | Sound effects. Licence varies per sound; the script filters | `FREESOUND_API_KEY` |
+
+**Tier 3 — paid. Quote the cost before spending, every time.**
+
+| Tool | Cost | Rights | Activate |
+|---|---|---|---|
+| Gemini image | ~0.02–0.03/still | Clean | `GEMINI_API_KEY` — needs billing, no free tier |
+| Veo | ~0.40/s | Clean | `GEMINI_API_KEY` — free-tier quota is tiny |
+| MiniMax video | ~0.36 per 6s clip | Clean | `MINIMAX_API_KEY` |
+| **ElevenLabs Music** | **from ~6 USD/mo** | **Clean — trained only on licensed catalogue (Merlin, Kobalt)** | `ELEVENLABS_API_KEY` |
+| Lyria (Google) | Paid | Clean | `GEMINI_API_KEY` — free-tier quota is literally 0 |
+| MiniMax music | Works unbilled | **UNSETTLED — internal use only** | `MINIMAX_API_KEY` |
+| Luma (via Replicate) | ~0.075/clip | Per-model | `REPLICATE_API_TOKEN`, `--preset luma` |
+| Runway (via Replicate) | ~0.40-0.48/clip | Per-model | `REPLICATE_API_TOKEN`, `--preset runway` |
+| Shutterstock | Search free; **download needs a subscription** | Standard licence | `SHUTTERSTOCK_TOKEN` |
+| Replicate | Varies | Varies per model | `REPLICATE_API_TOKEN` — one key, many models |
+
+**The music rights split is the most consequential line on this page, and it is
+cheaper to fix than it looks.** MiniMax music generates without billing, which
+makes it the path of least resistance, and its output rights are unsettled.
+ElevenLabs Music is trained *exclusively* on licensed catalogue through Merlin
+and Kobalt partnerships, and commercial use is included from roughly six
+dollars a month. For anything that will be published, that is the answer — the
+barrier was never really cost, it was that nobody had priced it.
+
+Two others worth knowing and NOT integrated: Suno has the best measured output
+quality but no official API and unsettled licensing with lawsuits in flight;
+Udio has clean deals (UMG, Warner, Merlin, Kobalt) but no public API below its
+enterprise tier. ElevenLabs is currently the only one that is both clean and
+reachable. Say which backend is in use BEFORE the user chooses,
+because the entire cut ends up shaped around whichever track arrives — a rights
+problem found afterwards means re-cutting, not re-tagging.
+
+**Tier 4 — present in the code, not currently reachable.**
+
+| Tool | State | Notes |
+|---|---|---|
+| `showwatcher` | Superseded, never published | Was the intended step-8 gate. Replaced by `qc_render.py`, bundled in `video-production` and needing no install, plus `video-studio qc_analyze` for frame-level checks. Judging whether the video is any GOOD still needs human eyes — pull frames and say that you did |
+| `yt-dlp` | One call site | Used by `source_clips.py` for `url:` sources. Install with `brew install yt-dlp` if you intend to pull from URLs |
+
+---
+
+## What should we add next
+
+Ranked by what actually went wrong in production rather than by feature count.
+
+1. **A verified-provenance stock source.** The single largest defect class so
+   far. Stock search does not respect geography: Japanese queries returned a
+   Hawaii temple, English queries returned Turkey twice and Morocco, Mexican
+   queries returned San Francisco and Colorado. Twenty-one shots were replaced
+   across three videos. `verify_clips.py` now catches duplicates, monochrome
+   and short clips, but it cannot verify that a place is the place. A source
+   that publishes shoot locations would remove a whole category of manual
+   checking.
+
+2. **A checker that can judge the PICTURE.** The mechanical half is covered:
+   `qc_render.py` proves a render matches its plan with no install, and
+   `qc_analyze` adds blur, off-palette colour, cut placement and caption timing.
+   What no tool here reports is whether the video was worth making. That
+   remains the one step whose guarantee depends on somebody looking.
+
+3. **Pika, if it ever ships an API worth having.** It is the one major video
+   generator with a free tier permitting commercial use — capped at 480p, which
+   is below the 1080x1920 every format here renders at, so it buys nothing
+   today. It also has no Replicate model, so it would need its own client
+   rather than a one-line preset.
+
+4. **A music generator that honours a requested length.** Asking for 140s has
+   returned 25s, 66s, 128s and 148s. Every track must be measured after
+   generation and the video designed to what arrived. A backend that returns
+   the length asked for would remove a re-roll loop.
+
+5. **Face or subject detection for poster frames.** `poster.py` ranks on colour
+   and contrast, which is why it put an underwater reef above a marigold market
+   for a Mexico spot. A cheap subject detector would fix the one case where the
+   ranking is reliably wrong.
+
+6. **A brand-mark detector for generated imagery.** Adobe Firefly is the commercial answer — trained on licensed Adobe Stock, so its output is commercially safe by construction and it would not have produced the swooshes. API access needs an enterprise agreement at roughly 1,000 USD a month, so this is a procurement decision rather than an integration one.
+
+7. **A local brand-mark detector**, for when Firefly is not bought. Image models reproduce real
+   trade dress unprompted — a generated sneaker sequence came back with legible
+   Nike swooshes and a Jumpman. Currently caught only by zooming frames by
+   hand before publishing.
+
+---
+
+## Deliberately not integrated
+
+- **Anything requiring an account to read.** Archives and stock that need a
+  login break the "make a whole video without signing up for anything" promise.
+- **Paid stock libraries.** The free tier covers everyday subjects well enough
+  that per-clip licensing is not justified for this pipeline's output.
+- **Cloud rendering.** The composer renders locally in minutes; a queue and a
+  bill would buy nothing at this scale.
+
+---
+
+## Activation, end to end
+
+```bash
+cd /path/to/video-studio
+cp .env.example .env          # gitignored
+$EDITOR .env                  # paste the keys you have
+the doctor script bundled in studio-setup      # what is reachable right now
+video-studio setup       # what is missing and what can be installed
+video-studio setup --yes # actually install it (asks first, changes your system)
+```
+
+Keys live in `.env` at the repo root. Every script reads plain environment
+variables, so exporting them by hand works identically — the file just saves
+doing it per shell. Holding a key costs nothing; only calls do.

--- a/skills/audio-acquisition/references/voice-landmines.md
+++ b/skills/audio-acquisition/references/voice-landmines.md
@@ -43,6 +43,14 @@ quietly.
 - **Generated music can arrive peaking at 0 dBFS**, leaving no headroom. This
   is why normalising after render is real work rather than cosmetics.
 
+## Clocks — the systemic bug class
+
+- A scene's duration is the **measured** narration WAV, never the planned
+  number. Building on planned durations desyncs audio, video and captions
+  cumulatively, and the drift grows scene by scene: 20-30 findings per video
+  before that rule, 0-6 after. `measure.py` exists so the measurement is
+  available before anything is built on a guess.
+
 ## The composer's mix
 
 - Music plays at a **fixed volume until you duck it.** The composer sets balance

--- a/skills/audio-acquisition/scripts/measure.py
+++ b/skills/audio-acquisition/scripts/measure.py
@@ -8,7 +8,7 @@ Usage:
   uv run scripts/measure.py --music TRACK      where the music actually changes
 
 The measured narration duration IS the scene clock — plans estimate,
-measurements decide (see references/api-landmines.md, "Clocks").
+measurements decide (see references/voice-landmines.md, "Clocks").
 
 --music exists because "cut to the music" is otherwise guesswork. It reports a
 per-second loudness profile and, more usefully, the transitions: the points

--- a/src/video_studio/styles/documentary.md
+++ b/src/video_studio/styles/documentary.md
@@ -1,0 +1,59 @@
+---
+name: documentary
+description: Restrained ink-on-cream captions and quiet lower-thirds
+---
+
+# documentary
+
+For pieces where the footage is the argument and the type stays out of its way.
+One flat colour rather than a per-word palette, no bounce, no wiggle, a thin
+stroke that exists only to hold the words off a busy background.
+
+Use it for explainers, histories and anything narrated in earnest. The
+temptation on a serious subject is to reach for the loud preset because it
+"performs better" — it also makes a piece about something difficult look like
+an advert.
+
+Cards sit as lower-thirds rather than centre-frame, so a name or a date can
+appear without interrupting the shot.
+
+```json
+{
+  "captions": {
+    "color": "#f8fafc",
+    "highlight": "#fbbf24",
+    "stroke": "#0f172a",
+    "strokeWidth": 5,
+    "fontSize": 54,
+    "uppercase": false,
+    "bounce": 1,
+    "wiggle": 0,
+    "wordsPerPage": 5,
+    "wordGap": 0.18,
+    "bottom": 0.12
+  },
+  "cards": {
+    "label": {
+      "bg": "#0f172a",
+      "fg": "#f8fafc",
+      "tracking": 0.06,
+      "rect": [0.06, 0.8, 0.62, 0.075],
+      "fade": { "in": 0.4, "out": 0.3 }
+    },
+    "stat": {
+      "bg": "#fef3c7",
+      "fg": "#78350f",
+      "tracking": 0.04,
+      "rect": [0.06, 0.76, 0.6, 0.12],
+      "fade": { "in": 0.4, "out": 0.3 }
+    },
+    "title": {
+      "bg": "#0f172a",
+      "fg": "#f8fafc",
+      "tracking": 0.1,
+      "rect": [0.1, 0.4, 0.8, 0.2],
+      "fade": { "in": 1.0, "out": 0.6 }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/loud-social.md
+++ b/src/video_studio/styles/loud-social.md
@@ -1,0 +1,54 @@
+---
+name: loud-social
+description: Big outlined per-word captions that survive a muted autoplay feed
+---
+
+# loud-social
+
+For the feed, where most viewers never unmute. Captions carry the whole
+message, so they are large, uppercase, cycled through a colour per word, and
+outlined heavily enough to stay legible over any footage.
+
+The two numbers that matter and are easy to get wrong:
+
+- `wordsPerPage: 3` — at this size four words overrun the frame width on a
+  1080-wide canvas. The default of 4 is tuned for smaller type.
+- `wordGap: 0.34` — a thick stroke grows each word's visual box. At the default
+  gap, outlined words at this size visibly merge into one another. Raise the
+  gap whenever you raise the stroke.
+
+Cards are deliberately plain here: when the captions are this loud, a styled
+card competes with them instead of supporting them.
+
+```json
+{
+  "captions": {
+    "palette": ["#fde047", "#f472b6", "#38bdf8", "#4ade80"],
+    "stroke": "#000000",
+    "strokeWidth": 14,
+    "fontSize": 88,
+    "uppercase": true,
+    "bounce": 1.16,
+    "wiggle": 2,
+    "wordsPerPage": 3,
+    "wordGap": 0.34,
+    "bottom": 0.2
+  },
+  "cards": {
+    "label": {
+      "bg": "#0f172a",
+      "fg": "#f8fafc",
+      "tracking": 0.12,
+      "rect": [0.06, 0.06, 0.6, 0.08],
+      "pop": true
+    },
+    "title": {
+      "bg": "#0f172a",
+      "fg": "#fde047",
+      "tracking": 0.16,
+      "rect": [0.08, 0.36, 0.84, 0.24],
+      "fade": { "in": 0.6, "out": 0.4 }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/tourism.md
+++ b/src/video_studio/styles/tourism.md
@@ -1,0 +1,78 @@
+---
+name: tourism
+description: Place labels, stat cards and a wordmark — the destination-spot look
+---
+
+# tourism
+
+The look used by the country spots: a saturated brand colour carrying white
+labels, inverted for stat cards so a number reads as a fact rather than a
+caption, and the wordmark held large in the centre for the open and close.
+
+Four roles:
+
+- `label` — a place name, bottom-left. Short strings only; `label-wide` exists
+  because "PLAYA DEL CARMEN" in a `label` rect crushes the tracking.
+- `stat` — cream on brand, for a number with a unit underneath.
+- `title` — the wordmark, centre frame, for the open and the final chorus.
+- `cta` — inverted title, for the closing line.
+
+Swap the two colours and the whole system re-skins. The rects are shared, which
+is the point: three spots built by hand drifted to three different label
+heights for the same kind of label.
+
+**On location labels:** this preset styles them, it does not license them. Only
+put a place name on a shot whose source metadata names that place — stock search
+returned a Hawaii temple for a Japanese query and a Colorado canyon for a
+Mexican one in the same week this preset was written.
+
+```json
+{
+  "captions": {
+    "fontSize": 64,
+    "stroke": "#000000",
+    "strokeWidth": 8,
+    "wordGap": 0.26,
+    "wordsPerPage": 3,
+    "uppercase": true,
+    "bottom": 0.16
+  },
+  "cards": {
+    "label": {
+      "bg": "#be185d",
+      "fg": "#fffbeb",
+      "tracking": 0.14,
+      "rect": [0.06, 0.775, 0.58, 0.085],
+      "pop": true
+    },
+    "label-wide": {
+      "bg": "#be185d",
+      "fg": "#fffbeb",
+      "tracking": 0.1,
+      "rect": [0.06, 0.775, 0.74, 0.085],
+      "pop": true
+    },
+    "stat": {
+      "bg": "#fffbeb",
+      "fg": "#be185d",
+      "tracking": 0.1,
+      "rect": [0.06, 0.735, 0.68, 0.135],
+      "pop": true
+    },
+    "title": {
+      "bg": "#be185d",
+      "fg": "#fffbeb",
+      "tracking": 0.18,
+      "rect": [0.1, 0.38, 0.8, 0.22],
+      "fade": { "in": 0.9, "out": 0.5 }
+    },
+    "cta": {
+      "bg": "#fffbeb",
+      "fg": "#be185d",
+      "tracking": 0.08,
+      "rect": [0.08, 0.38, 0.84, 0.22],
+      "fade": { "in": 0.8 }
+    }
+  }
+}
+```


### PR DESCRIPTION
The last content in the private `video-studio` tree apart from the composer — and six of these were worse than absent, because **shipped code pointed at them by path**:

| pointer | in |
|---|---|
| `references/api-landmines.md` | `skills/audio-acquisition/scripts/measure.py:11` — a **bundled** script |
| `references/api-landmines.md` | `gen_minimax.py:11`, `gen_veo.py:11` |
| `references/providers.md` | `gen_music.py:17` — the rights reasoning for refusing MiniMax on client work |
| `references/third-party.md` | `tutorials/tools-and-keys.md:15` |

`gen_minimax.py:34` went further: *"update in api-landmines.md if it drifts"* — maintenance instructions pointing into a repo the reader doesn't have.

## Translation, not just copying

The docs were written for the pre-packaging layout. `scripts/<name>.py` became `video-studio <name>` for the 26 engine programs, or a named bundled script for the six that ship inside skills.

`stack.md` and `third-party.md` still described **showwatcher** as the step-8 gate; both now say it was superseded by `qc_render.py` and `qc_analyze`. And `stack.md`'s composer row now states plainly that **the composer is not in this repo** — the single most important thing a maintainer reading that table needs to know.

## `measure.py` needed more than a path rewrite

It's **bundled** in `audio-acquisition`, so from an installed skill folder `references/…` resolves *inside that skill*, not at the repo root. Fixing the root copy alone would have left it dangling for every real user while looking fixed in the repo.

Copying 120 lines of `api-landmines.md` into the skill for one four-line section is the wrong trade. The clocks rule now lives in `voice-landmines.md` — which that skill already ships — and `measure.py` points there.

## The presets

No translation needed; they were already in `styles.py`'s format and all three validate with **zero** unknown keys.

Porting `tourism.md` also fixes `styles.py:9`, whose own docstring example is `--show tourism`. The CLI has been demonstrating a command that resolved to nothing. **14 presets now.**

## Verification

Every `references/*.md` pointer in the repo resolves — swept programmatically, not by reading. `verify-skills` green. `styles --show tourism` works.

## Still private after this

`gen_chalk.py`, `gen_sneaker_origin_art.py`, `tts_eleven.py` — each needs a module home, a `COMMANDS` entry and a skill mention, so they're a separate PR. And the composer, which is a licensing decision rather than a file move.