### PR TITLE
Make the docs correspond to the code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# Provider credentials. Copy to .env — which is gitignored — and fill in only
+# what you need. Nothing here is required to install or to use the prose
+# skills; each key unlocks one source, and `doctor.py` reports which are live.
+#
+# Every one of these is optional. A key that is absent disables its source
+# cleanly and says so; a key that is present but rejected fails at call time,
+# which the individual programs report.
+
+# Public-domain archives need no key at all (NASA, Wikimedia Commons).
+
+# Stock footage and images
+PEXELS_API_KEY=
+PIXABAY_API_KEY=
+SHUTTERSTOCK_TOKEN=
+SHUTTERSTOCK_KEY=
+
+# Stock audio
+FREESOUND_API_KEY=
+
+# Google: generated video (Veo), generated stills, and generated music (Lyria).
+# One credential covers all three. Lyria and the image models need billing
+# enabled on the project — their free-tier quota is zero.
+GEMINI_API_KEY=
+GOOGLE_API_KEY=
+
+# Generated video, cheaper per second. Note the rights position on its training
+# data is unsettled — internal and experimental work only.
+MINIMAX_API_KEY=
+
+# Many models behind one key.
+REPLICATE_API_TOKEN=
+
+# Paid narration and music. The local voice (tts_kokoro) is free and offline;
+# reach past it deliberately.
+ELEVENLABS_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 .root
+
+# Provider credentials. .env.example is the template and IS tracked; the
+# filled-in .env never is — setup's own repair step creates it by copying.
+.env
 .DS_Store
 
 # Python build artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,11 @@ vision = [
   # No opencv named here on purpose. mediapipe hard-requires
   # opencv-contrib-python, so declaring opencv-python alongside it put two
   # providers of the same cv2 module in one environment and left the winner to
-  # installation order. [qc] names contrib for the same reason.
+  # installation order. [qc] names none either, for the related reason set out
+  # in its own comment: scenedetect drags in opencv-python transitively, so
+  # naming a distribution there only ADDED a provider. Neither extra declares
+  # opencv; both get one through a dependency that hard-requires a specific
+  # build. [standard] still ends up with two, which that comment explains.
 ]
 
 # Timeline interchange. CapCut and FCPXML need nothing; OTIO is only for

--- a/skills/video-production/SKILL.md
+++ b/skills/video-production/SKILL.md
@@ -57,19 +57,19 @@ Projects cannot collide on content — each owns its props file, its media direc
 ## Step 8: what the gate does and does not cover
 
 `scripts/qc_render.py --video <render> --plan project/plan.json` checks the file
-against the plan `build_props` wrote for it: duration, the plan's own
-consistency, a black tail, a frozen ending, and with `--storyboard`, resolution
-and fps. Non-zero exit on failure, so it can gate. It decodes no frames, which
-is what keeps it install-free — run it on every render.
+against the plan `build_props` wrote: duration, the plan's own consistency, a
+black tail, a frozen ending, and with `--storyboard`, resolution and fps.
+Non-zero exit, so it can gate. It decodes no frames — run it on every render.
 
-The heavier gate decodes: `video-studio qc_analyze --video <render> --project
-<dir>` adds blur, off-palette colour, cut placement, caption timing against the
-word timings, and with the model extras, whether the planned subject is on
-screen. Needs the `[qc]` extra. Reach for it when a render surprises you, or
-before anything ships to a client.
+The heavier gate does decode. `video-studio qc_analyze --video <render>
+--project <dir>` adds blur, off-palette colour, cut placement and caption
+timing, plus planned-subject checks with the model extras. Needs `[qc]`. Reach
+for it when a render surprises you, or before anything ships to a client.
 
 Neither judges whether the video was worth making. The gate is two moves: run a
-checker, then `scripts/poster.py` and **open the contact sheet**. Say which.
+checker, then `scripts/poster.py` and **open the contact sheet** — say which. To
+report a day's output, `video-studio daily_digest` turns `git log` and a
+`runs/<date>/` tree into chat-sized plain text.
 
 ## Anti-patterns
 

--- a/src/video_studio/audio/duck_music.py
+++ b/src/video_studio/audio/duck_music.py
@@ -4,10 +4,10 @@
 """Duck the music bed under the narration. A post-pass over built props.
 
 Usage:
-  uv run scripts/duck_music.py --composer composer/ --project projects/foo
-  uv run scripts/duck_music.py --composer composer/ --project projects/foo \
+  video-studio duck_music --composer composer/ --project projects/foo
+  video-studio duck_music --composer composer/ --project projects/foo \
       --base 0.16 --depth 0.65          # louder bed / deeper dip
-  uv run scripts/duck_music.py ... --dry-run    # report, write nothing
+  video-studio duck_music ... --dry-run    # report, write nothing
 
 WHAT THE COMPOSER MUST DO WITH THIS. The envelope is written into the props as
 `music.envelope` — one value per COMPOSITION frame — alongside `music.baseVolume`.

--- a/src/video_studio/audio/gen_captions.py
+++ b/src/video_studio/audio/gen_captions.py
@@ -5,11 +5,11 @@
 """Word timings for narration this studio did not synthesise.
 
 Usage:
-  uv run scripts/gen_captions.py --audio projects/x/audio/hook.wav
-  uv run scripts/gen_captions.py --audio projects/x/audio/hook.wav \
+  video-studio gen_captions --audio projects/x/audio/hook.wav
+  video-studio gen_captions --audio projects/x/audio/hook.wav \
       --timings-out projects/x/audio/hook.timings.json
-  uv run scripts/gen_captions.py --project projects/x        # every scene WAV
-  uv run scripts/gen_captions.py --project projects/x --force # redo existing
+  video-studio gen_captions --project projects/x        # every scene WAV
+  video-studio gen_captions --project projects/x --force # redo existing
 
 Why this exists: tts_kokoro already emits `<scene>.timings.json` beside every
 WAV it synthesises, and build_props turns that into on-screen captions. Any

--- a/src/video_studio/audio/gen_music.py
+++ b/src/video_studio/audio/gen_music.py
@@ -6,11 +6,11 @@
 
 Usage:
   # auto-picks whichever provider has a key (Lyria preferred — see below):
-  uv run scripts/gen_music.py \
+  video-studio gen_music \
       --prompt "calm lo-fi bed, warm keys, no drums, unobtrusive under speech" \
       --seconds 35 --out projects/x/audio/music.mp3
 
-  uv run scripts/gen_music.py --provider elevenlabs ...   # force one
+  video-studio gen_music --provider elevenlabs ...   # force one
 
 Both options were chosen for RIGHTS, not for sound. The best-sounding music
 generators have unresolved training-data litigation and mostly no public API,

--- a/src/video_studio/audio/music_catalog.py
+++ b/src/video_studio/audio/music_catalog.py
@@ -4,14 +4,14 @@
 """The tracks you are licensed to use, and a deterministic way to pick one.
 
 Usage:
-  uv run scripts/music_catalog.py --where                  # where the catalog lives
-  uv run scripts/music_catalog.py --list                   # every track
-  uv run scripts/music_catalog.py --list --mood editorial  # filtered
-  uv run scripts/music_catalog.py --show warm-keys-01      # one track, resolved
-  uv run scripts/music_catalog.py --add path/to/track.mp3 --id warm-keys-01 \
+  video-studio music_catalog --where                  # where the catalog lives
+  video-studio music_catalog --list                   # every track
+  video-studio music_catalog --list --mood editorial  # filtered
+  video-studio music_catalog --show warm-keys-01      # one track, resolved
+  video-studio music_catalog --add path/to/track.mp3 --id warm-keys-01 \
       --moods editorial,warm --bpm 96 --license "Artlist, invoice 4471"
-  uv run scripts/music_catalog.py --remove warm-keys-01
-  uv run scripts/music_catalog.py --pick --moods editorial,warm --bpm 96 \
+  video-studio music_catalog --remove warm-keys-01
+  video-studio music_catalog --pick --moods editorial,warm --bpm 96 \
       --seed brand-origin-brick
 
 Why this exists: `gen_music` makes a bed from nothing, which is the right answer

--- a/src/video_studio/audio/tts_eleven.py
+++ b/src/video_studio/audio/tts_eleven.py
@@ -5,8 +5,8 @@
 # ///
 """Narration via ElevenLabs — the paid alternative to the local voice.
 
-    uv run scripts/tts_eleven.py --list
-    uv run scripts/tts_eleven.py --text "..." --voice <id> --out audio/hook.wav
+    video-studio tts_eleven --list
+    video-studio tts_eleven --text "..." --voice <id> --out audio/hook.wav
 
 The local voice (`tts_kokoro.py`) is free, runs offline, and returns word
 timings, so it stays the default and the only option for captioned formats.

--- a/src/video_studio/audio/tts_kokoro.py
+++ b/src/video_studio/audio/tts_kokoro.py
@@ -5,9 +5,9 @@
 """Kokoro TTS: narration WAV + word timings, or measured silence.
 
 Usage:
-  uv run scripts/tts_kokoro.py --text "Hello there" --voice am_adam \
+  video-studio tts_kokoro --text "Hello there" --voice am_adam \
       --out audio/hook.wav --timings-out audio/hook.timings.json
-  uv run scripts/tts_kokoro.py --silence 4.0 --out audio/beat.wav
+  video-studio tts_kokoro --silence 4.0 --out audio/beat.wav
 
 Never call with empty text — Kokoro raises "returned no audio"; use
 --silence for deliberate quiet beats (writes real silence so downstream

--- a/src/video_studio/export/burn_captions.py
+++ b/src/video_studio/export/burn_captions.py
@@ -5,18 +5,18 @@
 
 Usage:
   # one scene, subtitle file only
-  uv run scripts/burn_captions.py --timings projects/x/audio/hook.timings.json \
+  video-studio burn_captions --timings projects/x/audio/hook.timings.json \
       --out projects/x/subs/hook.ass
 
   # burn onto a clip
-  uv run scripts/burn_captions.py --timings projects/x/audio/hook.timings.json \
+  video-studio burn_captions --timings projects/x/audio/hook.timings.json \
       --video projects/x/clips/hook.mp4 --out projects/x/clips/hook-capped.mp4
 
   # a whole project, one .ass per scene, offset onto the project timeline
-  uv run scripts/burn_captions.py --project projects/x --out projects/x/subs/
+  video-studio burn_captions --project projects/x --out projects/x/subs/
 
   # take the look from a style preset
-  uv run scripts/burn_captions.py --timings ... --out ... --style tourism
+  video-studio burn_captions --timings ... --out ... --style tourism
 
 Why this exists: captions currently reach the screen ONE way — build_props
 folds `<scene>.timings.json` into composer props and Remotion draws them. Every

--- a/src/video_studio/export/export_capcut.py
+++ b/src/video_studio/export/export_capcut.py
@@ -4,9 +4,9 @@
 """Fill a CapCut project with this video's timeline — UNDOCUMENTED FORMAT.
 
 Usage:
-  uv run scripts/export_capcut.py --project projects/foo            # write the draft
-  uv run scripts/export_capcut.py --project projects/foo --install  # fill a CapCut project
-  uv run scripts/export_capcut.py --project foo --install --blank-project "Untitled"
+  video-studio export_capcut --project projects/foo            # write the draft
+  video-studio export_capcut --project projects/foo --install  # fill a CapCut project
+  video-studio export_capcut --project foo --install --blank-project "Untitled"
 
 WHAT CHANGED, AND WHY IT MATTERS
 --------------------------------

--- a/src/video_studio/export/export_edit.py
+++ b/src/video_studio/export/export_edit.py
@@ -5,7 +5,7 @@
 """Export a finished project as an editable timeline (Premiere, Resolve, FCP).
 
 Usage:
-  uv run scripts/export_edit.py --project projects/brand-origin-brick   # do this one
+  video-studio export_edit --project projects/brand-origin-brick   # do this one
   ... --bundle          # also write a .otiod folder with the media copied in
   ... --fcpxml          # also write FCP X XML (needs otio-fcpx-xml-adapter)
 

--- a/src/video_studio/export/export_fcpxml.py
+++ b/src/video_studio/export/export_fcpxml.py
@@ -4,7 +4,7 @@
 """Write a Final Cut Pro project (.fcpxml) with real titles and real motion.
 
 Usage:
-  uv run scripts/export_fcpxml.py --project projects/brand-origin-brick
+  video-studio export_fcpxml --project projects/brand-origin-brick
   ... --out somewhere/name.fcpxml
 
 Why this exists alongside the OTIO export: the generic interchange path drops

--- a/src/video_studio/generate/gen_boil.py
+++ b/src/video_studio/generate/gen_boil.py
@@ -5,7 +5,7 @@
 # ///
 """Draw a "boil" clip — hand-drawn-looking outlined vector art that jitters.
 
-    uv run scripts/gen_boil.py --shape chip --seconds 6 \
+    video-studio gen_boil --shape chip --seconds 6 \
         --out projects/foo/clips/beat2-still.mp4 --bg "#0b0e20" --fg "#8f9bf0"
 
 Why draw instead of generate: a video generator cannot hold a clean

--- a/src/video_studio/generate/gen_image.py
+++ b/src/video_studio/generate/gen_image.py
@@ -5,7 +5,7 @@
 """Generate one still image (Gemini image models, via the Gemini key).
 
 Usage:
-  GEMINI_API_KEY=... uv run scripts/gen_image.py \
+  GEMINI_API_KEY=... video-studio gen_image \
       --prompt "..." --aspect 9:16 --out clips/scene-1-broll.png
   ... --model gemini-3-pro-image     # slower, stronger
   ... --check                        # which image models this key can reach

--- a/src/video_studio/generate/gen_minimax.py
+++ b/src/video_studio/generate/gen_minimax.py
@@ -5,7 +5,7 @@
 """Generate one video clip with MiniMax (Hailuo).
 
 Usage:
-  MINIMAX_API_KEY=... uv run scripts/gen_minimax.py \
+  MINIMAX_API_KEY=... video-studio gen_minimax \
       --prompt "..." --seconds 6 --out clips/scene-1.mp4 [--resolution 1080P]
 
 Landmines encoded here (see references/api-landmines.md):

--- a/src/video_studio/generate/gen_replicate.py
+++ b/src/video_studio/generate/gen_replicate.py
@@ -9,7 +9,7 @@ script rather than one per vendor — adding an option becomes a row in
 MODELS, not a new integration.
 
 Usage:
-  REPLICATE_API_TOKEN=... uv run scripts/gen_replicate.py \
+  REPLICATE_API_TOKEN=... video-studio gen_replicate \
       --kind image --preset flux --prompt "..." --aspect 9:16 \
       --out projects/x/clips/beat-1-still.png
   ... --kind video --preset kling --seconds 5 --out .../beat-1-still.mp4

--- a/src/video_studio/generate/gen_veo.py
+++ b/src/video_studio/generate/gen_veo.py
@@ -5,7 +5,7 @@
 """Generate one video clip with Veo (Gemini API).
 
 Usage:
-  GEMINI_API_KEY=... uv run scripts/gen_veo.py \
+  GEMINI_API_KEY=... video-studio gen_veo \
       --prompt "..." --seconds 6 --aspect 9:16 --out clips/scene-1.mp4
 
 Landmines encoded here (see references/api-landmines.md):

--- a/src/video_studio/project/build_props.py
+++ b/src/video_studio/project/build_props.py
@@ -4,7 +4,7 @@
 """Storyboard → composer props. The invariant enforcer.
 
 Usage:
-  uv run scripts/build_props.py --storyboard project/storyboard.json \
+  video-studio build_props --storyboard project/storyboard.json \
       --project project/ --composer composer/ [--placeholders]
 
 What it enforces (never trust upstream to have done it):

--- a/src/video_studio/project/daily_digest.py
+++ b/src/video_studio/project/daily_digest.py
@@ -4,8 +4,8 @@
 """Draft the daily team digest: what shipped, what it scored, what's next.
 
 Usage:
-  uv run scripts/daily_digest.py                      # today, repo default
-  uv run scripts/daily_digest.py --since 2026-08-03 --runs runs/ --out digest.txt
+  video-studio daily_digest                      # today, repo default
+  video-studio daily_digest --since 2026-08-03 --runs runs/ --out digest.txt
 
 Reads two things and asks nothing of the network:
 - `git log` since --since, for repo changes

--- a/src/video_studio/project/preflight.py
+++ b/src/video_studio/project/preflight.py
@@ -4,9 +4,9 @@
 """Refuse to render a build that is not actually finished.
 
 Usage:
-  uv run scripts/preflight.py --composer composer/            # before render
-  uv run scripts/preflight.py --composer composer/ --json
-  uv run scripts/preflight.py --composer composer/ --allow-placeholders
+  video-studio preflight --composer composer/            # before render
+  video-studio preflight --composer composer/ --json
+  video-studio preflight --composer composer/ --allow-placeholders
 
 Exit 0 = safe to render. Exit 1 = do not render; the reasons are printed.
 

--- a/src/video_studio/project/setup.py
+++ b/src/video_studio/project/setup.py
@@ -4,10 +4,10 @@
 """Check every prerequisite and offer to install what is missing.
 
 Usage:
-  uv run scripts/setup.py              # report + the exact plan, changes NOTHING
-  uv run scripts/setup.py --json       # same, machine-readable
-  uv run scripts/setup.py --yes        # actually run the runnable fixes
-  uv run scripts/setup.py --yes --only composer,voice
+  video-studio setup              # report + the exact plan, changes NOTHING
+  video-studio setup --json       # same, machine-readable
+  video-studio setup --yes        # actually run the runnable fixes
+  video-studio setup --yes --only composer,voice
 
 `doctor.py` answers "what can I use right now". This answers "how do I get the
 rest", and can do it for you.
@@ -131,11 +131,13 @@ def node_modules_ok() -> bool:
 
 
 def voice_ok() -> bool:
-    script = SKILL_ROOT / "scripts" / "tts_kokoro.py"
-    if not script.exists() or not have("uv"):
-        return False
+    # Invoke the installed module, not a path. This probed
+    # SKILL_ROOT/scripts/tts_kokoro.py — where the script sat BEFORE the engine
+    # was packaged. That path exists in the old studio tree and in no pip
+    # install, so the check returned False for every installed copy and setup
+    # reported the voice broken even where kokoro was working.
     try:
-        r = subprocess.run(["uv", "run", str(script), "--check"],
+        r = subprocess.run([sys.executable, "-m", "video_studio.cli", "tts_kokoro", "--check"],
                            capture_output=True, text=True, timeout=600)
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
@@ -221,8 +223,8 @@ def build_components() -> list[dict]:
             "kind": "auto",
             # Running --check IS the install: uv resolves the pinned 3.12
             # interpreter and the dependencies on first use.
-            "cmd": ["uv", "run", str(SKILL_ROOT / "scripts" / "tts_kokoro.py"), "--check"],
-            "note": "uv run scripts/tts_kokoro.py --check  (first run downloads the model, a few minutes)",
+            "cmd": [sys.executable, "-m", "video_studio.cli", "tts_kokoro", "--check"],
+            "note": "video-studio tts_kokoro --check  (first run downloads the model, a few minutes)",
             "needs": ["uv"],
         },
         {

--- a/src/video_studio/project/studio.py
+++ b/src/video_studio/project/studio.py
@@ -4,9 +4,9 @@
 """Open the editor on a free port, without stepping on another agent.
 
 Usage:
-  uv run scripts/studio.py --project projects/brand-origin-brick
-  uv run scripts/studio.py --status          # who is editing what, right now
-  uv run scripts/studio.py --release         # drop a stale claim
+  video-studio studio --project projects/brand-origin-brick
+  video-studio studio --status          # who is editing what, right now
+  video-studio studio --release         # drop a stale claim
 
 Why this exists: the editor defaults to port 3000 and the composition reads a
 single global `props.json`. Two agents starting it therefore do not get two

--- a/src/video_studio/project/styles.py
+++ b/src/video_studio/project/styles.py
@@ -4,10 +4,10 @@
 """Reusable look presets: captions and card styling, defined once and reused.
 
 Usage:
-  uv run scripts/styles.py --list                       # every preset found
-  uv run scripts/styles.py --show tourism               # resolved values
-  uv run scripts/styles.py --apply tourism --storyboard project/storyboard.json
-  uv run scripts/styles.py --save mine --from project/storyboard.json
+  video-studio styles --list                       # every preset found
+  video-studio styles --show tourism               # resolved values
+  video-studio styles --apply tourism --storyboard project/storyboard.json
+  video-studio styles --save mine --from project/storyboard.json
 
 Why this exists: three tourism spots were built in one session and each one
 hand-rolled the same palette, the same label/stat/title rectangles and the same

--- a/src/video_studio/project/tutor.py
+++ b/src/video_studio/project/tutor.py
@@ -4,10 +4,10 @@
 """Serve a tutorial one step at a time, so it can be taught in conversation.
 
 Usage:
-  uv run scripts/tutor.py --list
-  uv run scripts/tutor.py --show getting-started        # the whole thing, for you
-  uv run scripts/tutor.py --step getting-started 1      # ONE beat, for the user
-  uv run scripts/tutor.py --step getting-started next --after 3
+  video-studio tutor --list
+  video-studio tutor --show getting-started        # the whole thing, for you
+  video-studio tutor --step getting-started 1      # ONE beat, for the user
+  video-studio tutor --step getting-started next --after 3
 
 The one-step-at-a-time interface is the entire point, and it is a guard rail
 rather than a convenience.

--- a/src/video_studio/sourcing/source_clips.py
+++ b/src/video_studio/sourcing/source_clips.py
@@ -6,12 +6,12 @@
 
 Usage:
   # user-supplied URL (their rights call — a notice is printed regardless):
-  uv run scripts/source_clips.py url --url "https://..." \
+  video-studio source_clips url --url "https://..." \
       --out project/clips/scene-1-broll.mp4
 
   # find free footage: searches YouTube and only accepts results whose
   # license metadata is Creative Commons:
-  uv run scripts/source_clips.py find --query "city timelapse rain" \
+  video-studio source_clips find --query "city timelapse rain" \
       --out project/clips/scene-1-broll.mp4 [--max-seconds 120]
 
 Copyright rule (from SKILL.md): `find` NEVER falls back to standard-license

--- a/src/video_studio/sourcing/stock_archive.py
+++ b/src/video_studio/sourcing/stock_archive.py
@@ -5,9 +5,9 @@
 """Search and download from public-domain institutional archives. No key.
 
 Usage:
-  uv run scripts/stock_archive.py --source nasa --query "aurora" \
+  video-studio stock_archive --source nasa --query "aurora" \
       --kind video --out projects/x/clips/beat-1-still.mp4
-  uv run scripts/stock_archive.py --source wikimedia --query "shipping container" \
+  video-studio stock_archive --source wikimedia --query "shipping container" \
       --kind image --out projects/x/clips/b4-still.jpg
   ... --list      # candidates only, download nothing
 

--- a/src/video_studio/sourcing/stock_freesound.py
+++ b/src/video_studio/sourcing/stock_freesound.py
@@ -5,7 +5,7 @@
 """Search and download sound effects (Freesound), licence-filtered.
 
 Usage:
-  FREESOUND_API_KEY=... uv run scripts/stock_freesound.py \
+  FREESOUND_API_KEY=... video-studio stock_freesound \
       --query "camera shutter" --out projects/x/audio/sfx-shutter.mp3
   ... --allow-attribution     # widen to CC-BY (we must then emit credits)
   ... --list

--- a/src/video_studio/sourcing/stock_pexels.py
+++ b/src/video_studio/sourcing/stock_pexels.py
@@ -5,7 +5,7 @@
 """Search and download free stock footage or photos (Pexels).
 
 Usage:
-  PEXELS_API_KEY=... uv run scripts/stock_pexels.py --check      # verify the key
+  PEXELS_API_KEY=... video-studio stock_pexels --check      # verify the key
   ... --query "rain on a window" --kind video --orientation portrait \
       --out projects/x/clips/beat-1-still.mp4
   ... --kind photo --size large --out projects/x/clips/beat-1-still.jpg

--- a/src/video_studio/sourcing/stock_pixabay.py
+++ b/src/video_studio/sourcing/stock_pixabay.py
@@ -5,7 +5,7 @@
 """Search and download free stock footage or photos (Pixabay).
 
 Usage:
-  PIXABAY_API_KEY=... uv run scripts/stock_pixabay.py \
+  PIXABAY_API_KEY=... video-studio stock_pixabay \
       --query "city at dusk" --kind video --orientation vertical \
       --out projects/x/clips/beat-2-still.mp4
   ... --list     # candidates only

--- a/src/video_studio/sourcing/stock_shutterstock.py
+++ b/src/video_studio/sourcing/stock_shutterstock.py
@@ -5,7 +5,7 @@
 """Search and license stock footage or images (Shutterstock).
 
 Usage:
-  SHUTTERSTOCK_TOKEN=... uv run scripts/stock_shutterstock.py --check
+  SHUTTERSTOCK_TOKEN=... video-studio stock_shutterstock --check
   ... --query "tokyo crossing at night" --kind video --orientation vertical --list
   ... --query "..." --kind video --out projects/x/clips/beat-1-still.mp4
 

--- a/src/video_studio/sourcing/verify_clips.py
+++ b/src/video_studio/sourcing/verify_clips.py
@@ -4,8 +4,8 @@
 """Check fetched clips against the storyboard BEFORE anything is rendered.
 
 Usage:
-  uv run scripts/verify_clips.py --project <dir>
-  uv run scripts/verify_clips.py --project <dir> --json
+  video-studio verify_clips --project <dir>
+  video-studio verify_clips --project <dir> --json
 
 Every check here exists because it went wrong in a real video, and every one of
 them was caught by hand — which means it was caught only because somebody

--- a/src/video_studio/vision/track_pointing.py
+++ b/src/video_studio/vision/track_pointing.py
@@ -10,7 +10,7 @@
 
 Analysis (MediaPipe Hands, bundled models — no downloads):
 
-  uv run scripts/track_pointing.py analyze --in me.mp4 --out events.json
+  video-studio track_pointing analyze --in me.mp4 --out events.json
 
 Emits pointing EVENTS: windows where an extended index finger holds a
 stable position, with the pointed-AT location (fingertip extrapolated
@@ -21,7 +21,7 @@ along the finger's direction), as canvas fractions:
 Layer emission (deterministic geometry — offset away from the point
 toward frame center, clamped on-canvas):
 
-  uv run scripts/track_pointing.py layers --events events.json \
+  video-studio track_pointing layers --events events.json \
       --images product.png,chart.png [--size 0.30]
 
 Prints storyboard-ready layers (file: sources, rect, atMs/untilMs,


### PR DESCRIPTION
A consistency pass before this gets tried on another machine. **Three live bugs and 67 wrong usage lines.**

## `video-studio setup` handed out repairs that could not work

`voice_ok()` probed `SKILL_ROOT/scripts/tts_kokoro.py` — where that script sat **before** the engine was packaged. So it returned `False` for every installed copy, and setup reported the voice broken on machines where kokoro was fine. The repair it then offered ran the same dead path. Both now invoke the module through `sys.executable`.

Its `.env` repair copied `SKILL_ROOT/.env.example` — **which did not exist in this repo.** That file now exists, derived from the key names `doctor` actually checks, with a line on each explaining what it unlocks and that every one is optional.

## And a secret-leak risk found while writing it

**`.env` was not gitignored.** A user following setup's own instruction (`cp .env.example .env`) would have created a file of API keys that git would happily stage. Ignored now; `.env.example` stays tracked, which is the pairing that makes the repair safe.

## 67 usage lines pointed at the old layout

Across 30 engine modules, docstrings still read `uv run scripts/<name>.py` — the pre-packaging invocation. They are `video-studio <name>` now.

The bundled skill scripts **keep** theirs, and that's deliberate: there the path is literally correct — the file *is* at `scripts/<name>.py` inside the skill folder, and `uv run --script` carries it (verified in the earlier sandbox). `cli.py` keeps its single mention, which is prose about the history.

## A comment contradicting its own fix

`pyproject`'s `[vision]` said *"[qc] names contrib for the same reason."* `[qc]` names no opencv at all — I corrected the `[qc]` comment when the cv2 fix landed and left this cross-reference pointing at the old text. Both now say the same true thing.

## `daily_digest`

The last command reachable from no skill. It reports on finished runs, so `video-production` owns it. **All 34 are now reachable by name** from `skills/` or the README.

## Verified

`verify-skills` green · 33/34 commands run (`composite_subject` needs `[vision]`'s mediapipe, expected) · README counts match reality exactly at 40/34/six · wheel ships 14 presets, 3 tutorials, 2 qc data files · composer typechecks.

## Not fixed — and you should know

**There are no executable tests.** `tests/` holds behavioural scenarios for the prose skills only. `TESTING.md`'s own rule — *"A skill should have at least one scenario"* — is unmet by **9 of 16**, all of them video skills. 13,000 lines of engine have no test and no CI.

That's a real gap and a separate piece of work; I didn't want to bundle it into a consistency pass.