### PR TITLE
Match Freesound licences by URL, which is what the API sends

### DIFF
--- a/src/video_studio/sourcing/stock_freesound.py
+++ b/src/video_studio/sourcing/stock_freesound.py
@@ -31,17 +31,32 @@ import os
 from pathlib import Path
 
 API = "https://freesound.org/apiv2"
-CC0 = ("Creative Commons 0",)
-BY = ("Attribution",)
+
+#: Freesound returns the licence as a URL, not a display name — e.g.
+#: "http://creativecommons.org/publicdomain/zero/1.0/". The first version of
+#: this filter matched display names ("Creative Commons 0", "Attribution"),
+#: which no response has ever contained, so every result was rejected and the
+#: script reported "no acceptably-licensed result" for every query ever run.
+#: Both forms are matched now: a display name costs nothing to keep and means
+#: the filter does not silently empty itself again if the field changes back.
+NONCOMMERCIAL = ("-nc", "noncommercial")
+PUBLIC_DOMAIN = ("publicdomain", "zero", "creative commons 0", "cc0")
+ATTRIBUTION = ("licenses/by/", "attribution")
 
 
 def acceptable(license_name: str, allow_attribution: bool) -> bool:
-    name = (license_name or "")
-    if "Noncommercial" in name or "NonCommercial" in name:
+    """Is this licence one we can hand downstream without an obligation?
+
+    Order matters. "licenses/by-nc/4.0/" contains "licenses/by", so the
+    non-commercial rejection has to run first — matching attribution first
+    would accept exactly the licences this script exists to refuse.
+    """
+    name = (license_name or "").lower()
+    if any(k in name for k in NONCOMMERCIAL):
         return False  # never — downstream use is commercial
-    if any(k in name for k in CC0):
+    if any(k in name for k in PUBLIC_DOMAIN):
         return True
-    return allow_attribution and any(k in name for k in BY)
+    return allow_attribution and any(k in name for k in ATTRIBUTION)
 
 
 def main() -> None:

--- a/tests/unit/test_freesound_licence.py
+++ b/tests/unit/test_freesound_licence.py
@@ -1,0 +1,73 @@
+"""The Freesound licence filter, against the strings Freesound actually sends.
+
+Freesound's API returns `license` as a URL. The original filter matched display
+names — "Creative Commons 0", "Attribution" — which no response contains, so
+`acceptable()` returned False for every sound ever returned and the script
+reported "no acceptably-licensed result" for every query, whatever was
+searched. Nothing errored; the filter simply rejected the world.
+
+The licence strings below are the real forms Freesound serves.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from video_studio.sourcing.stock_freesound import acceptable  # noqa: E402
+
+CC0 = "http://creativecommons.org/publicdomain/zero/1.0/"
+BY = "http://creativecommons.org/licenses/by/4.0/"
+BY_3 = "http://creativecommons.org/licenses/by/3.0/"
+BY_NC = "http://creativecommons.org/licenses/by-nc/4.0/"
+BY_NC_3 = "http://creativecommons.org/licenses/by-nc/3.0/"
+SAMPLING = "http://creativecommons.org/licenses/sampling+/1.0/"
+
+
+@pytest.mark.parametrize("lic", [CC0])
+def test_public_domain_is_accepted_by_default(lic):
+    assert acceptable(lic, False) is True
+    assert acceptable(lic, True) is True
+
+
+@pytest.mark.parametrize("lic", [BY, BY_3])
+def test_attribution_needs_the_flag(lic):
+    assert acceptable(lic, False) is False
+    assert acceptable(lic, True) is True
+
+
+@pytest.mark.parametrize("lic", [BY_NC, BY_NC_3])
+def test_noncommercial_is_never_accepted(lic):
+    """The ordering trap: "licenses/by-nc/4.0/" contains "licenses/by".
+
+    Checking attribution before non-commercial would accept exactly the
+    licences this script exists to refuse — and it would do so only when
+    --allow-attribution was passed, so the default path would look fine.
+    """
+    assert acceptable(lic, False) is False
+    assert acceptable(lic, True) is False
+
+
+def test_sampling_plus_is_not_mistaken_for_free():
+    assert acceptable(SAMPLING, False) is False
+    assert acceptable(SAMPLING, True) is False
+
+
+@pytest.mark.parametrize("lic", ["Creative Commons 0", "Attribution", "Attribution Noncommercial"])
+def test_display_names_still_work(lic):
+    """Kept deliberately: if the field ever reverts to display names, the
+    filter must not empty itself again."""
+    expected = {"Creative Commons 0": (True, True),
+                "Attribution": (False, True),
+                "Attribution Noncommercial": (False, False)}[lic]
+    assert (acceptable(lic, False), acceptable(lic, True)) == expected
+
+
+def test_empty_and_none_are_rejected():
+    for lic in ("", None):
+        assert acceptable(lic, False) is False
+        assert acceptable(lic, True) is False


### PR DESCRIPTION
`stock_freesound` has **never returned a result**.

The filter compared the licence against display names — `"Creative Commons 0"`, `"Attribution"` — and Freesound sends a URL:

```
http://creativecommons.org/publicdomain/zero/1.0/
```

No response has ever contained those words, so `acceptable()` returned `False` for every sound and the script reported *"no acceptably-licensed result for X (CC0 only)"* whatever was searched. Nothing errored — the filter rejected the world, in a message that reads like an honest empty result.

### Confirmed against the live API

| | |
|---|---|
| old filter | `no acceptably-licensed result for 'ambient pad' (CC0 only)` |
| new filter | six CC0 sounds, with credits and download URLs |

`--query "camera shutter" --out …` now downloads a real 34 KB CC0 mp3 that ffprobes at 2.87s.

### The ordering trap

`"licenses/by-nc/4.0/"` **contains** `"licenses/by"`. Testing attribution before non-commercial would accept exactly the licences this script exists to refuse — and only under `--allow-attribution`, so the default path would still look correct. Non-commercial is rejected first, and the test says why.

### Also kept

Display-name matching stays alongside the URL matching. It costs nothing and means the filter can't silently empty itself again if the field changes back.

`tests/unit/test_freesound_licence.py` — real URL forms, both CC-BY versions, both CC-BY-NC versions, `sampling+`, display names, empty/None. **Three fail against the old filter.**