### PR TITLE
Add five looks built on the faces a card can now set

### DIFF
--- a/skills/brand-kit/SKILL.md
+++ b/skills/brand-kit/SKILL.md
@@ -20,9 +20,11 @@ Without that install there is no `--list`, `--show`, `--apply` or `--save`, and 
     video-studio styles --apply tourism --storyboard <project>/storyboard.json
     video-studio styles --save theirs --from <project>/storyboard.json
 
-A preset is one markdown file: frontmatter (`name`, `description`), prose saying when to reach for it, and a single fenced JSON block holding the values. The JSON covers exactly two things — `captions` (colour, `stroke`, `strokeWidth`, `fontSize`, `wordGap`, `wordsPerPage`, `uppercase`, `bottom`, `palette`) and `cards`, a named role such as `label`, `stat`, `title` or `cta` mapped to `bg`, `fg`, `tracking`, `align` and a `rect`. Unknown keys are reported, not silently dropped, because a misspelled key renders as nothing and reads like a styling choice.
+A preset is one markdown file: frontmatter (`name`, `description`), prose saying when to reach for it, and a single fenced JSON block holding the values. The JSON covers exactly two things — `captions` (colour, `stroke`, `strokeWidth`, `fontSize`, `wordGap`, `wordsPerPage`, `uppercase`, `bottom`, `palette`) and `cards`, a named role such as `label`, `stat`, `title` or `cta` mapped to `bg`, `fg`, `fontFamily`, `italic`, `weight`, `fontSize`, `tracking`, `align` and a `rect`. Unknown keys are reported, not silently dropped, because a misspelled key renders as nothing and reads like a styling choice.
 
 Resolution order, first match winning: `<project>/styles/` → `$VIDEO_STUDIO_STYLES` → the user's own `~/.config/video-studio/styles/` → the presets shipped with the toolchain. The user-level directory is the load-bearing one; a preset kept in a checkout dies with the checkout.
+
+**A card can name its face.** `fontFamily` takes any family the editor loads — every Google font plus the system stacks — with `italic` and `weight` beside it. `bg: "transparent"` puts the type straight on the footage with no panel. This is most of what separates two looks: before it existed every card in every video was Inter, whatever the preset said. Name a real fallback (`"Playfair Display, Didot, Georgia, serif"`), and give an unusual display face an explicit `fontSize` — the automatic sizing is calibrated to Inter's width.
 
 **Author cards against a role, not a colour.** Write `{"card": {"style": "label", "heading": "TOKYO"}}` and let `--apply` fill in bg, fg, tracking and rect. Anything the scene sets explicitly wins, so a one-off override never means abandoning the brand.
 

--- a/src/video_studio/project/styles.py
+++ b/src/video_studio/project/styles.py
@@ -54,7 +54,11 @@ CAPTION_KEYS = {"color", "highlight", "fontFamily", "palette", "stroke",
                 "strokeWidth", "fontSize", "bounce", "wiggle", "uppercase",
                 "bottom", "wordsPerPage", "wordGap"}
 #: Card keys the composer renders, plus the placement keys that sit beside it.
-CARD_KEYS = {"bg", "fg", "tracking", "fontSize", "align", "size"}
+CARD_KEYS = {"bg", "fg", "tracking", "fontSize", "align", "size",
+             # The face, as of scrollmark/editor#175. Before it, a card could
+             # pick its colours and its size and then drew Inter whatever it
+             # asked for -- which is most of what a design template is.
+             "fontFamily", "italic", "weight", "flat"}
 PLACEMENT_KEYS = {"rect", "pop", "fade", "atMs", "untilMs", "enter", "exit"}
 
 

--- a/src/video_studio/styles/lookbook-sage.md
+++ b/src/video_studio/styles/lookbook-sage.md
@@ -1,0 +1,96 @@
+---
+name: lookbook-sage
+description: Sage and cream editorial, numbered like a lookbook
+---
+
+# lookbook-sage
+
+Cream type over sage green, an italic serif title, and a running number in the
+top corner — `01/12`, the same place every scene, so a sequence counts itself.
+
+Reach for it on a collection, a series, a numbered walk through anything with an
+order. The number card is the format's signature here; drop it and this becomes
+a generic serif look.
+
+The sage panel is used once, on the stat role, rather than behind every card.
+Type on footage with a single coloured block is the composition; type on a block
+in every scene is a slide deck.
+
+```json
+{
+  "captions": {
+    "color": "#efe4cd",
+    "highlight": "#c9a227",
+    "fontFamily": "Cormorant Garamond, Georgia, serif",
+    "stroke": "#2f4a42",
+    "strokeWidth": 4,
+    "fontSize": 44,
+    "uppercase": false,
+    "bounce": 1,
+    "wiggle": 0,
+    "wordsPerPage": 4,
+    "wordGap": 0.14,
+    "bottom": 0.12
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#efe4cd",
+      "fontFamily": "Playfair Display, Didot, Georgia, serif",
+      "italic": true,
+      "weight": 500,
+      "fontSize": 116,
+      "align": "center",
+      "tracking": -0.01,
+      "rect": [
+        0.06,
+        0.34,
+        0.88,
+        0.22
+      ],
+      "fade": {
+        "in": 0.6,
+        "out": 0.4
+      }
+    },
+    "label": {
+      "bg": "transparent",
+      "fg": "#efe4cd",
+      "fontFamily": "Inter, Helvetica, sans-serif",
+      "weight": 500,
+      "fontSize": 24,
+      "align": "center",
+      "tracking": 0.22,
+      "rect": [
+        0.06,
+        0.08,
+        0.24,
+        0.04
+      ],
+      "fade": {
+        "in": 0.4,
+        "out": 0.3
+      }
+    },
+    "stat": {
+      "bg": "#5f8b7c",
+      "fg": "#efe4cd",
+      "fontFamily": "Cormorant Garamond, Georgia, serif",
+      "weight": 600,
+      "fontSize": 48,
+      "align": "center",
+      "tracking": 0.02,
+      "rect": [
+        0.1,
+        0.68,
+        0.8,
+        0.14
+      ],
+      "fade": {
+        "in": 0.5,
+        "out": 0.35
+      }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/postcard-serif.md
+++ b/src/video_studio/styles/postcard-serif.md
@@ -1,0 +1,96 @@
+---
+name: postcard-serif
+description: Didone masthead with a hairline-tracked strapline
+---
+
+# postcard-serif
+
+A place name across the top in a high-contrast serif, a strapline under it in
+caps tracked almost to the point of falling apart, and a condensed block low in
+the frame for whatever the piece is called.
+
+Reach for it on travel, city, arrival — anywhere the location is the subject.
+It is built for footage with sky or street at the top of the frame; over a
+close-up the masthead has nothing to sit on and the whole postcard reads as a
+watermark.
+
+The 0.42 tracking on the strapline is not a typo. At that spacing four or five
+words is the ceiling — write the line to fit rather than tightening it.
+
+```json
+{
+  "captions": {
+    "color": "#fdfdfb",
+    "highlight": "#d9b26a",
+    "fontFamily": "Inter, Helvetica, sans-serif",
+    "stroke": "#1a1a18",
+    "strokeWidth": 4,
+    "fontSize": 40,
+    "uppercase": true,
+    "bounce": 1,
+    "wiggle": 0,
+    "wordsPerPage": 4,
+    "wordGap": 0.26,
+    "bottom": 0.11
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#fdfdfb",
+      "fontFamily": "Prata, Playfair Display, Didot, serif",
+      "weight": 400,
+      "fontSize": 124,
+      "align": "center",
+      "tracking": 0.0,
+      "rect": [
+        0.06,
+        0.1,
+        0.88,
+        0.14
+      ],
+      "fade": {
+        "in": 0.7,
+        "out": 0.5
+      }
+    },
+    "label": {
+      "bg": "transparent",
+      "fg": "#fdfdfb",
+      "fontFamily": "Inter, Helvetica, sans-serif",
+      "weight": 600,
+      "fontSize": 22,
+      "align": "center",
+      "tracking": 0.42,
+      "rect": [
+        0.2,
+        0.24,
+        0.6,
+        0.04
+      ],
+      "fade": {
+        "in": 0.6,
+        "out": 0.4
+      }
+    },
+    "stat": {
+      "bg": "transparent",
+      "fg": "#fdfdfb",
+      "fontFamily": "Bebas Neue, Inter, sans-serif",
+      "weight": 400,
+      "fontSize": 56,
+      "align": "left",
+      "tracking": 0.06,
+      "rect": [
+        0.07,
+        0.74,
+        0.5,
+        0.08
+      ],
+      "fade": {
+        "in": 0.5,
+        "out": 0.35
+      }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/pov-quiet.md
+++ b/src/video_studio/styles/pov-quiet.md
@@ -1,0 +1,79 @@
+---
+name: pov-quiet
+description: Small italic serif set mid-frame, almost whispered
+---
+
+# pov-quiet
+
+Captions in a small italic serif sitting near the middle of the frame rather
+than at the bottom, in cream on a thin dark outline. Nothing shouts.
+
+Reach for it on the `pov:` register — a held moment, a memory, a piece whose
+whole effect is that it is understated. It is the opposite of a mute-proof
+preset: the type is small and the contrast is gentle, so it assumes a viewer who
+is already watching.
+
+`bottom: 0.42` is what puts the line mid-frame. That is where it competes most
+with the subject, which is the intent — this look reads as a thought over the
+picture rather than a subtitle beneath it. Keep the pages long (six words) so it
+reads as a sentence, not as karaoke.
+
+```json
+{
+  "captions": {
+    "color": "#fbfaf7",
+    "highlight": "#e7d7bd",
+    "fontFamily": "EB Garamond, Cormorant Garamond, Georgia, serif",
+    "stroke": "#141210",
+    "strokeWidth": 3,
+    "fontSize": 38,
+    "uppercase": false,
+    "bounce": 1,
+    "wiggle": 0,
+    "wordsPerPage": 6,
+    "wordGap": 0.12,
+    "bottom": 0.42
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#fbfaf7",
+      "fontFamily": "EB Garamond, Cormorant Garamond, Georgia, serif",
+      "italic": true,
+      "weight": 500,
+      "fontSize": 62,
+      "align": "center",
+      "tracking": 0.0,
+      "rect": [
+        0.12,
+        0.44,
+        0.76,
+        0.12
+      ],
+      "fade": {
+        "in": 1.0,
+        "out": 0.8
+      }
+    },
+    "label": {
+      "bg": "transparent",
+      "fg": "#fbfaf7",
+      "fontFamily": "Inter, Helvetica, sans-serif",
+      "weight": 500,
+      "fontSize": 20,
+      "align": "center",
+      "tracking": 0.2,
+      "rect": [
+        0.3,
+        0.88,
+        0.4,
+        0.04
+      ],
+      "fade": {
+        "in": 0.6,
+        "out": 0.5
+      }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/summer-scrapbook.md
+++ b/src/video_studio/styles/summer-scrapbook.md
@@ -1,0 +1,97 @@
+---
+name: summer-scrapbook
+description: Swash serif over sun, with a month-and-year masthead
+---
+
+# summer-scrapbook
+
+A big italic serif across the middle of the frame, a month and a year in small
+letterspaced caps above it, and one real sentence sitting low. Cream type
+throughout on no panel at all, so it works over bright, blown-out footage.
+
+Reach for it on friends, holidays, festivals, a season of phone footage. The
+sentence at the bottom is the point: this look wants something said, not a
+caption. If there is nothing to say, use a louder preset and say nothing.
+
+The title is deliberately the only large thing. Two swash headings in one frame
+fight each other, and cream-on-photo stops working the moment anything else
+competes for the same brightness.
+
+```json
+{
+  "captions": {
+    "color": "#f7ecd8",
+    "highlight": "#e8b55c",
+    "fontFamily": "Cormorant Garamond, Georgia, serif",
+    "stroke": "#3a2c1b",
+    "strokeWidth": 4,
+    "fontSize": 42,
+    "uppercase": false,
+    "bounce": 1,
+    "wiggle": 0,
+    "wordsPerPage": 5,
+    "wordGap": 0.16,
+    "bottom": 0.1
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#f7ecd8",
+      "fontFamily": "Playfair Display, Didot, Georgia, serif",
+      "italic": true,
+      "weight": 700,
+      "fontSize": 128,
+      "align": "center",
+      "tracking": -0.02,
+      "rect": [
+        0.08,
+        0.38,
+        0.84,
+        0.18
+      ],
+      "fade": {
+        "in": 0.7,
+        "out": 0.5
+      }
+    },
+    "label": {
+      "bg": "transparent",
+      "fg": "#f7ecd8",
+      "fontFamily": "Inter, Helvetica, sans-serif",
+      "weight": 500,
+      "fontSize": 26,
+      "align": "center",
+      "tracking": 0.26,
+      "rect": [
+        0.08,
+        0.12,
+        0.36,
+        0.05
+      ],
+      "fade": {
+        "in": 0.5,
+        "out": 0.4
+      }
+    },
+    "stat": {
+      "bg": "transparent",
+      "fg": "#f7ecd8",
+      "fontFamily": "Cormorant Garamond, Georgia, serif",
+      "weight": 500,
+      "fontSize": 30,
+      "align": "center",
+      "tracking": 0.01,
+      "rect": [
+        0.16,
+        0.74,
+        0.68,
+        0.12
+      ],
+      "fade": {
+        "in": 0.6,
+        "out": 0.4
+      }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/weekend-gothic.md
+++ b/src/video_studio/styles/weekend-gothic.md
@@ -1,0 +1,77 @@
+---
+name: weekend-gothic
+description: Blackletter vermilion over neon, with a caps kicker
+---
+
+# weekend-gothic
+
+One blackletter word in vermilion, a short line of letterspaced caps under it,
+and captions that shout in Inter rather than competing with the title's face.
+
+Reach for it on night footage — bars, gigs, wet streets, neon. The face carries
+so much personality that the rest of the frame has to stay plain: the kicker is
+Inter on purpose, and a second gothic word anywhere in the same video undoes the
+whole thing.
+
+Blackletter is near-unreadable at caption size and in long strings. Use it for
+one or two words that the viewer recognises as a shape, never for a sentence,
+and never for anything a viewer actually has to read to follow the video.
+
+```json
+{
+  "captions": {
+    "color": "#f6efe3",
+    "highlight": "#e5342a",
+    "fontFamily": "Inter, Helvetica, sans-serif",
+    "stroke": "#0a0a0a",
+    "strokeWidth": 7,
+    "fontSize": 52,
+    "uppercase": true,
+    "bounce": 1.1,
+    "wiggle": 0,
+    "wordsPerPage": 3,
+    "wordGap": 0.2,
+    "bottom": 0.14
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#e5342a",
+      "fontFamily": "Pirata One, UnifrakturMaguntia, Georgia, serif",
+      "weight": 400,
+      "fontSize": 150,
+      "align": "center",
+      "tracking": 0.01,
+      "rect": [
+        0.05,
+        0.4,
+        0.9,
+        0.2
+      ],
+      "fade": {
+        "in": 0.25,
+        "out": 0.2
+      }
+    },
+    "label": {
+      "bg": "transparent",
+      "fg": "#f6efe3",
+      "fontFamily": "Inter, Helvetica, sans-serif",
+      "weight": 800,
+      "fontSize": 30,
+      "align": "center",
+      "tracking": 0.3,
+      "rect": [
+        0.1,
+        0.58,
+        0.8,
+        0.05
+      ],
+      "fade": {
+        "in": 0.2,
+        "out": 0.2
+      }
+    }
+  }
+}
+```

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -86,7 +86,7 @@ def test_all_extra_is_absent_and_standard_exists():
     assert "all" not in d, "[all] was removed because it never meant all; it is back"
 
 
-@pytest.mark.parametrize("subdir,minimum", [("styles", 17), ("tutorials", 3), ("qc/data", 2),
+@pytest.mark.parametrize("subdir,minimum", [("styles", 22), ("tutorials", 3), ("qc/data", 2),
                                             ("formats", 11)])
 def test_wheel_ships_package_data(tmp_path, subdir, minimum):
     """Data files ride along only because the build sweeps the package tree.


### PR DESCRIPTION
Five presets in the idioms of the reference templates we were shown — swash-serif summer, blackletter weekend, sage lookbook, travel postcard, quiet `pov:`.

They depend on scrollmark/editor#175. Before that, **every card in every video we made was Inter**, because the family was a constant in two files. A preset could pick colours, size and tracking and then got one typeface whatever it asked for — so a "look" was really just a palette. Now a card takes `fontFamily`, `italic` and `weight`, and these five are the first presets that describe type.

| Preset | Face | For |
|---|---|---|
| `summer-scrapbook` | Playfair Display italic | friends, holidays, a season of phone footage |
| `weekend-gothic` | Pirata One / UnifrakturMaguntia | night — bars, gigs, wet streets, neon |
| `lookbook-sage` | Playfair Display italic on sage | a collection or series that counts itself `01/12` |
| `postcard-serif` | Prata + Bebas Neue | travel, arrival, anywhere the place is the subject |
| `pov-quiet` | EB Garamond italic, mid-frame | the understated register |

Each says what it is *wrong* for as plainly as what it is right for: blackletter cannot be read at caption size or in a sentence; the postcard needs sky at the top of the frame or its masthead reads as a watermark; `pov-quiet` is the opposite of mute-proof and assumes a viewer already watching.

**`bg: "transparent"` is what puts type on footage.** `flat` drops the rounding and the shadow but *not* the fill — the panel is hidden only when the fill is literally transparent. Worth knowing before writing the sixth preset.

`CARD_KEYS` gains `fontFamily`, `italic`, `weight`, `flat`, and `brand-kit/SKILL.md` documents them with the two traps: name a real fallback stack, and give an unusual display face an explicit `fontSize`, because the automatic sizing is calibrated to Inter's advance.

22 presets now; the wheel-data test's minimum moves with it.