### PR TITLE
Add three looks and a cut-to-music recap format

### DIFF
--- a/MIGRATION-NOTES.md
+++ b/MIGRATION-NOTES.md
@@ -228,7 +228,7 @@ Three reasons, in order of how much they hurt.
 
 | Skill | What it is | Came from |
 |---|---|---|
-| `video-formats` | The ten scene grammars and the contract for writing an eleventh | `formats/*.md` |
+| `video-formats` | The eleven scene grammars and the contract for writing a twelfth | `formats/*.md` |
 | `agent-interview` | The choice-question protocol: ask decisions, not essays | the interview rounds threaded through the pipeline |
 | `brand-kit` | Deciding and recording a brand: palette, type, card roles, logo, voice, CTA | the Title system prose + `styles/*.md` |
 | `studio-setup` | What to install, what each key unlocks, and how to triage a dead pipeline | `third-party.md` + the doctor/setup prose |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ execution ships inside the skill; the rest is one `pip install` away.
 
 | Skill | Use when | Standalone? |
 |-------|----------|-------------|
-| `video-formats` | Planning, structuring, or critiquing a short-form video — choosing a format, laying out its scenes, or defining a new format. Covers ten scene grammars from talking-head to hand-drawn motion graphics. | Mostly — 8 of the 10 formats are pure structure. **Boil** and **PointerPopups** need the engine's generator and hand tracker (see below). |
+| `video-formats` | Planning, structuring, or critiquing a short-form video — choosing a format, laying out its scenes, or defining a new format. Covers eleven scene grammars from talking-head to hand-drawn motion graphics. | Mostly — 9 of the 11 formats are pure structure. **Boil** and **PointerPopups** need the engine's generator and hand tracker (see below). |
 | `brand-kit` | A user wants their videos to stay visually consistent — saving caption styling, card colours and geometry, title treatment, logos, fonts, voice and CTA copy once instead of redeciding them per video. | Deciding and recording a brand, yes. Applying a preset is `video-studio styles`, from the pip package. |
 | `media-acquisition` | Deciding where a shot's footage or stills should come from — public-domain archive, free stock, a paid generator, or a URL the user supplied — and when checking that what came back is actually usable before anything is built on it. | Partly. Ships `scripts/prekey.py`. The ten searching, generating and checking programs need `pip install 'video-studio-engine[sourcing,generate] @ https://github.com/scrollmark/social-skills/archive/refs/heads/master.tar.gz'`; without it the ladder is a briefing, not a workflow. |
 | `audio-acquisition` | A video needs narration, a music bed or sound effects — choosing a voice, deciding which music source is safe to publish with, timing a cut to a track, or fixing a render that came out quiet. | Partly. Ships `scripts/measure.py` and `scripts/normalize_audio.py`, so measuring and loudness work out of the box. Voice, music and licence-filtered effects need `pip install 'video-studio-engine[audio] @ https://github.com/scrollmark/social-skills/archive/refs/heads/master.tar.gz'`. |
@@ -153,7 +153,7 @@ look complete. **A skill whose work needs the package is not self-contained for 
 who skips it.**
 
 - The **seven social-media skills** are entirely unaffected. So is `agent-interview`.
-- `video-formats` still works for eight of its ten formats. Composition, Interview, Slots
+- `video-formats` still works for nine of its eleven formats. Composition, Interview, Slots
   and Grammar are structural; you can follow them with any editor.
 - **`boil` is roughly 40% inoperative** without `[generate]`. Its mark vocabulary, shape
   files and palette workflow are `gen_boil`; without it, the interview questions have no

--- a/skills/video-formats/SKILL.md
+++ b/skills/video-formats/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: video-formats
-description: Use when planning, structuring, or critiquing a short-form video — choosing a format, laying out its scenes, or defining a new format. Covers ten scene grammars from talking-head to hand-drawn motion graphics.
+description: Use when planning, structuring, or critiquing a short-form video — choosing a format, laying out its scenes, or defining a new format. Covers eleven scene grammars from talking-head to hand-drawn motion graphics.
 ---
 
 # Video Formats
 
-This skill is a router. The ten format grammars live in `references/formats/` — this skill tells you what a format is, which one to reach for, and how to write an eleventh.
+This skill is a router. The eleven format grammars live in `references/formats/` — this skill tells you what a format is, which one to reach for, and how to write an eleventh.
 
 ## What a Format Is
 
@@ -29,6 +29,7 @@ One distinguishing question each. Ask them in roughly this order and stop at the
 | **TitledVideo** | Do you have a finished clip that just needs titles to be postable? |
 | **TalkingHead** | Is one person talking to camera the whole way through? |
 | **PipStory** | Is there a host, but the story keeps citing things worth showing? |
+| **DailyRecap** | Is it a pile of clips from one day or trip, with no script and no arc? |
 | **Cinematic** | Is the point a feeling rather than an argument — cut to music, few words? |
 | **Explainer** | Is there a concept to explain, and no one on camera to explain it? |
 | **ProductLaunch** | Is there a product, three capabilities, and a name to land? |
@@ -36,16 +37,17 @@ One distinguishing question each. Ask them in roughly this order and stop at the
 | **TimelineExplainer** | Is the *list* the point — numbered beats the viewer counts along with? |
 | **Boil** | Can the subject not be photographed at all? |
 
-Two pairs are easy to confuse:
+Three pairs are easy to confuse:
 
 - **BrandOrigin vs. TimelineExplainer** — BrandOrigin is one transformation carried by a recurring motif, ~30s. TimelineExplainer is a countable sequence, 6-10 numbered beats, and runs longer. If the viewer would be counting, it's the timeline.
+- **DailyRecap vs. Cinematic** — both cut to music and neither needs a script. Cinematic builds to a peak and holds the longest shot after it; DailyRecap is an even run where any two beats could swap. If reordering the middle would break it, it's Cinematic.
 - **TalkingHead vs. PipStory** — the same host, but PipStory shrinks them into a corner whenever the narration names something concrete. If 25-50% of the beats cite a number, an object, or a place, it's PipStory.
 
 **Boil is the outlier.** It's the only format with no photography, no footage, and nothing licensed on screen. Reach for it when the subject is unreleased, abstract, or a service — or when stock would look borrowed.
 
 ## Reading a Format File
 
-Load `references/formats/{name}.md` from this skill's own directory. File names are kebab-case: `pip-story.md`, `brand-origin.md`, `pointer-popups.md`, `timeline-explainer.md`, `product-launch.md`, `talking-head.md`, `titled-video.md`, plus `boil.md`, `cinematic.md`, `explainer.md`.
+Load `references/formats/{name}.md` from this skill's own directory. File names are the kebab-case of the names in the table above: `pip-story.md`, `daily-recap.md`, `boil.md`, and so on.
 
 Every format file carries frontmatter above its prose — the same facts the document states, wherever it states them: `aspect`, `alsoWorks`, `scenes`, `sceneSeconds`, `captions`, `narration`, `music`, and `needs` (a comma-separated list, since a format can need two programs). A key a format does not state is absent rather than guessed, and the prose stays authoritative. `video-studio formats --list --aspect 9:16` narrows to the ones that fit; `video-studio formats --show explainer --style bold-neon` composes a format (the shape) with a style preset (the look) into a template, and reports an unknown or repeated key, a line that lost its colon, an aspect that is not a real frame, a `needs:` naming a program that does not exist, and anything the style preset itself would be reported for. Resolving a look into a storyboard is still `video-studio styles --apply`.
 
@@ -53,8 +55,7 @@ The files share a vocabulary that comes from the storyboard structure they compi
 
 - **`card`** — real typography rendered at composition time. Every exact word, number, name, year, and URL is a card. Never ask a generator for text; it invents letterforms.
 - **`ken`** — a slow Ken Burns drift over a still, so it reads as footage rather than a frozen frame. Alternate zoom direction and pan between consecutive scenes or the cuts all move identically.
-- **`rect`** — a layer's position as `[x, y, w, h]` in fractions of the frame. A corner inset is roughly `[0.58, 0.58, 0.42, 0.42]`.
-- **`atMs` / `untilMs` / `pop`** — a layer's visibility window inside its scene, with an optional pop-in.
+- **`rect`** — a layer's position as `[x, y, w, h]` in fractions of the frame; a corner inset is roughly `[0.58, 0.58, 0.42, 0.42]`. **`atMs` / `untilMs` / `pop`** — its visibility window inside the scene, with an optional pop-in.
 - **`broll` / `host` / `insert` / `main`** — conventional layer ids, not special types. The names carry intent between the format and whoever builds it.
 - **`plannedSeconds`** — an estimate. Measured narration length is the real clock.
 

--- a/skills/video-formats/references/formats/daily-recap.md
+++ b/skills/video-formats/references/formats/daily-recap.md
@@ -1,0 +1,78 @@
+---
+name: daily-recap
+title: DailyRecap
+description: Photo-dump recap cut to the track
+aspect: 9:16
+scenes: 8-14
+sceneSeconds: 1.5-3
+captions: optional
+narration: none
+music: required
+needs: measure
+---
+
+# DailyRecap — photo-dump recap cut to the track
+
+A day, a trip or a week as a fast run of short clips and stills, cut on the
+music rather than on a script. No narration: the track carries the pace and
+the pictures carry the content. The one piece of typography is a stamp — a
+date, a place, a week number — that repeats in the same corner so the run
+reads as one set rather than as a shuffle.
+
+The difference from Cinematic is arc. Cinematic builds to a peak and holds the
+longest shot after it; this format has no peak. It is an even run of beats
+where any two could swap without breaking anything, which is exactly why it
+suits footage nobody shot to a plan.
+
+## Composition
+Vertical 1080x1920 @30fps. One full-frame layer per scene, hard cuts only —
+no cross-fades, they blur the beat the cut is landing on. Eight to fourteen
+scenes at 1.5-3s each; under 1.5s a viewer registers movement rather than
+subject. A score is REQUIRED. Stills need a `ken` drift or they read as a
+stall in a run of moving pictures. Captions off unless there is a spoken clip
+in the run, in which case caption only that clip.
+
+## Interview
+Round A — header "Audio": ASK THIS FIRST. Score: supply a file or generate
+one? If generating, name the backend and its rights terms BEFORE they choose —
+every cut in this format is placed against the track, so a rights problem
+found later is a re-cut, not a re-tag. There is no voice track to ask about.
+Round 1 — header "Footage": The clips and stills, in the order they happened
+or in the order they look best? (Ask which; people assume chronological and
+often don't want it.)
+Round 2 — header "Stamp": What repeats in the corner — a date, a place, a day
+number, nothing?
+Round L — header "Look": Which caption/card preset — `video-studio styles --list`?
+Any look they describe should be saved with `video-studio styles --save`.
+Freeform: anything that must open or close the run.
+
+## Slots
+`clip-N` per scene (8-14), `music` file, optional `stamp` card repeated in
+every scene, optional `endcard`.
+
+## Grammar
+- **Open** on the strongest single frame, not on the earliest one.
+- **Run** the rest at 1.5-3s. Vary the length within that band; a run of
+  identical durations reads as a slideshow whatever the track is doing.
+- **Stamp** sits in the same corner in every scene, same size, same colour.
+  It is the only thing holding the set together.
+- **Close** on a held frame, 3-4s, longer than anything before it. A run that
+  simply stops reads as a video that was cut off.
+- No text over a clip that is under 2s. It cannot be read, and it competes
+  with the picture it is covering.
+
+## Render notes
+
+Measure the track, do not guess it: `measure --music` (bundled in
+`audio-acquisition`) reports the seconds where the energy actually changes.
+Put those seconds in the storyboard's `musicTransitions` and the editor will
+pull each cut onto the nearest one — see `snapToMusic`, which moves a cut at
+most a quarter of its own scene and never behind the cut before it.
+
+That snapping is section-level, not beat-level: the detection buckets to whole
+seconds, so it lands cuts on drops, lifts and breakdowns rather than on a
+snare. For 1.5-3s scenes it is the difference between a run that feels edited
+and one that feels shuffled, but do not promise beat sync on top of it.
+
+Order the run before timing it. Reordering after the cuts are placed moves
+every boundary and the snapping has to be redone.

--- a/src/video_studio/styles/analog-editorial.md
+++ b/src/video_studio/styles/analog-editorial.md
@@ -1,0 +1,69 @@
+---
+name: analog-editorial
+description: Warm film stock under fashion-magazine serifs
+---
+
+# analog-editorial
+
+Cream-on-ink serif type over footage that is allowed to look photographed
+rather than rendered. The reference is a magazine spread printed on uncoated
+paper: generous letter-spacing on the cards, a caption face with real
+contrast, and one warm accent that reads as a highlighter rather than a
+notification badge.
+
+Reach for it on travel, food, interiors, product-in-hand — anything where the
+footage already has grain, warmth or shallow depth and the type's job is to
+frame it. It is the wrong preset for a chart or a stat: a serif at this size
+loses to a number that wants to be read fast.
+
+Pair it with a `grain` effect layer at low intensity. Without one the type
+looks like it was printed on the wrong stock — the whole look depends on the
+picture having some texture of its own.
+
+```json
+{
+  "captions": {
+    "color": "#f4ece1",
+    "highlight": "#e0a34a",
+    "fontFamily": "Fraunces, Georgia, serif",
+    "stroke": "#2b2118",
+    "strokeWidth": 4,
+    "fontSize": 46,
+    "uppercase": false,
+    "bounce": 1,
+    "wiggle": 0,
+    "wordsPerPage": 4,
+    "wordGap": 0.14,
+    "bottom": 0.14
+  },
+  "cards": {
+    "title": {
+      "bg": "#f4ece1",
+      "fg": "#2b2118",
+      "fontSize": 78,
+      "align": "left",
+      "tracking": 0.08,
+      "rect": [0.08, 0.34, 0.84, 0.24],
+      "fade": { "in": 0.8, "out": 0.5 }
+    },
+    "label": {
+      "bg": "#2b2118",
+      "fg": "#f4ece1",
+      "fontSize": 24,
+      "align": "left",
+      "tracking": 0.16,
+      "rect": [0.08, 0.8, 0.5, 0.06],
+      "fade": { "in": 0.4, "out": 0.3 }
+    },
+    "stat": {
+      "bg": "#e0a34a",
+      "fg": "#2b2118",
+      "fontSize": 40,
+      "align": "left",
+      "tracking": 0.04,
+      "rect": [0.08, 0.72, 0.56, 0.12],
+      "fade": { "in": 0.4, "out": 0.3 }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/magazine-cover.md
+++ b/src/video_studio/styles/magazine-cover.md
@@ -1,0 +1,69 @@
+---
+name: magazine-cover
+description: Cover-line serif, black and white with one red
+---
+
+# magazine-cover
+
+A masthead-sized serif over the shot, small tracked cover-lines beneath it,
+and a single red for the one thing that matters. Everything else is black,
+white, or the footage.
+
+Reach for it on a launch, a lookbook, an announcement — a piece with one
+subject and one claim, where the restraint is the message. It is a poor fit
+for anything with several equal points to make: the whole composition assumes
+one line is larger than the rest, and three cover-lines of the same weight
+just look unfinished.
+
+Captions are uppercase, small and widely spaced, so they read as a strapline
+rather than as subtitles. If the piece is actually narrated end to end, use a
+preset whose captions are built to be read continuously — at this size and
+spacing, four pages of them is work.
+
+```json
+{
+  "captions": {
+    "color": "#ffffff",
+    "highlight": "#e11d48",
+    "fontFamily": "Fraunces, Didot, Georgia, serif",
+    "stroke": "#111111",
+    "strokeWidth": 3,
+    "fontSize": 40,
+    "uppercase": true,
+    "bounce": 1,
+    "wiggle": 0,
+    "wordsPerPage": 3,
+    "wordGap": 0.3,
+    "bottom": 0.1
+  },
+  "cards": {
+    "title": {
+      "bg": "#ffffff",
+      "fg": "#111111",
+      "fontSize": 120,
+      "align": "center",
+      "tracking": -0.04,
+      "rect": [0.06, 0.3, 0.88, 0.3],
+      "fade": { "in": 0.6, "out": 0.4 }
+    },
+    "label": {
+      "bg": "#111111",
+      "fg": "#ffffff",
+      "fontSize": 22,
+      "align": "center",
+      "tracking": 0.24,
+      "rect": [0.2, 0.64, 0.6, 0.05],
+      "fade": { "in": 0.4, "out": 0.3 }
+    },
+    "stat": {
+      "bg": "#e11d48",
+      "fg": "#ffffff",
+      "fontSize": 44,
+      "align": "center",
+      "tracking": 0.02,
+      "rect": [0.24, 0.72, 0.52, 0.1],
+      "fade": { "in": 0.4, "out": 0.3 }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/vhs-90s.md
+++ b/src/video_studio/styles/vhs-90s.md
@@ -1,0 +1,60 @@
+---
+name: vhs-90s
+description: Tape-deck monospace, cyan and magenta on near-black
+---
+
+# vhs-90s
+
+Uppercase monospace captions with an outline thick enough to survive any
+frame, a cyan label bar, and a magenta title. The look borrows from a camera's
+own on-screen display rather than from a design system, which is why the type
+is a typewriter mono and the tracking is wide: it is meant to read as burned in by the
+device, not laid on afterwards.
+
+Reach for it on skate, gig, night-out and behind-the-scenes footage — anything
+handheld, underexposed or a bit rough. The roughness is the point. On clean,
+well-lit product footage it reads as a costume.
+
+The 8px stroke is doing real work here and should not be trimmed: the palette
+is high-saturation, and saturated type on saturated footage is unreadable
+without an outline. `wiggle` is on, low, because a tape image never sat
+perfectly still.
+
+```json
+{
+  "captions": {
+    "color": "#f8fafc",
+    "highlight": "#22d3ee",
+    "fontFamily": "Courier New, ui-monospace, Menlo, monospace",
+    "stroke": "#0b0b0f",
+    "strokeWidth": 8,
+    "fontSize": 62,
+    "uppercase": true,
+    "bounce": 1.08,
+    "wiggle": 1,
+    "wordsPerPage": 3,
+    "wordGap": 0.22,
+    "bottom": 0.16
+  },
+  "cards": {
+    "title": {
+      "bg": "#0b0b0f",
+      "fg": "#ff3ea5",
+      "fontSize": 84,
+      "align": "left",
+      "tracking": 0.18,
+      "rect": [0.06, 0.38, 0.88, 0.22],
+      "fade": { "in": 0.3, "out": 0.2 }
+    },
+    "label": {
+      "bg": "#22d3ee",
+      "fg": "#0b0b0f",
+      "fontSize": 26,
+      "align": "left",
+      "tracking": 0.1,
+      "rect": [0.06, 0.06, 0.44, 0.06],
+      "fade": { "in": 0.2, "out": 0.2 }
+    }
+  }
+}
+```

--- a/tests/unit/test_formats.py
+++ b/tests/unit/test_formats.py
@@ -61,6 +61,7 @@ def test_every_named_program_exists(shipped):
         "boil": ["gen_boil"],
         "brand-origin": [],
         "cinematic": ["measure"],
+        "daily-recap": ["measure"],
         "explainer": [],
         "pip-story": [],
         "pointer-popups": ["track_pointing", "measure"],
@@ -182,9 +183,9 @@ def test_the_cli_runs_it(tmp_path):
     assert r.returncode == 0, r.stderr
     rows = json.loads(r.stdout)
     names = {row["name"] for row in rows}
-    # Eight of the ten: five are 9:16 outright and three carry it as alsoWorks.
-    # The count is asserted, not just membership — a filter that returned
-    # everything would pass a membership check.
-    assert names == {"boil", "brand-origin", "cinematic", "explainer", "pip-story",
-                     "product-launch", "talking-head", "timeline-explainer"}
+    # Nine of the eleven: six are 9:16 outright and three carry it as
+    # alsoWorks. The set is asserted, not just membership — a filter that
+    # returned everything would pass a membership check.
+    assert names == {"boil", "brand-origin", "cinematic", "daily-recap", "explainer",
+                     "pip-story", "product-launch", "talking-head", "timeline-explainer"}
     assert "pointer-popups" not in names  # source frame, fits nothing named

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -86,8 +86,8 @@ def test_all_extra_is_absent_and_standard_exists():
     assert "all" not in d, "[all] was removed because it never meant all; it is back"
 
 
-@pytest.mark.parametrize("subdir,minimum", [("styles", 14), ("tutorials", 3), ("qc/data", 2),
-                                            ("formats", 10)])
+@pytest.mark.parametrize("subdir,minimum", [("styles", 17), ("tutorials", 3), ("qc/data", 2),
+                                            ("formats", 11)])
 def test_wheel_ships_package_data(tmp_path, subdir, minimum):
     """Data files ride along only because the build sweeps the package tree.
 


### PR DESCRIPTION
Replaces #41, which GitHub closed when its base branch was deleted on merge of #40. Same content, rebased onto master.

Four templates modelled on categories Templify publishes — vintage film, VHS, editorial covers, and the day-recap photo dump. Their templates live inside their app and have no published specification, so these are our own presets in those idioms rather than copies of theirs: our palettes, our type, our names, our prose.

## Three looks

| Preset | For | Notes |
|---|---|---|
| `analog-editorial` | travel, food, interiors, product-in-hand | Cream-on-ink serif. Wants a `grain` layer under it — the look depends on the picture having texture of its own. |
| `vhs-90s` | skate, gigs, nights out, behind the scenes | Uppercase typewriter mono, 8px outline, cyan label, magenta title. On clean product footage it reads as a costume. |
| `magazine-cover` | a launch, a lookbook, one claim | Masthead serif, black and white and one red. A poor fit for three equal points. |

Each says what it is wrong for as plainly as what it is right for — a preset that only recommends itself is how you end up with a serious subject styled like an advert.

## One format

`DailyRecap` is the shape the set was missing. Cinematic builds to a peak and holds the longest shot after it; DailyRecap is an even run of 8–14 beats at 1.5–3s where any two could swap — which is what footage nobody shot to a plan actually is. A stamp in the same corner every scene is the only thing holding the set together.

It is also the first format built around `musicTransitions`: measure the track, put the seconds in the storyboard, and the editor pulls each cut onto the nearest one (scrollmark/editor#174). The Render notes are explicit that this is section-level, not beat-level — it lands cuts on drops and lifts, not on a snare, and calling it beat sync would promise something else.

## Counts

Eleven formats and seventeen presets. `SKILL.md`'s router table, the confusable pairs, the README's two counts and MIGRATION-NOTES all move with it; the wheel-data test's minimums go to 17 and 11. `test_every_named_program_exists` records `daily-recap: ["measure"]` — that mapping is asserted exactly, so a deleted `needs:` line fails.

scrollmark/scrollmark.github.io#27 pairs all four into the gallery.