### PR TITLE
Add the editor as a second render backend, behind a flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ composer/props/
 composer/public/
 composer/out/
 composer/src/registry.ts
+
+# The editor render backend's artefacts. `scrollmark build` writes the project
+# document beside the storyboard and `scrollmark render` writes the mp4 next to
+# it; both are generated from tracked inputs, exactly like composer/props/.
+projects/*/cut.project.json
+projects/*/cut.mp4

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ skill is missing from it.
 
 The engine used to live in a separate private repo, `scrollmark/video-studio`, and no
 skill here could touch it. That split is gone: the engine is in this repo now, and the
-40 programs behind these skills land in one of three places.
+41 programs behind these skills land in one of three places.
 
 **1. Bundled inside a skill — nothing to install.** Six programs are pure standard
 library and take their input on the command line, so they ship in the skill folder that
@@ -88,7 +88,7 @@ programs are bundled in two skills each; each skill carries its own copy, becaus
 may never reach outside its own folder. `./scripts/verify-skills.sh` fails if those copies
 drift apart, or if a `SKILL.md` names a bundled script that is not there.
 
-**2. The `video-studio-engine` package — one `pip install`.** The other 34 programs
+**2. The `video-studio-engine` package — one `pip install`.** The other 35 programs
 either carry third-party dependencies or read a project's state (a props document, a
 composer directory, a styles tree), which makes them unfit to sit in a skill folder as a
 lone file. They are built from `src/video_studio/` in this repo and run as
@@ -131,20 +131,23 @@ Only the source is tracked. `composer/props/`, `composer/public/`, `composer/out
 whatever projects a given machine has built, so it is deliberately not committed.
 
 **4. There is a second route that needs no licence.**
-Scrollmark's own editor is MIT, has no seat threshold and no
-paid tier, and exposes the timeline over MCP — so an agent can cut, caption, grade and export
-without `composer/` being involved at all.
+Scrollmark's own editor is MIT, with no seat threshold and no paid tier.
+`video-studio render --backend editor` uses it: `scrollmark build` turns the storyboard
+straight into a Scrollmark project document — running the editor's real `Command` objects
+headlessly, so there is no second timeline implementation — and `scrollmark render` drives a
+headless Chrome over it, because that export pipeline is WebGPU + OffscreenCanvas +
+WebCodecs. It writes the same `plan.json` step 8 already reads, so the quality gate is
+unchanged.
 
-It is not a drop-in swap for `npx remotion render`, and the difference matters:
+Two things to know before choosing it:
 
-- **It does not read the props document.** `build_props` writes a Remotion composition; the
-  editor has its own project format. An agent builds the timeline through the editor's own
-  commands, working from the same storyboard rather than from the props file.
-- **It needs a running editor**, browser or desktop, where Remotion renders headless in Node.
-  It suits an interactive or agent-driven run better than an unattended one.
+- **`@scrollmark/cli` is not published to npm yet**, so it only runs from a checkout of
+  `scrollmark/editor` with `SCROLLMARK_CLI` pointed at it.
+- **`scrollmark render` needs a running Studio** and will not start one, where Remotion
+  renders headless in Node.
 
-Use whichever fits. Remotion stays the headless path; the editor is the one with no licence to
-buy and a person able to watch and intervene.
+Remotion stays the default until that changes. Neither the composer nor Remotion is going
+away in this change.
 
 ### What a skipped `pip install` costs you
 

--- a/references/stack.md
+++ b/references/stack.md
@@ -6,7 +6,8 @@ file the single place these names live outside of executable code.
 
 | Role | What we actually use | Notes |
 |---|---|---|
-| Composer / editor | Remotion 4.0.x | Original compositions, no vendored third-party code. `npx remotion studio` = "the editor"; `npx remotion render` = rendering. **Not in this repo** — the composer is a separate, externally licensed tree, so nothing here can render on its own. |
+| Composer / editor | Remotion 4.0.x | Original compositions, no vendored third-party code. `npx remotion studio` = "the editor"; `npx remotion render` = rendering. Lives in `composer/`, but externally licensed — a paid Company Licence above three people, and for hosted or automated rendering. |
+| Second render backend | `@scrollmark/cli` (`scrollmark build` + `scrollmark render`) | The Scrollmark editor, from `scrollmark/editor`. Reads the storyboard directly, builds a project document by running the editor's real `Command` objects, renders it in a headless Chrome (WebGPU + OffscreenCanvas + WebCodecs). Proven; **not published to npm**, so it runs only from a checkout via `SCROLLMARK_CLI`. Selected with `video-studio render --backend editor`; Remotion stays the default until it publishes. |
 | Quality gate | `qc_render.py` (bundled) + `video-studio qc_analyze` | Two sizes. The bundled one needs no install and checks a render against its plan; `qc_analyze` decodes frames and needs `[qc]`. Both = "the quality check". Superseded showwatcher, which was never published. |
 | Clip generation | MiniMax (Hailuo), Google Veo | `video-studio gen_minimax`, `video-studio gen_veo`. Quirks in `api-landmines.md`. |
 | Voice | Kokoro (local, free) | `video-studio tts_kokoro` = "the built-in voice". |

--- a/skills/video-production/SKILL.md
+++ b/skills/video-production/SKILL.md
@@ -11,7 +11,7 @@ description: Use when actually producing a short-form video end to end — runni
 
 Four scripts **ship with this skill**: `scripts/doctor.py` (step 0's status report), `scripts/normalize_audio.py` (step 7's loudness fix), `scripts/qc_render.py` (step 8's gate) and `scripts/poster.py` (step 9's thumbnail shortlist). All stdlib-only; all want `ffmpeg`/`ffprobe`.
 
-The rest of the sequence needs `pip install 'video-studio-engine @ https://github.com/scrollmark/social-skills/archive/refs/heads/master.tar.gz'` — `video-studio setup` (step 0's install plan), `build_props` (steps 5 and 7), `studio` (the preview editor) and `preflight` (the render gate) — plus a renderer. Two exist: the composer's `npx remotion render`, which is Node, headless, neither bundled nor pip-installable from here, and separately licensed; or Scrollmark's own editor over MCP, which needs no licence but does need a running editor and does not read the props document — an agent builds the timeline from the storyboard through the editor's own commands. Sourcing, voice and export belong to the step skills named below and carry their own install lines.
+The rest of the sequence needs `pip install 'video-studio-engine @ https://github.com/scrollmark/social-skills/archive/refs/heads/master.tar.gz'` — `video-studio setup` (step 0's install plan), `build_props` (steps 5 and 7), `studio` (the preview editor) and `preflight` (the render gate) — plus `render`, which drives one of two backends: the composer's `npx remotion render` (the default; Node, so neither bundled nor pip-installable from here, and separately licensed) or the Scrollmark editor's `scrollmark build` + `scrollmark render`, which needs no licence, is proven end to end, and is **not published to npm yet**. Sourcing, voice and export belong to the step skills named below and carry their own install lines.
 
 **Skip the pip install and this skill still is not standalone — it drives the whole engine.** There is no props document, no preview and no preflight, so the sequence has nothing to sequence. What survives is the shape: which decision must precede which, and where money and silence enter a run.
 
@@ -26,7 +26,7 @@ The rest of the sequence needs `pip install 'video-studio-engine @ https://githu
 | 4 | Build the storyboard from the format's grammar | `video-formats` |
 | 5 | `video-studio build_props --placeholders`, open the editor, re-read `props.json` | here |
 | 6 | Resolve sources — TTS first, then footage; then `video-studio verify_clips` | `audio-acquisition`, `media-acquisition` |
-| 7 | `video-studio build_props` (no flag) → `video-studio preflight` → render → `scripts/normalize_audio.py` | here |
+| 7 | `video-studio build_props` (no flag) → `video-studio preflight` → `video-studio render` → `scripts/normalize_audio.py` | here |
 | 8 | `scripts/qc_render.py` — the render against its plan — then **pull frames and look at them** | here |
 | 9 | `scripts/poster.py` — pick the thumbnail, and **open the candidate sheet** | here |
 
@@ -37,7 +37,7 @@ A brand kit (`brand-kit`) is applied at step 4. An export to a human editor (`ed
 - **`scripts/doctor.py` runs before sourcing is offered, at step 3.** Offering a source with no key wastes the user's turn *and* makes the cost estimate wrong.
 - **Placeholder preview is the default before any spend.** Step 5 is free and catches layout mistakes while they still are. `--placeholders` appears there and nowhere else in the run. The user's edits to `props.json` are authoritative — re-read it after they finish.
 - **Quote total cost before the first paid call and again after the last.**
-- **Rebuild props immediately before every render**, and never skip preflight.
+- **Rebuild props immediately before every render**, and never skip preflight. Both belong to the Remotion backend; the editor backend has no props file and no preflight, and its gate is `scrollmark build` refusing a storyboard whose sources do not resolve.
 - **Never declare a render done without viewing frames from it.** "It rendered" and "it is correct" are different claims; only one of them is in the log.
 
 ## The Two Contracts

--- a/skills/video-production/references/hard-rules.md
+++ b/skills/video-production/references/hard-rules.md
@@ -81,6 +81,37 @@ itself. Hand-placing files into `composer/public/clips/` does **not** work;
   override it; `Config.setVideoImageFormat("png")` does. PNG frames render a
   little slower and produce a smaller file here.
 
+## The two backends are not equivalent
+
+`video-studio render` draws through the composer (`remotion`, the default) or
+through the Scrollmark editor's CLI (`editor`). They read the same storyboard
+and write the same `plan.json`, so step 8 does not change — but they do not draw
+the same picture, and the differences are silent. Do not switch backends
+mid-project and compare the result to a memory of the last render.
+
+What the editor backend does not do today:
+
+- **No ducking.** `duck_music` writes its per-frame envelope into the composer's
+  props file. The editor path has no props file — it reads the storyboard, where
+  `music` is a bare path — so the bed plays at one flat level. A narrated video
+  scored on Remotion and re-rendered on the editor loses the ducking and nothing
+  says so.
+- **One effect of six.** `vignette` arrives; `grain`, `breath`, `lightLeak`,
+  `glow` and `clock` are reported unsupported and dropped.
+- **Captions are pages of words, not per-word emphasis.** `wordsPerPage`,
+  `uppercase`, `bottom`, `fontSize` and `color` are honoured; `highlight`,
+  `palette`, `bounce`, `wiggle`, `stroke`, `fontFamily` and `wordGap` are
+  warned about and ignored. Track-level caption style is taken from the FIRST
+  captioned scene, so a later scene that disagrees is a warning, not an override.
+- **No preflight, and no silent-narration check.** `scrollmark build` refuses a
+  storyboard whose sources do not resolve, which covers the placeholder trap,
+  but a scene with written narration and no WAV falls back to `plannedSeconds`
+  and renders mute exactly as `preflight` was written to stop.
+
+And in the other direction: **card `align` and `size` are drawn by neither.**
+Both accept the keys, both list them as known, and neither warns. Type that
+needs to sit anywhere but centred is a `rect`.
+
 ## Verification
 
 Never declare a render done without viewing frames from it. Pull 4–6 frames

--- a/skills/video-production/references/run-mechanics.md
+++ b/skills/video-production/references/run-mechanics.md
@@ -79,12 +79,60 @@ Quote the running total cost before the first paid call and again after the last
 
 ## 7 — Final props, gate, render, normalise
 
-    video-studio build_props   # no --placeholders; measured narration becomes the clock
-    video-studio preflight     # nonzero = do not render
-    npx remotion render       # in the composer directory
+Two backends draw the picture, and `remotion` is the default. Pick one with
+`--backend`, `$VIDEO_STUDIO_RENDER_BACKEND`, or `renderBackend` in the studio
+root's `.video-studio.json`, in that order.
+
+**Remotion — the composer, and the only one that installs today.**
+
+    video-studio build_props            # no --placeholders; measured narration becomes the clock
+    video-studio preflight              # nonzero = do not render
+    video-studio render --project <dir> # npx remotion render, with the composition id
     python3 scripts/normalize_audio.py --in <mp4>
 
 Rebuild props immediately before **each** render. See `hard-rules.md` for why.
+`render` will not do it for you and refuses when the props file is absent —
+rendering whatever was built last is the failure this whole step guards against.
+The composition id is the project directory name and it is positional; that is
+why the render goes through this command rather than a bare `npx remotion
+render`, which renders whichever composition the registry lists first.
+
+**Editor — proven, and not packaged.**
+
+    video-studio render --project <dir> --backend editor
+    python3 scripts/normalize_audio.py --in <mp4>
+
+That runs two commands from the Scrollmark editor's CLI:
+
+    scrollmark build  --storyboard <dir>/storyboard.json --project <dir> --out <dir>/cut.project.json
+    scrollmark render --project-file <dir>/cut.project.json --out <dir>/cut.mp4
+
+`build` reads the storyboard directly and writes a Scrollmark project document,
+running the editor's real `Command` objects headlessly — there is no second
+timeline implementation. There is **no props file and no preflight** on this
+path: the document is the check, and `build` refuses a storyboard whose sources
+do not resolve unless you pass `--placeholders`. It writes `plan.json` in the
+same place `build_props` does, so step 8 is unchanged either way.
+
+**`@scrollmark/cli` is not published to npm yet.** `video-studio render` looks
+for it in `$SCROLLMARK_CLI`, then `scrollmarkCli` in `.video-studio.json`, then
+`scrollmark` on PATH, then `npx --yes @scrollmark/cli` — and that last one 404s
+today. When it does, the command says so rather than leaving you with npm's
+registry error. From a checkout:
+
+    export SCROLLMARK_CLI='node /abs/path/to/editor/packages/control/src/index.mjs'
+
+Two further prerequisites this backend has and the composer does not: a running
+`scrollmark studio` for it to attach to (`--url`/`--token`, or `MCP_URL` and
+`MCP_TOKEN`), and a Chrome it can drive (`CHROME_PATH`). `--dry-run` prints the
+exact commands and runs nothing, which is the way to check the wiring on a
+machine that cannot yet render.
+
+**What the editor backend does not do yet.** `duck_music` writes its per-frame
+envelope into the composer's props file, which this path never produces, so a
+ducked music bed is Remotion-only — the editor plays the bed at one flat level.
+Of the six `effect` layers the composer draws, only `vignette` arrives. Card
+`align` and `size` are accepted and drawn by neither. See `hard-rules.md`.
 
 ## 8 — Quality gate
 

--- a/src/video_studio/cli.py
+++ b/src/video_studio/cli.py
@@ -74,6 +74,7 @@ COMMANDS: dict[str, str] = {
     "build_props": "video_studio.project.build_props",
     "daily_digest": "video_studio.project.daily_digest",
     "preflight": "video_studio.project.preflight",
+    "render": "video_studio.project.render",
     "setup": "video_studio.project.setup",
     "studio": "video_studio.project.studio",
     "styles": "video_studio.project.styles",
@@ -87,7 +88,7 @@ GROUPS = [
     ("vision", "segmentation, compositing, hand tracking"),
     ("qc", "checking a render against the plan it was built from"),
     ("export", "burnt-in captions, CapCut / Final Cut / OTIO handoff"),
-    ("project", "props, preflight, editor, looks, tutorials, digest"),
+    ("project", "props, preflight, render, editor, looks, tutorials, digest"),
 ]
 
 

--- a/src/video_studio/project/build_props.py
+++ b/src/video_studio/project/build_props.py
@@ -40,7 +40,14 @@ from video_studio.paths import studio_root
 #: Card keys the composer actually renders. Anything else is dropped silently.
 CARD_KEYS = {"heading", "subtext", "lines", "bg", "fg", "size", "tracking",
              "footnote", "align", "fontSize", "flat"}
-LAYER_KEYS = ("rect", "enter", "exit", "fit", "atMs", "untilMs", "pop", "ken", "fade")
+#: Layer keys copied through to the props verbatim. `muted`, `loop` and `label`
+#: were absent here while the composer's Layer type honoured all three, so a
+#: storyboard saying `"muted": false` (keep this clip's own audio) produced a
+#: silent clip and no error anywhere — the key was dropped one step before the
+#: thing that reads it. The editor render backend honours the same three, so
+#: the omission also made the two backends disagree about the same document.
+LAYER_KEYS = ("rect", "enter", "exit", "fit", "atMs", "untilMs", "pop", "ken",
+              "fade", "muted", "loop", "label")
 EFFECT_KEYS = ("effect", "intensity", "palette")
 
 PLACEHOLDER_COLORS = ["#3b5b7a", "#7a3b5b", "#3b7a5b", "#7a6a3b", "#5b3b7a"]
@@ -217,7 +224,11 @@ def build(storyboard_path: Path, project: Path, composer: Path, placeholders: bo
                 if not resolved.is_absolute():
                     resolved = project / value
             elif kind in ("prompt", "url", "find"):
-                for ext in (".mp4", ".webm", ".png", ".jpg", ".jpeg"):
+                # Same list, in the same order, as the editor backend's
+                # MEDIA_EXTENSIONS. A clip the two builds disagree about
+                # resolving is a clip that renders on one backend and
+                # placeholders on the other from one storyboard.
+                for ext in (".mp4", ".webm", ".mov", ".png", ".jpg", ".jpeg", ".webp"):
                     candidate = project / "clips" / f"{sid}-{layer['id']}{ext}"
                     if candidate.exists():
                         resolved = candidate
@@ -267,6 +278,11 @@ def build(storyboard_path: Path, project: Path, composer: Path, placeholders: bo
                     # (generated footage caps at 6s while narration-driven
                     # scenes often run longer). <Loop> needs the source length
                     # in frames — OffthreadVideo has no `loop` prop.
+                    # A default, not a decision: `loop` is in LAYER_KEYS now, so
+                    # a storyboard that says `"loop": false` overwrites this
+                    # below. That is also the editor backend's rule (absent
+                    # means loop, false disables), so one storyboard means the
+                    # same thing on both.
                     entry["loop"] = True
                     entry["srcDurationInFrames"] = max(1, round(media_seconds(dest) * fps))
             for key in LAYER_KEYS:

--- a/src/video_studio/project/render.py
+++ b/src/video_studio/project/render.py
@@ -1,0 +1,146 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Render a built project, through whichever backend is selected.
+
+Usage:
+  video-studio render --project projects/brand-origin-brick
+  video-studio render --project projects/brand-origin-brick --backend editor
+  video-studio render --project projects/brand-origin-brick --backend editor --dry-run
+  video-studio render --project <dir> --out /tmp/cut.mp4
+
+Two backends, and `remotion` is the default. `--backend`, then
+$VIDEO_STUDIO_RENDER_BACKEND, then `renderBackend` in the studio root's
+`.video-studio.json` — see `render_backend.py` for the whole order.
+
+  remotion  what step 7 has always run, now with one command instead of a
+            remembered `cd`. Props must already be built: this does NOT run
+            build_props or preflight, because the sequencing rule is that you
+            run them yourself, immediately before, and read what they say.
+            Refuses rather than renders when the props file is missing.
+
+  editor    `scrollmark build` + `scrollmark render` from `@scrollmark/cli`.
+            The build translates the storyboard into a Scrollmark project
+            document and writes `plan.json` beside it — the same plan.json
+            step 8's `qc_render.py` already reads — and the render drives a
+            headless Chrome over that document. No composer, no props file, no
+            preflight (the document is the check).
+
+            **`@scrollmark/cli` is not published to npm yet.** Point
+            $SCROLLMARK_CLI at a checkout of scrollmark/editor, or this command
+            fails and says exactly that. It is not the default for that reason,
+            and it also needs a running `scrollmark studio` to attach to
+            (--url/--token, or MCP_URL and MCP_TOKEN) and a Chrome (CHROME_PATH).
+
+`--dry-run` prints the commands and runs nothing, which is the honest way to
+see what a backend would do on a machine that cannot yet do it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from video_studio.paths import studio_root
+from video_studio.project import render_backend as rb
+
+
+def slugify(project: Path) -> str:
+    """Stable id for a project: its directory name.
+
+    Identical to build_props.slugify and studio.slugify, and for the same
+    reason — it names the props file, the registered composition, and the URL.
+    The composition id is what `remotion render` is given here; if these drift
+    the render either fails or, worse, renders somebody else's video.
+    """
+    return project.resolve().name
+
+
+def remotion_argv(composition: str, out: Path) -> list[str]:
+    """`npx remotion render <composition> <out>`, run in the composer.
+
+    The composition id is positional and load-bearing. Omitting it renders
+    whichever composition the generated registry lists first — alphabetical,
+    so the same wrong project every time. The entry point comes from
+    `composer/remotion.config.ts`, so it is not repeated here.
+    """
+    return ["npx", "remotion", "render", composition, str(out)]
+
+
+def plan(project: Path, backend: str, out: Path, composer: Path) -> list[dict]:
+    """The commands a run would issue, in order, with the cwd for each."""
+    if backend == "remotion":
+        return [{
+            "cwd": str(composer),
+            "argv": remotion_argv(slugify(project), out),
+        }]
+    prefix, source = rb.scrollmark_command()
+    project_file = project / rb.PROJECT_FILE
+    return [
+        {"cwd": None, "source": source,
+         "argv": rb.build_argv(prefix, project / "storyboard.json", project,
+                               project_file)},
+        {"cwd": None, "source": source,
+         "argv": rb.render_argv(prefix, project_file, out)},
+    ]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--project", required=True, help="project dir")
+    ap.add_argument("--backend", choices=rb.BACKENDS,
+                    help=f"default {rb.DEFAULT_BACKEND}; see {rb.ENV_BACKEND}")
+    ap.add_argument("--out", help="output file (default <project>/cut.mp4)")
+    ap.add_argument("--composer", default=str(studio_root() / "composer"),
+                    help="remotion backend only")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print the commands and run nothing")
+    args = ap.parse_args()
+
+    backend = rb.resolve_backend(args.backend)
+    project = Path(args.project)
+    if not (project / "storyboard.json").exists():
+        raise SystemExit(f"no storyboard.json in {project}")
+    out = Path(args.out).expanduser() if args.out else project / "cut.mp4"
+    composer = Path(args.composer)
+
+    if backend == "remotion":
+        props = composer / "props" / f"{slugify(project)}.json"
+        if not props.exists() and not args.dry_run:
+            raise SystemExit(
+                f"no props at {props} — run `video-studio build_props --storyboard "
+                f"{project}/storyboard.json --project {project}` and then "
+                f"`video-studio preflight --project {slugify(project)}` first."
+            )
+
+    steps = plan(project, backend, out.resolve(), composer)
+
+    if args.dry_run:
+        print(json.dumps({"backend": backend, "out": str(out),
+                          "steps": [{k: v for k, v in s.items() if v is not None}
+                                    for s in steps]}, indent=2))
+        return
+
+    for step in steps:
+        r = subprocess.run(step["argv"], cwd=step["cwd"])
+        if r.returncode != 0:
+            # An npx invocation that failed is overwhelmingly likely to have
+            # failed because the package does not exist yet, and npm reports
+            # that as a 404 against a registry URL — which reads as a network
+            # fault. Say what it actually is.
+            if step.get("source") == "npx":
+                print("\n" + rb.not_published_note(), file=sys.stderr)
+            raise SystemExit(
+                f"{backend} backend failed ({' '.join(step['argv'][:3])}, "
+                f"exit {r.returncode})"
+            )
+
+    print(json.dumps({"backend": backend, "out": str(out),
+                      "exists": out.exists()}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/video_studio/project/render_backend.py
+++ b/src/video_studio/project/render_backend.py
@@ -1,0 +1,168 @@
+"""Which program turns a storyboard into an mp4 — and how to find it.
+
+There are two, and they are not interchangeable yet:
+
+  remotion  the composer in `composer/`. `build_props` writes
+            `composer/props/<slug>.json`, `preflight` checks it, and
+            `npx remotion render` draws it. This is the DEFAULT and the only
+            backend that installs today.
+  editor    the Scrollmark editor's own CLI, `@scrollmark/cli`. It takes the
+            storyboard directly: `scrollmark build` translates it into a
+            Scrollmark project document (by running the editor's real Command
+            objects headlessly — there is no second timeline implementation)
+            and `scrollmark render` drives a headless Chrome over it, because
+            that export pipeline is WebGPU + OffscreenCanvas + WebCodecs.
+
+The editor path is proven — four videos were rendered from raw footage through
+it — and it is **not published to npm yet**. That is the whole reason remotion
+stays the default and this module goes out of its way to say so when the
+command cannot be found. A backend that silently is not there is worse than no
+backend, and `npx` failing on a missing package prints npm's error, not ours.
+
+Selection order, most specific first:
+
+  1. an explicit `--backend`
+  2. $VIDEO_STUDIO_RENDER_BACKEND
+  3. `renderBackend` in <studio root>/.video-studio.json
+  4. "remotion"
+
+Finding the editor CLI, same shape:
+
+  1. $SCROLLMARK_CLI — a whole command, shell-quoted, so a checkout works:
+     SCROLLMARK_CLI='node /path/to/editor/packages/cli/dist/index.js'
+  2. `scrollmarkCli` in <studio root>/.video-studio.json
+  3. `scrollmark` on PATH
+  4. `npx --yes @scrollmark/cli` — the eventual install, and today the one
+     that fails. `not_published_note()` is what to print when it does.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+from pathlib import Path
+
+from video_studio.paths import studio_root
+
+#: Every backend `--backend` accepts. The first is the default.
+BACKENDS = ("remotion", "editor")
+DEFAULT_BACKEND = BACKENDS[0]
+
+ENV_BACKEND = "VIDEO_STUDIO_RENDER_BACKEND"
+ENV_CLI = "SCROLLMARK_CLI"
+
+#: Read from the studio root, next to composer/ and projects/. Optional; a
+#: missing or unparseable file is simply no configuration, never an error —
+#: this is a lookup, and failing a render over a stray comma would be absurd.
+CONFIG_NAME = ".video-studio.json"
+
+#: The npm package the editor CLI will ship as. Not published at time of
+#: writing; see the module docstring.
+PACKAGE = "@scrollmark/cli"
+
+#: What `scrollmark build` writes and `scrollmark render` reads: the project
+#: document, the editor's actual source of truth. Named beside the storyboard
+#: rather than inside composer/ — the editor path never touches composer/.
+PROJECT_FILE = "cut.project.json"
+
+
+def read_config(root: Path | None = None) -> dict:
+    """`<studio root>/.video-studio.json`, or {} if it is absent or broken."""
+    path = (root or studio_root()) / CONFIG_NAME
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def resolve_backend(explicit: str | None = None,
+                    env: dict | None = None,
+                    config: dict | None = None) -> str:
+    """The backend to render with. See the module docstring for the order."""
+    env = os.environ if env is None else env
+    config = read_config() if config is None else config
+    for value in (explicit, env.get(ENV_BACKEND), config.get("renderBackend")):
+        if not value:
+            continue
+        name = str(value).strip().lower()
+        if name not in BACKENDS:
+            raise SystemExit(
+                f"unknown render backend {value!r} — expected one of "
+                f"{', '.join(BACKENDS)}"
+            )
+        return name
+    return DEFAULT_BACKEND
+
+
+def scrollmark_command(env: dict | None = None,
+                       config: dict | None = None) -> tuple[list[str], str]:
+    """The argv prefix that runs the editor CLI, and where it came from.
+
+    The source is returned rather than logged here because the caller is the
+    only thing that knows whether the run failed, and "npx" plus a failure is
+    the one combination that needs `not_published_note()`.
+    """
+    env = os.environ if env is None else env
+    override = (env.get(ENV_CLI) or "").strip()
+    if override:
+        return shlex.split(override), ENV_CLI
+    config = read_config() if config is None else config
+    configured = str(config.get("scrollmarkCli") or "").strip()
+    if configured:
+        return shlex.split(configured), CONFIG_NAME
+    if shutil.which("scrollmark"):
+        return ["scrollmark"], "PATH"
+    return ["npx", "--yes", PACKAGE], "npx"
+
+
+def not_published_note() -> str:
+    """Why `npx @scrollmark/cli` just failed, in the reader's terms.
+
+    npm's own error for a package that does not exist is a 404 against a
+    registry URL, which reads as a network problem. It is not one: the package
+    has never been published. Say that, and say the two ways to get the command
+    anyway, because both exist today.
+    """
+    return (
+        f"{PACKAGE} is NOT PUBLISHED to npm yet — that 404 is not a network\n"
+        "fault, there is nothing at that name to install. The editor render\n"
+        "backend works, but only from a checkout of scrollmark/editor:\n"
+        "\n"
+        "    git clone https://github.com/scrollmark/editor\n"
+        "    cd editor && bun install\n"
+        f"    export {ENV_CLI}='node /abs/path/to/editor/packages/control/src/index.mjs'\n"
+        "\n"
+        f"Or put it in <studio root>/{CONFIG_NAME} as\n"
+        '    {"scrollmarkCli": "node /abs/path/to/editor/packages/control/src/index.mjs"}\n'
+        "\n"
+        "There is no build step — the CLI is plain .mjs — but `scrollmark build`\n"
+        "imports @scrollmark/editor, which is what the install provides.\n"
+        "\n"
+        f"Until then the default backend is {DEFAULT_BACKEND!r}: drop --backend, or\n"
+        f"unset {ENV_BACKEND}."
+    )
+
+
+def build_argv(prefix: list[str], storyboard: Path, project: Path,
+               out: Path) -> list[str]:
+    """`scrollmark build` — storyboard in, project document + plan.json out.
+
+    It writes `plan.json` beside the project itself, which is what
+    `qc_render.py` reads. That is not a coincidence: the editor path was built
+    to land in the same place `build_props` does, so step 8 is unchanged
+    whichever backend produced the file.
+    """
+    return [*prefix, "build",
+            "--storyboard", str(storyboard),
+            "--project", str(project),
+            "--out", str(out)]
+
+
+def render_argv(prefix: list[str], project_file: Path, out: Path) -> list[str]:
+    """`scrollmark render` — project document in, mp4 out."""
+    return [*prefix, "render",
+            "--project-file", str(project_file),
+            "--out", str(out)]

--- a/tests/scenarios/video-production/which-render-backend.md
+++ b/tests/scenarios/video-production/which-render-backend.md
@@ -1,0 +1,23 @@
+---
+skill: video-production
+---
+
+## Prompt
+
+Can I just use the Scrollmark editor instead of Remotion for this? I heard it's a drop-in replacement.
+
+## Without skill (baseline)
+
+Claude either says yes — repeating the claim it was handed — or says it has never heard of it. Neither answer tells the user what will actually happen when they try, and the first one costs them an afternoon discovering that `npx @scrollmark/cli` 404s.
+
+## With skill (expected)
+
+Claude says there are two render backends, that `remotion` is the default, and that the editor backend is selected with `video-studio render --backend editor`. It says plainly that `@scrollmark/cli` is **not published to npm yet**, so today the editor path runs only from a checkout of `scrollmark/editor` with `SCROLLMARK_CLI` pointed at it — and that it also wants a running `scrollmark studio` and a Chrome. It does not call it a drop-in replacement: it names what is lost (music ducking, five of the six effects, per-word caption emphasis) and what is unchanged (`plan.json`, so step 8's gate works either way). It offers `--dry-run` to check the wiring without rendering.
+
+## Behavioral markers
+
+- [ ] Names both backends and says which is the default
+- [ ] States that the CLI is not published, rather than handing over an install command that fails
+- [ ] Names at least one thing the editor backend does not do yet
+- [ ] Does not repeat "drop-in replacement" unqualified
+- [ ] Does not propose deleting or bypassing `composer/`

--- a/tests/unit/test_render_backend.py
+++ b/tests/unit/test_render_backend.py
@@ -1,0 +1,225 @@
+"""Two render backends, one default, and a command that does not exist yet.
+
+Every assertion here is about a decision made BEFORE anything renders, which
+is deliberate: a render needs a browser or a Remotion install and neither
+belongs in a unit suite. What can go wrong without either is the part that has
+gone wrong before — a backend silently defaulting to the wrong one, and a
+missing program reported as somebody else's error.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from video_studio.project import render as render_mod
+from video_studio.project import render_backend as rb
+
+from conftest import run_cli
+
+
+# --- selection ---------------------------------------------------------
+
+def test_remotion_is_the_default():
+    """It stays the default until @scrollmark/cli is published. A default that
+    points at an unpublished package turns every fresh machine into a support
+    ticket."""
+    assert rb.resolve_backend(None, env={}, config={}) == "remotion"
+    assert rb.DEFAULT_BACKEND == "remotion"
+
+
+def test_env_var_selects_a_backend():
+    assert rb.resolve_backend(None, env={rb.ENV_BACKEND: "editor"}, config={}) == "editor"
+
+
+def test_config_selects_a_backend():
+    assert rb.resolve_backend(None, env={}, config={"renderBackend": "editor"}) == "editor"
+
+
+def test_the_flag_beats_the_env_which_beats_the_config():
+    assert rb.resolve_backend("remotion",
+                              env={rb.ENV_BACKEND: "editor"},
+                              config={"renderBackend": "editor"}) == "remotion"
+    assert rb.resolve_backend(None,
+                              env={rb.ENV_BACKEND: "remotion"},
+                              config={"renderBackend": "editor"}) == "remotion"
+
+
+def test_an_unknown_backend_names_the_ones_that_exist():
+    with pytest.raises(SystemExit) as e:
+        rb.resolve_backend("scrollmark", env={}, config={})
+    assert "remotion" in str(e.value) and "editor" in str(e.value)
+
+
+def test_a_broken_config_is_no_config_rather_than_a_crash(tmp_path: Path):
+    """This is a lookup on the way to a render. Failing it over a stray comma
+    would strand a user with a valid storyboard and a syntax error."""
+    (tmp_path / rb.CONFIG_NAME).write_text("{not json,}")
+    assert rb.read_config(tmp_path) == {}
+    (tmp_path / rb.CONFIG_NAME).write_text('["a list, not an object"]')
+    assert rb.read_config(tmp_path) == {}
+    assert rb.read_config(tmp_path / "nowhere") == {}
+
+
+# --- finding the CLI ---------------------------------------------------
+
+def test_the_env_var_is_a_whole_command_not_a_path():
+    """A checkout is run as `node <file>`, so the override has to be able to
+    carry an interpreter. shlex, not a bare path."""
+    argv, source = rb.scrollmark_command(
+        env={rb.ENV_CLI: "node /opt/editor/packages/control/src/index.mjs"}, config={})
+    assert argv == ["node", "/opt/editor/packages/control/src/index.mjs"]
+    assert source == rb.ENV_CLI
+
+
+def test_config_is_consulted_when_the_env_var_is_not_set():
+    argv, source = rb.scrollmark_command(
+        env={}, config={"scrollmarkCli": "node /opt/x/index.mjs"})
+    assert argv == ["node", "/opt/x/index.mjs"]
+    assert source == rb.CONFIG_NAME
+
+
+def test_it_falls_through_to_npx(monkeypatch):
+    """The eventual install. Today it 404s, which is what the note is for."""
+    monkeypatch.setattr(rb.shutil, "which", lambda _: None)
+    argv, source = rb.scrollmark_command(env={}, config={})
+    assert argv == ["npx", "--yes", "@scrollmark/cli"]
+    assert source == "npx"
+
+
+def test_the_failure_note_says_the_package_is_not_published(monkeypatch):
+    note = rb.not_published_note()
+    assert "NOT PUBLISHED" in note
+    assert "scrollmark/editor" in note, "the note must say where to get it instead"
+    assert rb.ENV_CLI in note, "the note must name the override that fixes it"
+
+
+# --- the command lines -------------------------------------------------
+
+def test_editor_build_and_render_command_lines():
+    prefix = ["scrollmark"]
+    project = Path("/w/projects/brick")
+    assert rb.build_argv(prefix, project / "storyboard.json", project,
+                         project / rb.PROJECT_FILE) == [
+        "scrollmark", "build",
+        "--storyboard", "/w/projects/brick/storyboard.json",
+        "--project", "/w/projects/brick",
+        "--out", "/w/projects/brick/cut.project.json",
+    ]
+    assert rb.render_argv(prefix, project / rb.PROJECT_FILE,
+                          project / "cut.mp4") == [
+        "scrollmark", "render",
+        "--project-file", "/w/projects/brick/cut.project.json",
+        "--out", "/w/projects/brick/cut.mp4",
+    ]
+
+
+def test_remotion_command_line_names_the_composition():
+    """Omitting it renders whichever composition the generated registry lists
+    first — alphabetical, so the same wrong project every time."""
+    argv = render_mod.remotion_argv("brick", Path("/w/projects/brick/cut.mp4"))
+    assert argv == ["npx", "remotion", "render", "brick",
+                    "/w/projects/brick/cut.mp4"]
+
+
+# --- end to end, without rendering -------------------------------------
+
+def test_dry_run_editor_prints_both_commands(project: Path, monkeypatch):
+    monkeypatch.setenv(rb.ENV_CLI, "node /opt/editor/packages/control/src/index.mjs")
+    r = run_cli("render", "--project", str(project), "--backend", "editor", "--dry-run")
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["backend"] == "editor"
+    assert [s["argv"][2] for s in out["steps"]] == ["build", "render"]
+    assert out["steps"][0]["argv"][:2] == ["node", "/opt/editor/packages/control/src/index.mjs"]
+    assert out["steps"][0]["argv"][-1].endswith("/cut.project.json")
+    assert out["steps"][1]["argv"][-1].endswith("/cut.mp4")
+    # The build reads the storyboard, not a props file: the editor path never
+    # touches composer/.
+    assert "composer" not in json.dumps(out)
+
+
+def test_dry_run_defaults_to_remotion(project: Path, monkeypatch):
+    monkeypatch.delenv(rb.ENV_BACKEND, raising=False)
+    r = run_cli("render", "--project", str(project), "--dry-run")
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["backend"] == "remotion"
+    assert out["steps"][0]["argv"][:3] == ["npx", "remotion", "render"]
+    assert out["steps"][0]["argv"][3] == project.name, "composition id is the slug"
+
+
+def test_env_var_switches_the_backend_end_to_end(project: Path, monkeypatch):
+    monkeypatch.setenv(rb.ENV_BACKEND, "editor")
+    monkeypatch.setenv(rb.ENV_CLI, "scrollmark")
+    r = run_cli("render", "--project", str(project), "--dry-run")
+    assert json.loads(r.stdout)["backend"] == "editor"
+
+
+def test_remotion_refuses_when_props_were_never_built(project: Path, tmp_path: Path,
+                                                      monkeypatch):
+    """`render` does not run build_props for you — the sequencing rule is that
+    you run it yourself, immediately before, and read what it says. Refusing is
+    the only other honest option; rendering last week's props is not."""
+    monkeypatch.delenv(rb.ENV_BACKEND, raising=False)
+    r = run_cli("render", "--project", str(project),
+                "--composer", str(tmp_path / "empty-composer"))
+    assert r.returncode == 1
+    assert "build_props" in r.stderr and "preflight" in r.stderr
+
+
+def test_a_project_without_a_storyboard_is_refused(tmp_path: Path):
+    r = run_cli("render", "--project", str(tmp_path), "--dry-run")
+    assert r.returncode == 1
+    assert "storyboard.json" in r.stderr
+
+
+# --- one storyboard, two backends, the same meaning ---------------------
+
+def test_layer_keys_the_editor_honours_survive_build_props(require_ffmpeg,
+                                                           project: Path,
+                                                           composer: Path):
+    """`muted`, `loop` and `label` are honoured by the editor backend AND by
+    the composer's Layer type — and `build_props` dropped all three on the way
+    between them, silently, because a key not in LAYER_KEYS is not copied and
+    nothing looks for it afterwards. A storyboard saying "keep this clip's own
+    audio" therefore meant two different videos depending on the backend.
+    """
+    sb_path = project / "storyboard.json"
+    sb = json.loads(sb_path.read_text())
+    sb["scenes"][0]["layers"][0].update({"muted": False, "loop": False,
+                                         "label": "HOST"})
+    sb_path.write_text(json.dumps(sb, indent=2))
+
+    r = run_cli("build_props", "--storyboard", str(sb_path),
+                "--project", str(project), "--composer", str(composer),
+                "--placeholders")
+    assert r.returncode == 0, r.stderr[-500:]
+    layer = json.loads(
+        (composer / "props" / f"{project.name}.json").read_text()
+    )["scenes"][0]["layers"][0]
+    assert layer["muted"] is False
+    assert layer["loop"] is False
+    assert layer["label"] == "HOST", "an explicit label must beat the derived one"
+
+
+def test_the_composer_reads_the_keys_build_props_now_passes(repo: Path):
+    """The other half of the contract, and the reason the pass-through is a
+    fix rather than a new feature: the composer already honoured these."""
+    video_tsx = repo / "composer" / "src" / "Video.tsx"
+    if not video_tsx.exists():
+        pytest.skip("composer not present")
+    source = video_tsx.read_text()
+    for key in ("muted", "loop", "label"):
+        assert f"layer.{key}" in source, f"the composer never reads layer.{key}"
+
+
+def test_both_builds_look_for_the_same_media_extensions(repo: Path):
+    """A clip one build resolves and the other placeholders, from one
+    storyboard, is the worst kind of backend difference: it looks like footage
+    went missing rather than like a list drifted."""
+    source = (repo / "src" / "video_studio" / "project" / "build_props.py").read_text()
+    for ext in (".mp4", ".webm", ".mov", ".png", ".jpg", ".jpeg", ".webp"):
+        assert f'"{ext}"' in source, f"{ext} is not probed under clips/"


### PR DESCRIPTION
Nothing in this repo referenced `scrollmark/editor` before this change — every
render went through `composer/` and `npx remotion render`. That is the whole
reason the "drop-in replacement for Remotion" claim was not true here: there was
no path to be a replacement for.

## What this adds

`video-studio render --project <dir>` — one command, two backends.

    # remotion (default) — unchanged behaviour, one command instead of a remembered cd
    video-studio build_props && video-studio preflight
    video-studio render --project projects/foo

    # editor
    video-studio render --project projects/foo --backend editor
    #   scrollmark build  --storyboard projects/foo/storyboard.json --project projects/foo \
    #                     --out projects/foo/cut.project.json
    #   scrollmark render --project-file projects/foo/cut.project.json --out projects/foo/cut.mp4

`scrollmark build` reads the storyboard directly and writes a Scrollmark project
document by running the editor's real `Command` objects headlessly, plus
`plan.json` in the same place `build_props` puts it — so step 8's `qc_render.py`
gate is unchanged whichever backend produced the file. `scrollmark render`
drives a headless Chrome, because that export pipeline is WebGPU +
OffscreenCanvas + WebCodecs.

Backend selection: `--backend`, then `$VIDEO_STUDIO_RENDER_BACKEND`, then
`renderBackend` in `<studio root>/.video-studio.json`, then `remotion`.

## It is not published, and the code says so

`@scrollmark/cli` is not on npm yet. The command is looked up via
`$SCROLLMARK_CLI`, then `scrollmarkCli` in `.video-studio.json`, then
`scrollmark` on PATH, then `npx --yes @scrollmark/cli`. When that last one 404s,
`render` prints what actually happened — the package has never been published —
and the checkout route, instead of leaving npm's registry error as the last word.
`--dry-run` prints the exact commands and runs nothing.

**Remotion stays the default and `composer/` is untouched.** Removing it is
issue #110's job, not this one.

## Drift the second backend exposed

`build_props` dropped `muted`, `loop` and `label`: three keys the composer's own
`Layer` type honours, and which the editor honours too. A storyboard saying
`"muted": false` therefore produced a silent clip through Remotion and an audible
one through the editor, from one document, with no error on either path. Fixed,
with a test asserting both halves of the contract. Its `clips/` extension probe
now matches the editor's `MEDIA_EXTENSIONS` as well (`.mov`, `.webp`).

## Honest about the gaps

`references/hard-rules.md` gains a section saying the two backends are not
equivalent, because they are not:

- **No music ducking on the editor path.** `duck_music` writes its per-frame
  envelope into the composer's props file; the editor path has no props file and
  types `music` as a bare path, so the bed plays flat.
- **One effect of six.** `vignette` arrives; `grain`, `breath`, `lightLeak`,
  `glow`, `clock` are dropped as unsupported.
- **Captions are pages of words.** `highlight`, `palette`, `bounce`, `wiggle`,
  `stroke`, `fontFamily`, `wordGap` are warned about and ignored.
- **No preflight equivalent, and no silent-narration check.** `scrollmark build`
  refuses unresolved sources (covering the placeholder trap), but a scene with
  written narration and no WAV renders mute.
- Card `align` and `size` are accepted by both and drawn by neither.
- The editor backend also needs a running `scrollmark studio` to attach to and a
  Chrome — `scrollmark render` will not start a Studio itself.

## Tests

`tests/unit/test_render_backend.py` — 20 tests covering selection order, CLI
lookup order, both command lines, the two `--dry-run` paths, the refusals, and
the `muted`/`loop`/`label` pass-through against a real `build_props` run. Plus a
behavioural scenario for the question that started this ("is it a drop-in
replacement?"). Full suite: 107 passed.
