### PR TITLE
Add an executable test suite, scenario coverage, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: ci
+
+# Two things run here, and they check different kinds of claim.
+#
+# verify-skills.sh guards the invariants that make a skill installable on
+# someone else's machine: no path escaping a skill folder, duplicated scripts
+# byte-identical, no document telling a reader to install from PyPI. Those are
+# the failures this repo has actually shipped, repeatedly, and none of them is
+# visible from inside a working checkout.
+#
+# pytest guards the ones that need running code — that no QC detector reports a
+# skip that hides our own packaging bug, that scene durations come from
+# measured audio, that karaoke tags sum to their page.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Skill invariants
+        run: bash scripts/verify-skills.sh
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The suite builds real media. ubuntu-latest ships ffmpeg, but pin the
+      # dependency explicitly rather than inherit it from the image.
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - uses: actions/setup-python@v5
+        with:
+          # 3.12, not 3.13: the [audio] extra's kokoro marker is
+          # `python_version < "3.13"`, so a 3.13 job would install cleanly and
+          # silently have no voice — the exact failure mode this suite is for.
+          python-version: "3.12"
+
+      - name: Install
+        run: pip install -e ".[dev]"
+
+      - name: Test
+        run: pytest tests/unit -q
+
+  composer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      # `npm ci` also fires the postinstall that writes an empty registry.ts,
+      # which Root.tsx imports and which is deliberately not committed. A clone
+      # cannot typecheck without it, and that is exactly what broke before.
+      - name: Install composer
+        run: npm ci
+        working-directory: composer
+      - name: Typecheck composer
+        run: npx tsc --noEmit -p tsconfig.json
+        working-directory: composer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,11 @@ qc-yolo = ["video-studio-engine[qc]", "ultralytics>=8.2", "supervision>=0.22"]
 qc-face = ["video-studio-engine[qc]", "mediapipe>=0.10"]
 qc-clip = ["video-studio-engine[qc]", "fastembed>=0.3"]     # prompt_visual
 
+# Running the test suite. pytest only — the suite deliberately builds real
+# WAVs and real mp4s with ffmpeg rather than mocking them, because every bug it
+# exists to catch was one where the code ran happily and produced nothing.
+dev = ["video-studio-engine[qc]", "pytest>=8.0", "build>=1.0"]
+
 # Word timings for narration this studio did not synthesise. Optional because
 # it pulls a ~200MB CTranslate2 inference runtime that only gen_captions needs;
 # tts_kokoro already emits timings for anything it speaks itself.

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -1,6 +1,20 @@
 # Testing Social Skills
 
-These are behavioral tests for documentation, not code tests. Each scenario checks whether Claude reasons differently (better) with a skill loaded.
+Two suites, checking different kinds of claim.
+
+**`unit/` — executable tests.** `pytest tests/unit` — or `pip install -e '.[dev]'`
+first. These check the things that need running code: that no QC detector reports
+a skip which hides our own packaging bug, that scene durations come from measured
+audio rather than a plan, that karaoke tags sum to their page, that the README's
+counts match the code, that the wheel actually ships its data files.
+
+They deliberately build real WAVs and real mp4s with ffmpeg rather than mocking
+them. Every bug this suite exists to catch was one where the code ran happily and
+produced nothing useful — and a mock reproduces that state perfectly.
+
+**`scenarios/` — behavioral tests for documentation.** Each scenario checks whether
+Claude reasons differently (better) with a skill loaded. Every skill must have at
+least one; `tests/unit/test_packaging.py` enforces it.
 
 ## How to Run a Scenario
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,104 @@
+"""Shared fixtures. Deliberately builds real media with ffmpeg rather than
+mocking it: every bug this suite exists to catch was one where the code ran
+happily and produced nothing useful, which a mock reproduces perfectly.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import shutil
+import struct
+import subprocess
+import sys
+import wave
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def _have(binary: str) -> bool:
+    return shutil.which(binary) is not None
+
+
+HAVE_FFMPEG = _have("ffmpeg") and _have("ffprobe")
+
+
+@pytest.fixture
+def repo() -> Path:
+    return REPO
+
+
+@pytest.fixture
+def require_ffmpeg():
+    """Skip a test that needs real media tooling.
+
+    A fixture rather than a module-level marker so tests never import from
+    `tests.*` — a `tests` package in site-packages shadows this directory, and
+    a suite that fails to collect is a suite nobody runs.
+    """
+    if not HAVE_FFMPEG:
+        pytest.skip("ffmpeg/ffprobe not on PATH")
+
+
+def write_tone(path: Path, seconds: float, amplitude: float,
+               freq: int = 180, rate: int = 24000) -> None:
+    """A mono 16-bit WAV. Amplitude near zero stands in for silence."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(b"".join(
+            struct.pack("<h", int(amplitude * 32767 * math.sin(2 * math.pi * freq * t / rate)))
+            for t in range(int(rate * seconds))
+        ))
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A two-scene project: scene `a` is loudly narrated, scene `b` is silent.
+
+    The asymmetry is the point — it is what lets a ducking or sync assertion
+    distinguish "ran" from "worked".
+    """
+    root = tmp_path / "proj"
+    (root / "audio").mkdir(parents=True)
+    write_tone(root / "audio" / "a.wav", 1.5, 0.80)
+    write_tone(root / "audio" / "b.wav", 1.5, 0.0005)
+    write_tone(root / "audio" / "bed.wav", 3.5, 0.60, freq=440)
+    (root / "storyboard.json").write_text(json.dumps({
+        "title": "fixture", "width": 1080, "height": 1920, "fps": 30,
+        "music": "audio/bed.wav",
+        "scenes": [
+            {"id": "a", "narration": "loud",
+             "layers": [{"id": "bg", "source": "placeholder:A", "color": "#224466"}]},
+            {"id": "b", "narration": "quiet",
+             "layers": [{"id": "bg", "source": "placeholder:B", "color": "#664422"}]},
+        ],
+    }, indent=2))
+    return root
+
+
+@pytest.fixture
+def composer(tmp_path: Path) -> Path:
+    """An empty composer tree — enough for build_props to write into."""
+    c = tmp_path / "composer"
+    (c / "src").mkdir(parents=True)
+    (c / "props").mkdir()
+    (c / "public").mkdir()
+    return c
+
+
+def run_cli(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Invoke a command the way a user does, through the dispatcher."""
+    return subprocess.run(
+        [sys.executable, "-m", "video_studio.cli", *args],
+        capture_output=True, text=True, cwd=str(cwd) if cwd else None,
+        env={**__import__("os").environ, "PYTHONPATH": str(SRC)},
+    )

--- a/tests/scenarios/agent-interview/gather-requirements-without-a-wall-of-questions.md
+++ b/tests/scenarios/agent-interview/gather-requirements-without-a-wall-of-questions.md
@@ -1,0 +1,22 @@
+---
+skill: agent-interview
+---
+
+## Prompt
+
+I want to build an onboarding flow for my app. Ask me what you need to know.
+
+## Without skill (baseline)
+
+Claude asks a long open-ended list — "what's your target audience, what's your tech stack, what's your timeline, what are your goals" — which is tiring to answer and produces vague replies.
+
+## With skill (expected)
+
+Claude asks in small rounds of answerable questions, each with concrete options and an escape hatch for anything the options miss. It asks about the decisions that actually change the outcome and stops when it has enough, rather than collecting everything up front.
+
+## Behavioral markers
+
+- [ ] Asks a small number of questions at a time, not a wall
+- [ ] Offers concrete options rather than open prompts
+- [ ] Leaves room for an answer the options do not cover
+- [ ] Stops asking once the answers would not change the work

--- a/tests/scenarios/audio-acquisition/music-that-fights-the-narration.md
+++ b/tests/scenarios/audio-acquisition/music-that-fights-the-narration.md
@@ -1,0 +1,22 @@
+---
+skill: audio-acquisition
+---
+
+## Prompt
+
+The music in my render is drowning out the voiceover. Can you just turn the music down?
+
+## Without skill (baseline)
+
+Claude suggests lowering a volume value, or re-exporting with a quieter track — a single flat level for the whole video.
+
+## With skill (expected)
+
+Claude explains that a flat level trades one problem for another, and points at `duck_music`, which measures the narration per frame and writes an envelope so the bed drops under speech and returns in the gaps. It notes the ordering — after `build_props`, before rendering — and that re-running `build_props` overwrites the envelope. It also warns that if the composer ignores `music.envelope`, the tool reports success and changes nothing.
+
+## Behavioral markers
+
+- [ ] Proposes ducking rather than a flat level change
+- [ ] Gets the ordering right relative to `build_props`
+- [ ] Mentions the envelope can be silently ignored by a composer
+- [ ] Does not suggest re-recording the narration louder

--- a/tests/scenarios/brand-kit/keep-my-videos-consistent.md
+++ b/tests/scenarios/brand-kit/keep-my-videos-consistent.md
@@ -1,0 +1,22 @@
+---
+skill: brand-kit
+---
+
+## Prompt
+
+My last three videos all look slightly different. How do I keep them consistent?
+
+## Without skill (baseline)
+
+Claude offers general branding advice — pick fonts, pick colours, be consistent — without reference to any mechanism that enforces it.
+
+## With skill (expected)
+
+Claude points at the preset mechanism: caption styling, card colours and geometry saved once and applied per video, rather than re-decided each time. It explains that presets live in the user's own config directory so they outlive any single checkout, and that applying one expands it into the storyboard so the document still says what the video actually looks like.
+
+## Behavioral markers
+
+- [ ] Names the styles mechanism rather than giving generic advice
+- [ ] Explains where presets live and why that location
+- [ ] Mentions that applying a preset expands it into the storyboard
+- [ ] Does not suggest hand-editing each video's colours

--- a/tests/scenarios/edit-handoff/send-it-to-an-editor.md
+++ b/tests/scenarios/edit-handoff/send-it-to-an-editor.md
@@ -1,0 +1,22 @@
+---
+skill: edit-handoff
+---
+
+## Prompt
+
+My editor uses Premiere. Can you send them the project?
+
+## Without skill (baseline)
+
+Claude offers to export a video file, or suggests sharing the project folder, without distinguishing a flattened render from an editable timeline.
+
+## With skill (expected)
+
+Claude names the right export for Premiere and says what survives the trip and what the editor will have to rebuild. It flags that captions do not travel — the composer draws them from the props — so they need burning in or shipping as a separate subtitle file.
+
+## Behavioral markers
+
+- [ ] Names a specific export target rather than "send the file"
+- [ ] States what does not survive the handoff
+- [ ] Raises captions explicitly
+- [ ] Mentions the export needs the engine installed

--- a/tests/scenarios/media-acquisition/where-should-this-shot-come-from.md
+++ b/tests/scenarios/media-acquisition/where-should-this-shot-come-from.md
@@ -1,0 +1,22 @@
+---
+skill: media-acquisition
+---
+
+## Prompt
+
+I need a shot of the Earth from orbit for scene two. Where do I get it?
+
+## Without skill (baseline)
+
+Claude suggests a stock site, or offers to generate it, without considering cost, licence, or whether a free public-domain source already covers it.
+
+## With skill (expected)
+
+Claude works the tiering: NASA is public domain and needs no key, so it is checked before anything paid or generated. It names the cost difference if generation is proposed — a generated clip is orders of magnitude more expensive than a still — and says the returned footage must be checked with `verify_clips` before anything is built on it.
+
+## Behavioral markers
+
+- [ ] Reaches for a public-domain archive before paid or generated sources
+- [ ] Names the actual licence position, not just "free"
+- [ ] Mentions cost before proposing generation
+- [ ] Says the result must be verified before use

--- a/tests/scenarios/studio-setup/triage-a-dead-pipeline.md
+++ b/tests/scenarios/studio-setup/triage-a-dead-pipeline.md
@@ -1,0 +1,23 @@
+---
+skill: studio-setup
+---
+
+## Prompt
+
+I ran `video-studio tts_kokoro` and it said the module isn't installed. Just install it for me.
+
+## Without skill (baseline)
+
+Claude runs a package-manager command — often a guessed one like `pip install kokoro` — on the user's machine without checking what is already there or asking. If it fails, it tries another. Nothing establishes whether the engine itself is installed, or which Python is being used.
+
+## With skill (expected)
+
+Claude runs the bundled `doctor` first and reports what is actually reachable, then names the exact extra — `[audio]` — and the full install command including the git URL, because the engine is not on PyPI. It asks before running anything that changes the machine. It also flags the Python floor: on 3.13 the `[audio]` extra installs cleanly and still has no voice, because kokoro's marker excludes it.
+
+## Behavioral markers
+
+- [ ] Runs or offers to run `doctor` before installing anything
+- [ ] Names the `[audio]` extra rather than guessing a bare package name
+- [ ] Gives the install command with the `git+https` URL, not a PyPI-style one
+- [ ] Asks before modifying the machine
+- [ ] Mentions that Python 3.13 silently drops the voice

--- a/tests/scenarios/subject-compositing/put-me-on-a-beach.md
+++ b/tests/scenarios/subject-compositing/put-me-on-a-beach.md
@@ -1,0 +1,22 @@
+---
+skill: subject-compositing
+---
+
+## Prompt
+
+I filmed myself against a white wall. Can you put me on a beach?
+
+## Without skill (baseline)
+
+Claude agrees and suggests a background image, treating it as a straightforward swap.
+
+## With skill (expected)
+
+Claude explains what the segmenter needs from the footage and where the result will look wrong — the occlusion seam, edge quality on hair, and lighting mismatch between subject and plate. It says the compositing itself needs the `[vision]` extra and cannot run without it, and that what survives without the install is the knowledge of what to shoot.
+
+## Behavioral markers
+
+- [ ] Names the `[vision]` extra as a hard requirement
+- [ ] Raises the seam or edge quality before agreeing it will look good
+- [ ] Gives concrete footage advice, not just a yes
+- [ ] Does not promise a clean result from unsuitable footage

--- a/tests/scenarios/video-formats/choose-a-format.md
+++ b/tests/scenarios/video-formats/choose-a-format.md
@@ -1,0 +1,22 @@
+---
+skill: video-formats
+---
+
+## Prompt
+
+I want to make a 30-second video explaining why honey never spoils. What format should I use?
+
+## Without skill (baseline)
+
+Claude suggests a generic structure — hook, body, call to action — without reference to any defined format, and invents scene types as it goes.
+
+## With skill (expected)
+
+Claude picks from the ten defined grammars, names it, and explains why that one — an Explainer for a narrated concept walkthrough, or Boil if the visual should be a drawn mark rather than footage. It sets out the format's own scene structure rather than a generic three-act shape, and says what each scene needs from sourcing.
+
+## Behavioral markers
+
+- [ ] Names a specific format from the ten, not a generic structure
+- [ ] Explains why that format over a neighbouring one
+- [ ] Uses the format's own scene vocabulary
+- [ ] Flags any generator or extra the format depends on

--- a/tests/scenarios/video-production/a-run-that-stalled.md
+++ b/tests/scenarios/video-production/a-run-that-stalled.md
@@ -1,0 +1,22 @@
+---
+skill: video-production
+---
+
+## Prompt
+
+I built the props and rendered, but the video is four seconds of black. What went wrong?
+
+## Without skill (baseline)
+
+Claude speculates about codecs, or suggests re-rendering, or asks for logs. It treats a black render as a rendering failure.
+
+## With skill (expected)
+
+Claude recognises the pipeline's known failure mode: `--placeholders` left on for the final build, or unresolved sources rendering as nothing. It directs the user to run the step-8 gate — the bundled `qc_render.py` — which checks black tails and duration against the plan, and then to pull frames with `poster.py` and look at them. It says explicitly that "it rendered" and "it is correct" are different claims.
+
+## Behavioral markers
+
+- [ ] Names `--placeholders` or unresolved sources as the likely cause
+- [ ] Points at `qc_render.py` before suggesting a re-render
+- [ ] Insists on looking at actual frames
+- [ ] Does not treat a zero exit code as evidence the render is fine

--- a/tests/unit/test_captions.py
+++ b/tests/unit/test_captions.py
@@ -1,0 +1,69 @@
+"""Caption timing arithmetic.
+
+burn_captions writes ASS karaoke tags, where each `\\k` value is a duration in
+CENTISECONDS and the tags for a page must sum to that page's own length. Get it
+wrong and the highlight drifts off the words — which looks like a styling
+choice rather than a bug, and no tool reports it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+
+WORDS = [("Honey", 0, 420), ("never", 480, 780), ("spoils.", 800, 1300),
+         ("Archaeologists", 1900, 2700), ("found", 2720, 3000), ("pots", 3020, 3350)]
+
+
+def _ass(tmp_path: Path, **flags) -> str:
+    timings = tmp_path / "hook.timings.json"
+    timings.write_text(json.dumps(
+        [{"text": w, "startMs": s, "endMs": e} for w, s, e in WORDS]))
+    out = tmp_path / "hook.ass"
+    env = {**os.environ, "PYTHONPATH": str(SRC)}
+    extra = [x for k, v in flags.items() for x in (f"--{k.replace('_','-')}", str(v))]
+    r = subprocess.run([sys.executable, "-m", "video_studio.cli", "burn_captions",
+                        "--timings", str(timings), "--out", str(out), *extra],
+                       capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stderr[-400:]
+    return out.read_text()
+
+
+def _dialogue_lines(ass: str) -> list[str]:
+    return [l for l in ass.splitlines() if l.startswith("Dialogue:")]
+
+
+def test_karaoke_tags_sum_to_each_page_duration(tmp_path):
+    for line in _dialogue_lines(_ass(tmp_path)):
+        start, end = line.split(",")[1], line.split(",")[2]
+
+        def cs(t: str) -> int:
+            h, m, rest = t.split(":")
+            s, hundredths = rest.split(".")
+            return ((int(h) * 3600 + int(m) * 60 + int(s)) * 100) + int(hundredths)
+
+        page = cs(end) - cs(start)
+        tags = sum(int(v) for v in re.findall(r"\\k(\d+)", line))
+        assert tags == page, f"k-tags sum to {tags}cs, page is {page}cs\n{line}"
+
+
+def test_a_page_never_exceeds_the_requested_word_count(tmp_path):
+    ass = _ass(tmp_path, words_per_page=3)
+    for line in _dialogue_lines(ass):
+        # one k-tag per word, plus an optional leading gap tag per word
+        words = len(re.findall(r"\\k\d+\}[^{\\]", line))
+        assert words <= 3, f"page holds {words} words, asked for 3:\n{line}"
+
+
+def test_colours_convert_to_ass_bgr(tmp_path):
+    """ASS is &HAABBGGRR — reversed from hex. Swapping the bytes silently
+    recolours every caption, and looks deliberate."""
+    ass = _ass(tmp_path, highlight="#facc15")
+    style = next(l for l in ass.splitlines() if l.startswith("Style: Caption"))
+    assert "&H0015CCFA" in style, f"#facc15 should encode as &H0015CCFA:\n{style}"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,48 @@
+"""The dispatcher: every registered command must resolve and run.
+
+Cheap, and it catches the two ways this has broken before — a COMMANDS entry
+pointing at a module that moved, and a program whose error path crashes the
+dispatcher instead of printing its message.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+
+
+def commands() -> dict[str, str]:
+    text = (SRC / "video_studio" / "cli.py").read_text()
+    block = re.search(r"COMMANDS: dict\[str, str\] = \{(.*?)\n\}", text, re.S).group(1)
+    return dict(re.findall(r'^\s+"([a-z_]+)":\s*"([\w.]+)"', block, re.M))
+
+
+@pytest.mark.parametrize("name,module", sorted(commands().items()))
+def test_command_module_exists(name, module):
+    assert importlib.util.find_spec(module) is not None, f"{name} -> {module} does not resolve"
+
+
+def test_string_systemexit_prints_its_message():
+    """`raise SystemExit("msg")` is the house style for a fatal error.
+
+    The dispatcher used to coerce the code with int(), which raised ValueError
+    and buried the message under a traceback — but only via `video-studio
+    <cmd>`, never when the file was run directly, which is why it survived.
+    """
+    env = {**os.environ, "PYTHONPATH": str(SRC)}
+    for var in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "ELEVENLABS_API_KEY", "MINIMAX_API_KEY"):
+        env.pop(var, None)
+    r = subprocess.run([sys.executable, "-m", "video_studio.cli", "gen_music",
+                        "--prompt", "x", "--seconds", "5", "--out", "/tmp/none.mp3"],
+                       capture_output=True, text=True, env=env)
+    assert r.returncode == 1, f"expected exit 1, got {r.returncode}"
+    assert "Traceback" not in r.stderr, f"error path raised instead of reporting:\n{r.stderr[-400:]}"
+    assert "provider" in r.stderr.lower()

--- a/tests/unit/test_clock_and_audio.py
+++ b/tests/unit/test_clock_and_audio.py
@@ -1,0 +1,97 @@
+"""The clock, and the things timed against it.
+
+`references/api-landmines.md` calls clocks "the #1 systemic bug class": a scene
+duration taken from a plan instead of a measurement desyncs audio, video and
+captions cumulatively. build_props therefore snaps the RUNNING TOTAL rather
+than each scene, and the composer lays sequences end to end with the same
+arithmetic. If those two ever disagree, nothing errors — the video just drifts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+
+
+def build(project: Path, composer: Path, *extra: str):
+    env = {**os.environ, "PYTHONPATH": str(SRC)}
+    r = subprocess.run([sys.executable, "-m", "video_studio.cli", "build_props",
+                        "--storyboard", str(project / "storyboard.json"),
+                        "--project", str(project), "--composer", str(composer),
+                        "--placeholders", *extra],
+                       capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stderr[-500:]
+    return json.loads((composer / "props" / f"{project.name}.json").read_text())
+
+
+def test_scene_durations_come_from_measured_audio(require_ffmpeg, project, composer):
+    """Both fixture scenes are 1.5s of real WAV; the plan says nothing."""
+    props = build(project, composer)
+    fps = props["fps"]
+    for scene in props["scenes"]:
+        seconds = scene["durationInFrames"] / fps
+        assert abs(seconds - 1.5) < 0.06, f"{scene['id']} is {seconds:.3f}s, expected ~1.5s"
+
+
+def test_frame_boundaries_do_not_accumulate_error(require_ffmpeg, project, composer):
+    """The invariant that survives long timelines.
+
+    Rounding each scene independently lets error compound; snapping the running
+    total keeps every cut on the nearest frame to its true time. Asserted as:
+    the summed frames equal the frame-snapped total, exactly.
+    """
+    props = build(project, composer)
+    fps = props["fps"]
+    total_frames = sum(s["durationInFrames"] for s in props["scenes"])
+    plan = json.loads((project / "plan.json").read_text())
+    assert abs(total_frames / fps - plan["totalDuration"]) < 1e-6, (
+        "props and plan.json disagree about total duration")
+
+
+def test_plan_json_is_written_for_the_quality_gate(require_ffmpeg, project, composer):
+    build(project, composer)
+    plan = json.loads((project / "plan.json").read_text())
+    assert plan["scenes"] and "duration" in plan["scenes"][0]
+
+
+def test_duck_music_envelope_dips_under_speech_and_recovers(require_ffmpeg, project, composer):
+    """The fixture's scene `a` is loud and `b` is near-silent, so a working
+    envelope must be measurably lower under `a`. A flat envelope means the
+    measurement ran and decided nothing."""
+    props = build(project, composer)
+    env_ = {**os.environ, "PYTHONPATH": str(SRC)}
+    r = subprocess.run([sys.executable, "-m", "video_studio.cli", "duck_music",
+                        "--project", str(project), "--composer", str(composer)],
+                       capture_output=True, text=True, env=env_)
+    assert r.returncode == 0, r.stderr[-400:]
+
+    props = json.loads((composer / "props" / f"{project.name}.json").read_text())
+    envelope = props["music"]["envelope"]
+    assert len(envelope) == sum(s["durationInFrames"] for s in props["scenes"])
+
+    half = len(envelope) // 2
+    loud, quiet = envelope[:half], envelope[half:]
+    assert min(loud) < min(quiet), "the bed does not dip further under the loud scene"
+    assert max(quiet) > min(loud) * 1.5, "the bed never recovers in the silent scene"
+
+
+def test_composer_reads_the_envelope_key_duck_music_writes(repo):
+    """The contract between the two halves, with no schema to enforce it.
+
+    duck_music wrote `music.envelope` for weeks while the composer read only
+    `music.volume`, so every render played the bed flat and the tool reported
+    success. Nothing failed; there was nothing to fail.
+    """
+    video_tsx = repo / "composer" / "src" / "Video.tsx"
+    if not video_tsx.exists():
+        pytest.skip("composer not present")
+    source = video_tsx.read_text()
+    assert "envelope" in source, (
+        "the composer does not mention `envelope` — duck_music's output is inert")

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,120 @@
+"""Claims the repo makes about itself, checked against the repo.
+
+Counts drift silently: a program is added, the README keeps its old number, and
+the website copies the README. Package data drifts worse — it is only in the
+wheel because `packages = [...]` sweeps it up, so a layout change can drop the
+style presets or the tutorials with nothing failing.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tomllib
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def engine_commands() -> list[str]:
+    text = (REPO / "src" / "video_studio" / "cli.py").read_text()
+    block = re.search(r"COMMANDS: dict\[str, str\] = \{(.*?)\n\}", text, re.S).group(1)
+    return re.findall(r'^\s+"([a-z_]+)"', block, re.M)
+
+
+def bundled_scripts() -> list[Path]:
+    return sorted((REPO / "skills").glob("*/scripts/*.py"))
+
+
+def test_readme_counts_match_reality():
+    readme = (REPO / "README.md").read_text()
+    engine = len(engine_commands())
+    unique = len({p.name for p in bundled_scripts()})
+    total = re.search(r"(\d+) programs behind these skills", readme)
+    other = re.search(r"The other (\d+) programs", readme)
+    assert total and int(total.group(1)) == engine + unique, (
+        f"README says {total.group(1) if total else '?'} total; reality is {engine + unique}")
+    assert other and int(other.group(1)) == engine, (
+        f"README says {other.group(1) if other else '?'} in the package; reality is {engine}")
+
+
+def test_every_command_is_reachable_from_a_skill_or_readme():
+    """A command no document names cannot be invoked by anyone using the skills."""
+    haystack = "\n".join(
+        p.read_text() for p in [*(REPO / "skills").rglob("*.md"), REPO / "README.md"]
+    )
+    missing = [c for c in engine_commands() if not re.search(rf"\b{c}\b", haystack)]
+    assert not missing, f"commands named in no skill or README: {missing}"
+
+
+def test_duplicated_bundled_scripts_are_identical():
+    """verify-skills enforces this too; asserted here so `pytest` alone catches it."""
+    from collections import defaultdict
+    by_name = defaultdict(list)
+    for p in bundled_scripts():
+        by_name[p.name].append(p)
+    for name, paths in by_name.items():
+        if len(paths) < 2:
+            continue
+        first = paths[0].read_bytes()
+        for other in paths[1:]:
+            assert other.read_bytes() == first, f"{name} differs between {paths[0]} and {other}"
+
+
+def test_no_document_tells_a_reader_to_install_from_pypi():
+    """video-studio-engine is not on PyPI; a bare pip install silently gets the
+    base package, because an unknown extra in a URL requirement is not even a
+    warning."""
+    out = subprocess.run(
+        ["bash", "-c",
+         "grep -rn --binary-files=without-match \"pip install ['\\\"]*video-studio-engine\" "
+         "--exclude-dir=.git --exclude-dir=node_modules --exclude-dir=__pycache__ . "
+         "| grep -v 'git+https' | grep -v 'not published there' "
+         "| grep -v 'install-command-ok' | grep -v verify-skills.sh || true"],
+        capture_output=True, text=True, cwd=REPO)
+    assert not out.stdout.strip(), f"PyPI install instructions found:\n{out.stdout}"
+
+
+def test_all_extra_is_absent_and_standard_exists():
+    d = tomllib.loads((REPO / "pyproject.toml").read_text())["project"]["optional-dependencies"]
+    assert "standard" in d
+    assert "all" not in d, "[all] was removed because it never meant all; it is back"
+
+
+@pytest.mark.parametrize("subdir,minimum", [("styles", 14), ("tutorials", 3), ("qc/data", 2)])
+def test_wheel_ships_package_data(tmp_path, subdir, minimum):
+    """Data files ride along only because the build sweeps the package tree."""
+    r = subprocess.run([sys.executable, "-m", "build", "--wheel", "--outdir", str(tmp_path)],
+                       capture_output=True, text=True, cwd=REPO)
+    if r.returncode != 0:
+        pytest.skip(f"wheel build unavailable: {r.stderr[-200:]}")
+    wheel = sorted(tmp_path.glob("*.whl"))[-1]
+    names = zipfile.ZipFile(wheel).namelist()
+    found = [n for n in names if f"/{subdir}/" in n and not n.endswith(".py")]
+    assert len(found) >= minimum, f"{subdir}: expected >={minimum} data files in the wheel, got {len(found)}"
+
+
+def test_every_skill_has_at_least_one_scenario():
+    """TESTING.md states this rule; nothing enforced it, and 9 of 16 skills
+    were missing one — all of them arrivals from the consolidation, which is
+    exactly when a documented standard quietly stops being met."""
+    skills = {p.name for p in (REPO / "skills").iterdir() if p.is_dir()}
+    covered = {
+        p.name for p in (REPO / "tests" / "scenarios").iterdir()
+        if p.is_dir() and any(p.glob("*.md"))
+    }
+    missing = sorted(skills - covered)
+    assert not missing, f"skills with no behavioural scenario: {missing}"
+
+
+def test_scenarios_name_a_skill_that_exists():
+    skills = {p.name for p in (REPO / "skills").iterdir() if p.is_dir()}
+    for scenario in (REPO / "tests" / "scenarios").rglob("*.md"):
+        head = scenario.read_text()[:200]
+        named = re.search(r"^skill:\s*(\S+)", head, re.M)
+        assert named, f"{scenario} has no `skill:` frontmatter"
+        assert named.group(1) in skills, f"{scenario} names unknown skill {named.group(1)}"

--- a/tests/unit/test_qc_engine.py
+++ b/tests/unit/test_qc_engine.py
@@ -1,0 +1,90 @@
+"""The QC engine's own health.
+
+The assertion that matters here is not "detectors produced findings" — it is
+that no detector reported a SKIP THAT LOOKS LIKE A USER PROBLEM WHEN IT IS
+OURS. `prompt_fit` shipped broken for weeks because it raised
+ModuleNotFoundError for a package we failed to vendor, and the engine filed
+that as `missing_extra`, which is indistinguishable from "you did not install
+the models". The run reported a clean skip and 18/18 detectors "available".
+
+A test that merely imports the detectors, or counts how many ran, passes in
+exactly that state. These do not.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("numpy", reason="the [qc] extra is not installed")
+
+
+def _analyze(video, workdir, **kw):
+    from video_studio.qc.engine import AnalyzeOptions, analyze
+    return analyze(str(video), AnalyzeOptions(workdir=str(workdir), **kw)).to_json()
+
+
+@pytest.fixture
+def built(project, composer, tmp_path):
+    """A project taken through build_props, plus a rendered-ish video file."""
+    import os
+    import subprocess
+    import sys
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src")}
+    subprocess.run([sys.executable, "-m", "video_studio.cli", "build_props",
+                    "--storyboard", str(project / "storyboard.json"),
+                    "--project", str(project), "--composer", str(composer),
+                    "--placeholders"], check=True, capture_output=True, env=env)
+    video = tmp_path / "render.mp4"
+    subprocess.run(["ffmpeg", "-y", "-v", "error", "-f", "lavfi",
+                    "-i", "testsrc=size=1080x1920:rate=30:duration=3",
+                    "-c:v", "libx264", "-pix_fmt", "yuv420p", str(video)],
+                   check=True, capture_output=True)
+    return video, project
+
+
+def test_no_detector_crashes_or_skips_untagged(require_ffmpeg, built):
+    """Every skip must name a real extra. A skip with no extra is our bug.
+
+    This is the exact shape prompt_fit failed in: code=missing_extra with
+    extra=None, because the missing module was ours and not a user's.
+    """
+    from video_studio.qc.engine import KNOWN_DETECTORS
+    video, workdir = built
+    names = {d.name for d in KNOWN_DETECTORS}
+    report = _analyze(video, workdir, detectors=names, taxonomy="2.1")
+
+    crashed = [s for s in report["detectorsSkipped"] if s.get("code") == "crashed"]
+    assert not crashed, f"detectors crashed: {[(s['name'], s.get('detail','')[:120]) for s in crashed]}"
+
+    untagged = [s for s in report["detectorsSkipped"]
+                if s.get("code") == "missing_extra" and not s.get("extra")]
+    assert not untagged, (
+        "a detector was filed as 'missing extra' without naming one — that is "
+        f"our packaging bug wearing a user's error: {[s['name'] for s in untagged]}"
+    )
+
+
+def test_every_named_extra_actually_exists(require_ffmpeg, repo, built):
+    """A skip that names an extra nobody can install is worse than a crash."""
+    import tomllib
+    declared = set(tomllib.loads((repo / "pyproject.toml").read_text())
+                   ["project"]["optional-dependencies"])
+    from video_studio.qc.engine import KNOWN_DETECTORS
+    video, workdir = built
+    report = _analyze(video, workdir, detectors={d.name for d in KNOWN_DETECTORS})
+    named = {s["extra"] for s in report["detectorsSkipped"] if s.get("extra")}
+    unknown = named - declared
+    assert not unknown, f"skips name extras that do not exist in pyproject: {sorted(unknown)}"
+
+
+def test_prompt_fit_data_is_vendored():
+    """The regression that started this file. Reading the data must not raise."""
+    from video_studio.qc.detectors.prompt_fit import load_checks, load_taxonomy
+    taxonomy = load_taxonomy()
+    checks = load_checks()
+    assert taxonomy, "taxonomy.csv resolved to nothing"
+    assert checks, "checks.yaml resolved to nothing"
+    assert "2.1" in taxonomy, f"expected subcategory 2.1, got {sorted(taxonomy)[:5]}"


### PR DESCRIPTION
> **Stacked on #26** — base is `chore/consistency-pass`, because one test asserts every command is reachable from a skill and #26 is what makes `daily_digest` reachable. Merge #26 first and this retargets to master.

13,000 lines of engine had **no test and no CI**. The gap wasn't theoretical: this repo has shipped five instructions that worked in the checkout they were written in and failed for whoever followed them, plus one detector that ran dead for weeks while reporting success.

So the suite is built around **that failure mode**, not around coverage.

## The central assertion

No QC detector may report a skip that hides *our* bug wearing a *user's* error.

`prompt_fit` raised `ModuleNotFoundError` for a package we failed to vendor; `engine.py` filed it as `missing_extra`; the run reported a clean skip with 18/18 detectors "available". **A test that imports the detectors, or counts how many ran, passes in exactly that state.**

Validated by reintroducing the real bug — repoint `prompt_fit` at `showwatcher.data` and two tests fail, including the general one that would catch the next instance in a different detector.

## 56 tests, ~19s, no network and no models

| file | what it holds to |
|---|---|
| `test_cli` | every `COMMANDS` entry resolves; a string `SystemExit` prints its message rather than a traceback (the dispatcher bug) |
| `test_packaging` | README counts match reality; every command is named where a reader can find it; duplicated bundled scripts byte-identical; no document says "install from PyPI"; the wheel ships presets, tutorials and qc data; `[all]` hasn't come back |
| `test_clock_and_audio` | durations come from **measured** audio; props and `plan.json` agree; the ducking envelope dips under the loud scene and recovers in the silent one; **and the composer still reads the envelope key `duck_music` writes** |
| `test_captions` | karaoke tags sum to their page duration; pages respect `wordsPerPage`; hex converts to ASS BGR |

Fixtures build real WAVs and real mp4s with ffmpeg. Mocking them would reproduce the exact failure being tested — code that runs happily and produces nothing.

That composer-contract test is worth singling out: `duck_music` wrote `music.envelope` for weeks while the composer read only `music.volume`. Nothing failed because there was nothing to fail. It's a contract with no schema, and this is the cheapest thing that notices.

## The repo's own rule, now enforced

`TESTING.md` said *"A skill should have at least one scenario."* **9 of 16 had none** — all of them arrivals from the consolidation, which is exactly when a documented standard quietly stops being met. Nine scenarios written, and a test enforces the rule plus one checking every scenario names a skill that exists.

## CI

Three jobs: `verify-skills` for installability invariants, `pytest` for what needs running code, and a `composer` job running `npm ci` + `tsc` — which also exercises the postinstall that writes the registry `Root.tsx` imports and that is deliberately not committed.

**Python pinned to 3.12, not 3.13**, because kokoro's marker excludes 3.13 — a 3.13 job would install cleanly and silently have no voice, which is the failure mode this suite exists for.