### PR TITLE
Fix tts_kokoro failing under the documented uv tool install route

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ Two things that bite people, both verified rather than guessed:
 ### The skills
 
 ```bash
-npx skills add scrollmark/social-skills
+npx skills add scrollmark/social-skills                    # all sixteen
+npx skills add scrollmark/social-skills -s hook-anatomy    # just one
 ```
 
 Needs Node. If you would rather not install Node, the same thing without it — note the
@@ -235,8 +236,13 @@ Needs Node. If you would rather not install Node, the same thing without it — 
 mkdir -p ~/social-skills
 curl -Ls https://github.com/scrollmark/social-skills/archive/refs/heads/master.tar.gz \
   | tar xz --strip-components=1 -C ~/social-skills
-~/social-skills/install.sh
+~/social-skills/install.sh                                 # all sixteen
+~/social-skills/install.sh hook-anatomy                    # just one
 ```
+
+The two routes take a single skill differently, which is easy to trip over: `npx skills
+add` wants the `-s` flag, `install.sh` takes bare names. `install.sh --list` prints what
+is available, and an unknown name is refused rather than half-installed.
 
 `install.sh` **symlinks** into that directory, so it has to live somewhere permanent —
 extract to `/tmp` and every skill dies at the next purge, all at once and with no error.

--- a/src/video_studio/cli.py
+++ b/src/video_studio/cli.py
@@ -15,10 +15,22 @@ Three ways in, all equivalent:
 
 The third is the one to reach for in a skill: it names the module explicitly and
 survives this dispatcher being renamed.
+
+VIRTUAL_ENV is set here, defensively, for every entry path. `uv tool install`
+(the README's documented route for this package) runs the installed
+`video-studio` console-script directly against its own venv's python, which
+never sets VIRTUAL_ENV -- unlike `uv run`, which does. tts_kokoro's first-run
+spaCy model bootstrap shells out to `uv pip install` and that subprocess reads
+VIRTUAL_ENV to know which environment to install into; without it, uv refuses
+with "No virtual environment found ... pass --system", even though we are
+demonstrably running inside one (sys.prefix names it). setdefault leaves an
+already-set VIRTUAL_ENV alone, so `uv run` and the manual `.venv-tts` recipe in
+tts_kokoro's own INSTALL_HINT are unaffected.
 """
 
 from __future__ import annotations
 
+import os
 import runpy
 import sys
 
@@ -94,6 +106,8 @@ def _usage() -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # See the VIRTUAL_ENV paragraph in this module's docstring.
+    os.environ.setdefault("VIRTUAL_ENV", sys.prefix)
     args = list(sys.argv[1:] if argv is None else argv)
     if not args or args[0] in ("-h", "--help", "help"):
         print(_usage())

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+import video_studio.cli as cli
+
 SRC = Path(__file__).resolve().parents[2] / "src"
 
 
@@ -46,3 +48,31 @@ def test_string_systemexit_prints_its_message():
     assert r.returncode == 1, f"expected exit 1, got {r.returncode}"
     assert "Traceback" not in r.stderr, f"error path raised instead of reporting:\n{r.stderr[-400:]}"
     assert "provider" in r.stderr.lower()
+
+
+def test_main_defaults_virtual_env_to_sys_prefix(monkeypatch):
+    """`uv tool install` — the README's documented route for this package —
+    runs the installed `video-studio` console-script directly against its own
+    venv's python, and that entry path never sets VIRTUAL_ENV (unlike `uv
+    run`, which does). tts_kokoro's first-run spaCy model bootstrap shells out
+    to `uv pip install`, and that subprocess reads VIRTUAL_ENV to know which
+    environment to target; without it, uv refuses with "No virtual
+    environment found ... pass --system" even though we are demonstrably
+    running inside one. Reproduced by hand on a machine that had never
+    synthesized narration before: installing the audio extra via uv's tool
+    route, then running tts_kokoro, failed with exactly that error; unsetting
+    VIRTUAL_ENV before calling `main()` reproduces it here.
+    """
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    assert cli.main(["help"]) == 0
+    assert os.environ["VIRTUAL_ENV"] == sys.prefix
+
+
+def test_main_does_not_override_an_existing_virtual_env(monkeypatch):
+    """`uv run` already sets VIRTUAL_ENV to its own ephemeral env; the
+    dispatcher must not clobber that with sys.prefix of whatever interpreter
+    happens to be running it.
+    """
+    monkeypatch.setenv("VIRTUAL_ENV", "/some/other/venv")
+    assert cli.main(["help"]) == 0
+    assert os.environ["VIRTUAL_ENV"] == "/some/other/venv"


### PR DESCRIPTION
See commit message. Reproduced by resetting an installed tool venv to first-run state (removing en_core_web_sm) and confirming the exact 'No virtual environment found' error from spaCy's uv-backed model download; the patch resolves it without needing any manual VIRTUAL_ENV export. Adds two tests to tests/unit/test_cli.py; full suite (71) and verify-skills.sh pass.