### PR TITLE
Document installing one skill, on both routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ Two things that bite people, both verified rather than guessed:
 ### The skills
 
 ```bash
-npx skills add scrollmark/social-skills
+npx skills add scrollmark/social-skills                    # all sixteen
+npx skills add scrollmark/social-skills -s hook-anatomy    # just one
 ```
 
 Needs Node. If you would rather not install Node, the same thing without it — note the
@@ -235,8 +236,13 @@ Needs Node. If you would rather not install Node, the same thing without it — 
 mkdir -p ~/social-skills
 curl -Ls https://github.com/scrollmark/social-skills/archive/refs/heads/master.tar.gz \
   | tar xz --strip-components=1 -C ~/social-skills
-~/social-skills/install.sh
+~/social-skills/install.sh                                 # all sixteen
+~/social-skills/install.sh hook-anatomy                    # just one
 ```
+
+The two routes take a single skill differently, which is easy to trip over: `npx skills
+add` wants the `-s` flag, `install.sh` takes bare names. `install.sh --list` prints what
+is available, and an unknown name is refused rather than half-installed.
 
 `install.sh` **symlinks** into that directory, so it has to live somewhere permanent —
 extract to `/tmp` and every skill dies at the next purge, all at once and with no error.


### PR DESCRIPTION
The website publishes a per-skill install command **sixteen times** — once on every skill card — and the README documented only the install-everything form. A reader arriving from the site already knows something the repo doesn't mention.

Both routes are now shown, and the trap between them is stated rather than left to be discovered:

```bash
npx skills add scrollmark/social-skills -s hook-anatomy    # flag
~/social-skills/install.sh hook-anatomy                    # positional
```

Someone who learns one form and tries it on the other gets no help from either.

**Verified rather than assumed:** `npx skills add --help` does list `-s, --skill <skills>`, so the sixteen commands the site prints are correct. `install.sh --list` prints the available names, and an unknown name is refused outright rather than half-installing.

`verify-skills.sh` OK · 69 tests pass