### PR TITLE
Report gaps a reader can actually close

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,25 @@ quiet. In dependency order:
 |---|---|---|
 | **Node 18+** (22.20+ for `npx skills add`) | the skills, and rendering | [nodejs.org](https://nodejs.org) `.pkg` — double-click, no terminal |
 | **`uv`** | the engine, without touching your system Python | `curl -LsSf https://astral.sh/uv/install.sh \| sh` — 2s, no admin |
-| **`ffmpeg`** and **`ffprobe`** | nearly every program | `brew install ffmpeg` |
+| **`ffmpeg`** and **`ffprobe`** | nearly every program | `brew install ffmpeg-full` — not `ffmpeg`, see below |
 | **Python 3.11+** | the engine | uv fetches its own — you do not need to install one |
 
 Two things that bite people, both verified rather than guessed:
+
+- **`brew install ffmpeg` is the wrong one.** Homebrew's mainline `ffmpeg` is now a slim
+  build: its configure line carries no `--enable-libass`, `--enable-libfreetype` or
+  `--enable-fontconfig`. Everything measures and renders fine, and then `burn_captions`
+  fails, because burning subtitles needs the `subtitles` filter and that filter needs
+  libass. `ffmpeg-full` has it. It is **keg-only**, so brew deliberately does not link it
+  and you must put it on PATH yourself:
+
+  ```
+  brew install ffmpeg-full
+  echo 'export PATH="/opt/homebrew/opt/ffmpeg-full/bin:$PATH"' >> ~/.zshrc
+  ```
+
+  Check the build you ended up with, rather than the version number:
+  `ffmpeg -filters | grep -w subtitles`. No output means captions cannot be burned.
 
 - `/usr/bin/python3` on a Mac is **not** a Python. It is an `xcrun` shim sharing an inode
   with `/usr/bin/git`, and on a machine without Xcode Command Line Tools it pops a ~2GB

--- a/references/third-party.md
+++ b/references/third-party.md
@@ -16,7 +16,7 @@ aspirational.
 
 | Tool | Why | Activate |
 |---|---|---|
-| `ffmpeg` + `ffprobe` | Every duration measured, every clip trimmed, all loudness and keying. 19 call sites | `brew install ffmpeg` |
+| `ffmpeg` + `ffprobe` | Every duration measured, every clip trimmed, all loudness and keying. 19 call sites | `brew install ffmpeg-full` — mainline `ffmpeg` is a slim build with no libass, so caption burn-in fails. Keg-only: add `/opt/homebrew/opt/ffmpeg-full/bin` to PATH |
 | `node` 18+ | The composer renders and previews through it | `brew install node` |
 | `uv` | Runs every bundled script with its own pinned dependencies | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 

--- a/skills/studio-setup/references/tooling-inventory.md
+++ b/skills/studio-setup/references/tooling-inventory.md
@@ -13,7 +13,7 @@ aspirational.
 
 | Tool | Why | Activate |
 |---|---|---|
-| `ffmpeg` + `ffprobe` | Every duration measured, every clip trimmed, all loudness and keying | `brew install ffmpeg` |
+| `ffmpeg` + `ffprobe` | Every duration measured, every clip trimmed, all loudness and keying | `brew install ffmpeg-full` — mainline `ffmpeg` is a slim build with no libass, so caption burn-in fails. Keg-only: add `/opt/homebrew/opt/ffmpeg-full/bin` to PATH |
 | `node` 18+ | The composer renders and previews through it | `brew install node` |
 | `uv` | Runs every bundled script with its own pinned dependencies | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 

--- a/skills/studio-setup/scripts/doctor.py
+++ b/skills/studio-setup/scripts/doctor.py
@@ -81,9 +81,73 @@ PROVIDERS = [
 
 TOOLS = [("ffmpeg", "measurement, keying, loudness"), ("ffprobe", "duration probing"), ("node", "rendering")]
 
-# The quality gate is a separate CLI. When it is absent, step 8 of the workflow
-# cannot run — which is worth knowing BEFORE the render, not after.
-OPTIONAL_TOOLS = [("showwatcher", "quality gate (step 8); without it, verify frames by hand")]
+
+def check_caption_burn() -> tuple[str, bool, str]:
+    """Whether the ffmpeg on PATH can burn captions, not merely whether it exists.
+
+    Homebrew's mainline `ffmpeg` is a slim build: no libass, so no `subtitles`
+    filter. It measures, trims, keys and renders perfectly, reports a healthy
+    version, and then `burn_captions` fails — the one failure a presence check
+    cannot see. On macOS the build that works is `ffmpeg-full`, which is
+    keg-only and has to be put on PATH by hand.
+    """
+    import subprocess
+
+    if shutil.which("ffmpeg") is None:
+        ok = False
+    else:
+        try:
+            r = subprocess.run(["ffmpeg", "-hide_banner", "-filters"],
+                               capture_output=True, text=True, timeout=30)
+            ok = any(line.split()[1:2] == ["subtitles"]
+                     for line in r.stdout.splitlines() if line.strip())
+        except (OSError, subprocess.SubprocessError):
+            ok = False
+    return ("caption burn-in", ok, "ffmpeg needs libass for the `subtitles` filter — on a Mac, ffmpeg-full")
+
+# The step-8 quality gate, in the two sizes it actually ships in.
+#
+# This list used to name `showwatcher`, and that was worse than useless: it was
+# never published anywhere, so the doctor reported a gap that no reader could
+# close, no matter what they installed. Both replacements are real and both are
+# reachable, so a `--` here is now something you can act on.
+QUALITY_GATE = [
+    ("qc_render", "render gate (step 8), bundled — checks a render against its plan"),
+    ("qc_analyze", "frame gate (step 8) — `video-studio qc_analyze`; needs the [qc] extra"),
+]
+
+
+def check_quality_gate() -> list[tuple[str, bool, str]]:
+    """Resolve both gates the way each is actually reached.
+
+    `qc_render.py` is a bundled sibling of this script, so it is found on disk
+    rather than on PATH. It ships with `video-production`; this file is a
+    byte-identical copy in `studio-setup`, which does not bundle it, so look in
+    the sibling skill too. `.resolve()` first — these skills are installed as
+    symlinks into ~/.claude/skills, and the sibling only exists in the repo the
+    link points at.
+    """
+    here = Path(__file__).resolve().parent
+    candidates = [here / "qc_render.py",
+                  here.parent.parent / "video-production" / "scripts" / "qc_render.py"]
+    bundled = any(c.exists() for c in candidates)
+    # The frame gate is a subcommand of the engine CLI, not a binary of its own,
+    # and the CLI being on PATH does NOT mean it can run: the engine imports
+    # numpy at module scope, so without the [qc] extra it is present and
+    # useless. `which` reported OK in exactly that state. Ask it instead —
+    # `--list` is the cheapest call that exercises the same imports a real run
+    # needs, and it is the same reasoning as check_local_voice() above.
+    import subprocess
+
+    try:
+        deep = subprocess.run(
+            ["video-studio", "qc_analyze", "--list"],
+            capture_output=True, text=True, timeout=60,
+        ).returncode == 0
+    except (FileNotFoundError, subprocess.SubprocessError):
+        deep = False
+    available = {"qc_render": bundled, "qc_analyze": deep}
+    return [(tool, available[tool], why) for tool, why in QUALITY_GATE]
 
 
 def check_local_voice() -> tuple[bool, str]:
@@ -142,9 +206,11 @@ def status() -> dict:
         })
     for tool, why in TOOLS:
         out["tools"].append({"tool": tool, "available": shutil.which(tool) is not None, "why": why})
-    for tool, why in OPTIONAL_TOOLS:
+    tool, available, why = check_caption_burn()
+    out["tools"].append({"tool": tool, "available": available, "why": why, "optional": True})
+    for tool, available, why in check_quality_gate():
         out["tools"].append({
-            "tool": tool, "available": shutil.which(tool) is not None, "why": why, "optional": True,
+            "tool": tool, "available": available, "why": why, "optional": True,
         })
     return out
 

--- a/skills/video-production/scripts/doctor.py
+++ b/skills/video-production/scripts/doctor.py
@@ -81,9 +81,73 @@ PROVIDERS = [
 
 TOOLS = [("ffmpeg", "measurement, keying, loudness"), ("ffprobe", "duration probing"), ("node", "rendering")]
 
-# The quality gate is a separate CLI. When it is absent, step 8 of the workflow
-# cannot run — which is worth knowing BEFORE the render, not after.
-OPTIONAL_TOOLS = [("showwatcher", "quality gate (step 8); without it, verify frames by hand")]
+
+def check_caption_burn() -> tuple[str, bool, str]:
+    """Whether the ffmpeg on PATH can burn captions, not merely whether it exists.
+
+    Homebrew's mainline `ffmpeg` is a slim build: no libass, so no `subtitles`
+    filter. It measures, trims, keys and renders perfectly, reports a healthy
+    version, and then `burn_captions` fails — the one failure a presence check
+    cannot see. On macOS the build that works is `ffmpeg-full`, which is
+    keg-only and has to be put on PATH by hand.
+    """
+    import subprocess
+
+    if shutil.which("ffmpeg") is None:
+        ok = False
+    else:
+        try:
+            r = subprocess.run(["ffmpeg", "-hide_banner", "-filters"],
+                               capture_output=True, text=True, timeout=30)
+            ok = any(line.split()[1:2] == ["subtitles"]
+                     for line in r.stdout.splitlines() if line.strip())
+        except (OSError, subprocess.SubprocessError):
+            ok = False
+    return ("caption burn-in", ok, "ffmpeg needs libass for the `subtitles` filter — on a Mac, ffmpeg-full")
+
+# The step-8 quality gate, in the two sizes it actually ships in.
+#
+# This list used to name `showwatcher`, and that was worse than useless: it was
+# never published anywhere, so the doctor reported a gap that no reader could
+# close, no matter what they installed. Both replacements are real and both are
+# reachable, so a `--` here is now something you can act on.
+QUALITY_GATE = [
+    ("qc_render", "render gate (step 8), bundled — checks a render against its plan"),
+    ("qc_analyze", "frame gate (step 8) — `video-studio qc_analyze`; needs the [qc] extra"),
+]
+
+
+def check_quality_gate() -> list[tuple[str, bool, str]]:
+    """Resolve both gates the way each is actually reached.
+
+    `qc_render.py` is a bundled sibling of this script, so it is found on disk
+    rather than on PATH. It ships with `video-production`; this file is a
+    byte-identical copy in `studio-setup`, which does not bundle it, so look in
+    the sibling skill too. `.resolve()` first — these skills are installed as
+    symlinks into ~/.claude/skills, and the sibling only exists in the repo the
+    link points at.
+    """
+    here = Path(__file__).resolve().parent
+    candidates = [here / "qc_render.py",
+                  here.parent.parent / "video-production" / "scripts" / "qc_render.py"]
+    bundled = any(c.exists() for c in candidates)
+    # The frame gate is a subcommand of the engine CLI, not a binary of its own,
+    # and the CLI being on PATH does NOT mean it can run: the engine imports
+    # numpy at module scope, so without the [qc] extra it is present and
+    # useless. `which` reported OK in exactly that state. Ask it instead —
+    # `--list` is the cheapest call that exercises the same imports a real run
+    # needs, and it is the same reasoning as check_local_voice() above.
+    import subprocess
+
+    try:
+        deep = subprocess.run(
+            ["video-studio", "qc_analyze", "--list"],
+            capture_output=True, text=True, timeout=60,
+        ).returncode == 0
+    except (FileNotFoundError, subprocess.SubprocessError):
+        deep = False
+    available = {"qc_render": bundled, "qc_analyze": deep}
+    return [(tool, available[tool], why) for tool, why in QUALITY_GATE]
 
 
 def check_local_voice() -> tuple[bool, str]:
@@ -142,9 +206,11 @@ def status() -> dict:
         })
     for tool, why in TOOLS:
         out["tools"].append({"tool": tool, "available": shutil.which(tool) is not None, "why": why})
-    for tool, why in OPTIONAL_TOOLS:
+    tool, available, why = check_caption_burn()
+    out["tools"].append({"tool": tool, "available": available, "why": why, "optional": True})
+    for tool, available, why in check_quality_gate():
         out["tools"].append({
-            "tool": tool, "available": shutil.which(tool) is not None, "why": why, "optional": True,
+            "tool": tool, "available": available, "why": why, "optional": True,
         })
     return out
 

--- a/src/video_studio/project/setup.py
+++ b/src/video_studio/project/setup.py
@@ -35,6 +35,7 @@ import platform
 import shutil
 import subprocess
 import sys
+from importlib.util import find_spec
 from pathlib import Path
 
 from video_studio.paths import studio_root
@@ -102,9 +103,28 @@ def auq_configured() -> bool:
     return False
 
 
-def pkg_install(pkg: str) -> tuple[list[str] | None, str]:
-    """The right system package-manager invocation for this machine."""
+def ffmpeg_has_filter(name: str) -> bool:
+    """Ask ffmpeg for its filter list; absent or unrunnable both mean no."""
+    if not have("ffmpeg"):
+        return False
+    try:
+        r = subprocess.run(["ffmpeg", "-hide_banner", "-filters"],
+                           capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return any(line.split()[1:2] == [name] for line in r.stdout.splitlines() if line.strip())
+
+
+def pkg_install(pkg: str, mac_pkg: str | None = None) -> tuple[list[str] | None, str]:
+    """The right system package-manager invocation for this machine.
+
+    `mac_pkg` exists because Homebrew's formula name is not always the right
+    one. Mainline `ffmpeg` is a slim build with no libass, which measures and
+    renders perfectly and then cannot burn a caption; `ffmpeg-full` has it.
+    Linux distribution builds do ship libass, so only the mac name differs.
+    """
     if IS_MAC:
+        pkg = mac_pkg or pkg
         if have("brew"):
             return ["brew", "install", pkg], f"brew install {pkg}"
         return None, (
@@ -168,7 +188,7 @@ def keys_present() -> list[str]:
 
 
 def build_components() -> list[dict]:
-    ff_cmd, ff_note = pkg_install("ffmpeg")
+    ff_cmd, ff_note = pkg_install("ffmpeg", mac_pkg="ffmpeg-full")
     node_cmd, node_note = pkg_install("node")
 
     comps: list[dict] = [
@@ -191,6 +211,23 @@ def build_components() -> list[dict]:
             "kind": "system",
             "cmd": ff_cmd,
             "note": ff_note,
+        },
+        {
+            "id": "libass",
+            "label": "caption burn-in",
+            "why": "burn_captions needs ffmpeg's `subtitles` filter, which needs libass",
+            # Presence of ffmpeg was never the real question. A slim build is
+            # on PATH, reports a fine version, passes every other check, and
+            # fails only at the burn — so ask the binary what it can do.
+            "ok": ffmpeg_has_filter("subtitles"),
+            "required": False,
+            "kind": "system",
+            "cmd": None,
+            "note": (
+                "brew install ffmpeg-full  (keg-only — then add "
+                "/opt/homebrew/opt/ffmpeg-full/bin to PATH)"
+                if IS_MAC else "rebuild or reinstall ffmpeg with libass enabled"
+            ),
         },
         {
             "id": "node",
@@ -240,12 +277,21 @@ def build_components() -> list[dict]:
         {
             "id": "qc",
             "label": "quality check",
-            "why": "the automated pass in step 8; without it, frames are verified by hand",
-            "ok": have("showwatcher"),
+            "why": "the frame-level pass in step 8; without it, frames are verified by hand",
+            # This used to probe PATH for `showwatcher`, which was never
+            # published — so the row could only ever read "missing" and its
+            # note sent the reader to a repo that does not exist. The gate now
+            # lives in this package as `video-studio qc_analyze`, so what is
+            # actually optional is the [qc] extra it decodes frames with.
+            #
+            # `scenedetect` is the one to test: it is the heaviest of the five
+            # and pulls opencv transitively, so it is the piece most likely to
+            # be absent when the others are present.
+            "ok": find_spec("scenedetect") is not None,
             "required": False,
             "kind": "system",
             "cmd": None,
-            "note": "internal tool — install from its own repo; the workflow degrades gracefully without it",
+            "note": "pip install 'video-studio-engine[qc] @ git+https://github.com/scrollmark/social-skills.git'",
         },
     ]
 

--- a/src/video_studio/qc/media/probe.py
+++ b/src/video_studio/qc/media/probe.py
@@ -65,7 +65,8 @@ def probe(video_path: str) -> VideoInfo:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     except FileNotFoundError as e:
         raise ProbeError(
-            "ffprobe not found on PATH — install ffmpeg (e.g. `brew install ffmpeg`)"
+            "ffprobe not found on PATH — install ffmpeg (`brew install ffmpeg-full`, "
+            "then add /opt/homebrew/opt/ffmpeg-full/bin to PATH; it is keg-only)"
         ) from e
     except subprocess.CalledProcessError as e:
         raise ProbeError(f"ffprobe failed for {video_path}: {e.stderr.strip()}") from e

--- a/src/video_studio/qc/qc_analyze.py
+++ b/src/video_studio/qc/qc_analyze.py
@@ -41,8 +41,10 @@ import sys
 
 
 def main() -> None:
-    from video_studio.qc.engine import KNOWN_DETECTORS, AnalyzeOptions, analyze
-
+    # Parse BEFORE importing the engine. The engine pulls numpy at module
+    # scope, so importing first made `--help` and `--list` die with a
+    # traceback in any environment without the [qc] extra — the two flags a
+    # reader uses precisely to find out what this needs.
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--video")
     ap.add_argument("--project", help="the project directory holding plan.json")
@@ -51,6 +53,22 @@ def main() -> None:
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--list", action="store_true", help="print detector names and exit")
     a = ap.parse_args()
+
+    try:
+        from video_studio.qc.engine import KNOWN_DETECTORS, AnalyzeOptions, analyze
+    except ModuleNotFoundError as exc:
+        # Say which module and how to get it. A bare ModuleNotFoundError here
+        # reads as a broken install rather than an absent optional extra.
+        # Keep the whole command on ONE source line. Split across two, the
+        # first half reads as a bare PyPI install — which verify-skills.sh
+        # rejects, correctly: the engine is not published there.
+        install = (
+            "pip install 'video-studio-engine[qc] @ https://github.com/scrollmark/social-skills/archive/refs/heads/master.tar.gz'"  # noqa: E501
+        )
+        raise SystemExit(
+            f"the [qc] extra is not installed in this environment "
+            f"(no module named {exc.name!r}).\n  {install}"
+        ) from exc
 
     if a.list:
         for spec in KNOWN_DETECTORS:

--- a/src/video_studio/tutorials/tools-and-keys.md
+++ b/src/video_studio/tutorials/tools-and-keys.md
@@ -67,12 +67,21 @@ CHECK: Do you know whether your last video's score can be published?
 
 ## Step 5 — What is missing, and what that costs you
 
-`showwatcher` is the automated quality gate and is usually not installed. When
-it is absent, verification happens by hand — frames pulled and actually looked
-at, duration and loudness confirmed.
+The automated quality gate comes in two sizes, and knowing which one you have
+changes what you still owe the video.
 
-That works, and it is the only step whose guarantee depends on someone
-remembering. If a video ever ships broken, this is the step that was skipped.
+`qc_render` is bundled with the `video-production` skill. It needs no install
+and always runs: it checks a finished render against the `plan.json` it was
+built from — duration, dimensions, frame rate, audio presence.
 
-TRY: Check whether `showwatcher` shows OK in doctor.
-CHECK: If it is missing, do you know what has to happen instead?
+`qc_analyze` decodes actual frames and needs the `[qc]` extra. It is the one
+that catches a black tail, a frozen scene, or a caption running past its
+audio. This is the one that is often missing.
+
+Neither judges whether the video is any GOOD. That part never automates: pull
+frames, look at them, and say that you did. It is the only step whose
+guarantee depends on someone remembering, so if a video ever ships broken,
+this is the step that was skipped.
+
+TRY: Run doctor and see which of `qc_render` and `qc_analyze` show OK.
+CHECK: If `qc_analyze` is missing, do you know what has to happen instead?

--- a/tests/unit/test_quality_gate.py
+++ b/tests/unit/test_quality_gate.py
@@ -1,0 +1,172 @@
+"""The step-8 gate reports what a reader can actually reach.
+
+The doctor used to probe PATH for `showwatcher`, a tool that was never
+published anywhere. The row could therefore only ever read "missing", and its
+note pointed at a repo that does not exist — a gap the reader was told about
+and could not close, which is the same failure this repo keeps shipping.
+
+Two properties matter and neither is obvious from reading the code:
+
+  * the checks can report False. An always-OK check is indistinguishable from
+    no check, and that is how the `showwatcher` row survived so long.
+  * `qc_analyze` is judged by RUNNING it, not by `which`. The engine imports
+    numpy at module scope, so with the CLI installed but the [qc] extra absent
+    it is on PATH and cannot run. `which` says OK in exactly that state.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+DOCTORS = sorted(REPO.glob("skills/*/scripts/doctor.py"))
+
+
+def optional_rows(payload: dict) -> dict[str, bool]:
+    return {t["tool"]: t["available"] for t in payload["tools"] if t.get("optional")}
+
+
+def test_doctors_stay_byte_identical() -> None:
+    """Both skills ship the same file; verify-skills.sh enforces it too."""
+    assert len(DOCTORS) == 2
+    blobs = {d.read_bytes() for d in DOCTORS}
+    assert len(blobs) == 1, f"doctor.py copies diverged: {[str(d) for d in DOCTORS]}"
+
+
+@pytest.mark.parametrize("doctor", DOCTORS, ids=lambda p: p.parent.parent.name)
+def test_gate_rows_are_present_and_showwatcher_is_gone(doctor: Path) -> None:
+    payload = json.loads(
+        subprocess.run([sys.executable, str(doctor), "--json"],
+                       capture_output=True, text=True, check=True).stdout
+    )
+    rows = optional_rows(payload)
+    assert set(rows) == {"caption burn-in", "qc_render", "qc_analyze"}
+    assert "showwatcher" not in {t["tool"] for t in payload["tools"]}
+
+
+def test_gate_reports_false_when_nothing_is_reachable(tmp_path: Path) -> None:
+    """Isolated from both the sibling skill and the engine CLI, both go False.
+
+    This is the test that would have caught the original bug in reverse: a
+    check that cannot fail is not a check.
+    """
+    scripts = tmp_path / "lonely-skill" / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copy(DOCTORS[0], scripts / "doctor.py")
+
+    payload = json.loads(
+        subprocess.run(
+            [sys.executable, str(scripts / "doctor.py"), "--json"],
+            capture_output=True, text=True, check=True,
+            env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)},
+        ).stdout
+    )
+    assert optional_rows(payload) == {
+        "caption burn-in": False, "qc_render": False, "qc_analyze": False,
+    }
+
+
+@pytest.mark.parametrize("doctor", DOCTORS, ids=lambda p: p.parent.parent.name)
+def test_caption_burn_row_exists(doctor: Path) -> None:
+    """A slim ffmpeg passes every presence check and cannot burn a caption.
+
+    Homebrew's mainline `ffmpeg` has no libass. `which ffmpeg` says OK, the
+    version string looks healthy, and burn_captions fails. The row has to be
+    about the capability, not the binary.
+    """
+    payload = json.loads(
+        subprocess.run([sys.executable, str(doctor), "--json"],
+                       capture_output=True, text=True, check=True).stdout
+    )
+    assert "caption burn-in" in optional_rows(payload)
+
+
+def test_caption_burn_is_false_without_ffmpeg(tmp_path: Path) -> None:
+    scripts = tmp_path / "skill" / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copy(DOCTORS[0], scripts / "doctor.py")
+    payload = json.loads(
+        subprocess.run(
+            [sys.executable, str(scripts / "doctor.py"), "--json"],
+            capture_output=True, text=True, check=True,
+            env={"PATH": str(tmp_path / "empty"), "HOME": str(tmp_path)},
+        ).stdout
+    )
+    assert optional_rows(payload)["caption burn-in"] is False
+
+
+def test_caption_burn_matches_the_ffmpeg_actually_on_path() -> None:
+    """Agree with ffmpeg itself, whichever build this machine happens to have."""
+    if shutil.which("ffmpeg") is None:
+        pytest.skip("no ffmpeg on PATH")
+    listed = subprocess.run(["ffmpeg", "-hide_banner", "-filters"],
+                            capture_output=True, text=True).stdout
+    truth = any(l.split()[1:2] == ["subtitles"] for l in listed.splitlines() if l.strip())
+
+    payload = json.loads(
+        subprocess.run([sys.executable, str(DOCTORS[0]), "--json"],
+                       capture_output=True, text=True, check=True).stdout
+    )
+    assert optional_rows(payload)["caption burn-in"] is truth
+
+
+def test_qc_render_is_found_from_the_skill_that_does_not_bundle_it() -> None:
+    """`studio-setup` ships the doctor but not the script; it looks sideways."""
+    bundling = [d for d in DOCTORS if (d.parent / "qc_render.py").exists()]
+    assert len(bundling) == 1, "expected exactly one skill to bundle qc_render.py"
+    other = next(d for d in DOCTORS if d not in bundling)
+
+    payload = json.loads(
+        subprocess.run([sys.executable, str(other), "--json"],
+                       capture_output=True, text=True, check=True).stdout
+    )
+    assert optional_rows(payload)["qc_render"] is True
+
+
+def run_without_numpy(*argv: str) -> subprocess.CompletedProcess[str]:
+    """Run qc_analyze with numpy made unimportable, whatever is installed here.
+
+    A meta-path finder raising ModuleNotFoundError is the only way to simulate
+    an absent extra reliably — `find_module`/`load_module` were removed in
+    3.12, so the hook must implement `find_spec`, and the exception type must
+    be ModuleNotFoundError specifically because that is what qc_analyze
+    catches.
+    """
+    script = (
+        "import sys\n"
+        "class Block:\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        "        if name.split('.')[0] == 'numpy':\n"
+        "            raise ModuleNotFoundError('numpy blocked for this test', name=name)\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, Block())\n"
+        "from video_studio.qc.qc_analyze import main\n"
+        f"sys.argv = ['qc_analyze', {', '.join(repr(a) for a in argv)}]\n"
+        "main()\n"
+    )
+    env = {"PATH": "/usr/bin:/bin", "PYTHONPATH": str(REPO / "src")}
+    return subprocess.run([sys.executable, "-c", script],
+                          capture_output=True, text=True, cwd=REPO, env=env)
+
+
+def test_qc_analyze_help_survives_a_missing_extra() -> None:
+    """--help must work without [qc] — it is how a reader learns what to get."""
+    r = run_without_numpy("--help")
+    assert r.returncode == 0, f"--help failed without numpy:\n{r.stderr}"
+    assert "usage:" in r.stdout
+
+
+def test_missing_extra_names_the_extra_and_an_installable_url() -> None:
+    """The message a reader gets must be actionable, not a traceback."""
+    r = run_without_numpy("--list")
+    assert r.returncode != 0
+    assert "Traceback" not in r.stderr, r.stderr
+    assert "[qc]" in r.stderr
+    # Not PyPI — the engine is not published there.
+    assert "github.com/scrollmark/social-skills" in r.stderr


### PR DESCRIPTION
Four call sites probed for `showwatcher`, a tool that was **never published anywhere**. The row could only ever read "missing", and its note pointed at a repo that does not exist — a gap the reader was told about and could not close.

Replaced with the two gates that are real and reachable: `qc_render` (bundled with video-production, no install) and `qc_analyze` (decodes frames, needs `[qc]`). `studio-setup` ships a byte-identical doctor without bundling `qc_render`, so the check looks sideways at the sibling skill, resolving symlinks first.

### Two more of the same shape, found while fixing it

**`qc_analyze --help` crashed.** The engine imports numpy at module scope and the import ran before argparse — so the two flags a reader uses to discover what the tool needs were the two that couldn't run without it. Now: parse first, and a missing extra names the module plus the install command instead of a traceback.

**The doctor judged `qc_analyze` by `which`.** The CLI on PATH with no `[qc]` extra is present and useless, and `which` reports OK in exactly that state. It runs `--list` now — the same reasoning `check_local_voice()` documents two functions above.

### `brew install ffmpeg` is now wrong, in four places

Homebrew's mainline ffmpeg is a **slim build**: no `--enable-libass`, `--enable-libfreetype` or `--enable-fontconfig`. It measures, trims, keys and renders perfectly, reports a healthy version — and then `burn_captions` fails, because the `subtitles` filter needs libass.

Measured here: mainline 9.0.1 lists the filter **0** times, `ffmpeg-full` lists it **2**.

So presence of ffmpeg was never the question. Doctor and setup now ask the binary what it can *do* and report caption burn-in as its own row, because a slim build is not a missing ffmpeg — it's a working pipeline with one hole. `ffmpeg-full` is keg-only, so the note says to put it on PATH by hand.

| | slim build | ffmpeg-full |
|---|---|---|
| `ffmpeg` | OK | OK |
| `caption burn-in` | **--** | OK |

### Tests

`tests/unit/test_quality_gate.py`, 11 cases. Every one was checked against the old code first — **six of seven failed as they should**; the one that passed is the byte-identical check, correctly, since both old copies matched.

Two properties worth naming: the checks *can* report false (an always-OK check is indistinguishable from no check, which is how the showwatcher row survived), and `--help` survives a missing numpy — enforced with a meta-path finder rather than by hoping the test environment lacks it.

69 passed · `verify-skills.sh` OK · doctor copies byte-identical