### PR TITLE
Isolate the doctor test from the platform it runs on

### DIFF
--- a/tests/unit/test_quality_gate.py
+++ b/tests/unit/test_quality_gate.py
@@ -60,11 +60,18 @@ def test_gate_reports_false_when_nothing_is_reachable(tmp_path: Path) -> None:
     scripts.mkdir(parents=True)
     shutil.copy(DOCTORS[0], scripts / "doctor.py")
 
+    # PATH must be an EMPTY directory, not "/usr/bin:/bin". On a Mac those hold
+    # no ffmpeg, so the first version of this test passed locally and failed on
+    # Ubuntu, where /usr/bin/ffmpeg exists and has libass — making the caption
+    # row correctly True and the assertion wrong. Isolation has to be real,
+    # not a guess about what a given platform keeps in /usr/bin.
+    empty = tmp_path / "empty-path"
+    empty.mkdir()
     payload = json.loads(
         subprocess.run(
             [sys.executable, str(scripts / "doctor.py"), "--json"],
             capture_output=True, text=True, check=True,
-            env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)},
+            env={"PATH": str(empty), "HOME": str(tmp_path)},
         ).stdout
     )
     assert optional_rows(payload) == {


### PR DESCRIPTION
Master is red. `test_gate_reports_false_when_nothing_is_reachable` set `PATH="/usr/bin:/bin"` to simulate a bare machine — a **Mac assumption**. Ubuntu keeps ffmpeg in `/usr/bin`, and its build has libass, so `caption burn-in` was correctly `True` and the assertion was wrong.

```
E   {'caption burn-in': True} != {'caption burn-in': False}
```

Now points PATH at an empty directory it creates, so the isolation is real rather than a guess about what a platform keeps in `/usr/bin`. The neighbouring caption test already did this and passed on CI, which made the cause obvious.

Verified the mechanism locally with a stub ffmpeg that reports the `subtitles` filter: the doctor returns `caption burn-in: True`, which is exactly the CI condition.

This is the same failure the suite exists to catch — a check correct for whoever wrote it and wrong for whoever runs it next. It got through because I verified the tests by reverting the *fixes* and watching them fail, which proves they test the right behaviour, and never by running them anywhere but this Mac.