### PR TITLE
Give three presets the faces their own prose promises

### DIFF
--- a/src/video_studio/styles/analog-editorial.md
+++ b/src/video_studio/styles/analog-editorial.md
@@ -43,8 +43,18 @@ picture having some texture of its own.
       "fontSize": 78,
       "align": "left",
       "tracking": 0.08,
-      "rect": [0.08, 0.34, 0.84, 0.24],
-      "fade": { "in": 0.8, "out": 0.5 }
+      "rect": [
+        0.08,
+        0.34,
+        0.84,
+        0.24
+      ],
+      "fade": {
+        "in": 0.8,
+        "out": 0.5
+      },
+      "fontFamily": "Fraunces, Georgia, serif",
+      "italic": true
     },
     "label": {
       "bg": "#2b2118",
@@ -52,8 +62,17 @@ picture having some texture of its own.
       "fontSize": 24,
       "align": "left",
       "tracking": 0.16,
-      "rect": [0.08, 0.8, 0.5, 0.06],
-      "fade": { "in": 0.4, "out": 0.3 }
+      "rect": [
+        0.08,
+        0.8,
+        0.5,
+        0.06
+      ],
+      "fade": {
+        "in": 0.4,
+        "out": 0.3
+      },
+      "fontFamily": "Inter, Helvetica, sans-serif"
     },
     "stat": {
       "bg": "#e0a34a",
@@ -61,8 +80,17 @@ picture having some texture of its own.
       "fontSize": 40,
       "align": "left",
       "tracking": 0.04,
-      "rect": [0.08, 0.72, 0.56, 0.12],
-      "fade": { "in": 0.4, "out": 0.3 }
+      "rect": [
+        0.08,
+        0.72,
+        0.56,
+        0.12
+      ],
+      "fade": {
+        "in": 0.4,
+        "out": 0.3
+      },
+      "fontFamily": "Fraunces, Georgia, serif"
     }
   }
 }

--- a/src/video_studio/styles/arcade-crt.md
+++ b/src/video_studio/styles/arcade-crt.md
@@ -1,0 +1,93 @@
+---
+name: arcade-crt
+description: Phosphor green pixels, Press Start over VT323
+---
+
+# arcade-crt
+
+A pixel face at title size and a terminal face for everything else, in the
+green a CRT actually emitted, on black. Captions are uppercase and monospaced
+so they read as output rather than as subtitles.
+
+Reach for it on games, builds, benchmarks, anything with a score or a number
+going up. It is a costume on a lifestyle clip, and the pixels turn to mush
+over busy footage — this look wants dark, simple frames or a flat colour.
+
+Press Start 2P is enormously wide: eight characters fill a phone frame. Keep
+titles to one short word and trust the explicit `fontSize` here rather than
+the automatic sizing, which is calibrated to Inter and will overshoot badly.
+
+```json
+{
+  "captions": {
+    "color": "#39ff14",
+    "highlight": "#ffffff",
+    "fontFamily": "VT323, ui-monospace, monospace",
+    "stroke": "#03170a",
+    "strokeWidth": 6,
+    "fontSize": 64,
+    "uppercase": true,
+    "bounce": 1,
+    "wiggle": 0,
+    "wordsPerPage": 4,
+    "wordGap": 0.18,
+    "bottom": 0.12
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#39ff14",
+      "fontFamily": "Press Start 2P, ui-monospace, monospace",
+      "fontSize": 72,
+      "align": "center",
+      "tracking": 0.02,
+      "rect": [
+        0.04,
+        0.4,
+        0.92,
+        0.2
+      ],
+      "fade": {
+        "in": 0.15,
+        "out": 0.15
+      }
+    },
+    "label": {
+      "bg": "#03170a",
+      "fg": "#39ff14",
+      "fontFamily": "VT323, ui-monospace, monospace",
+      "fontSize": 40,
+      "align": "center",
+      "tracking": 0.08,
+      "rect": [
+        0.2,
+        0.1,
+        0.6,
+        0.06
+      ],
+      "fade": {
+        "in": 0.15,
+        "out": 0.15
+      }
+    },
+    "stat": {
+      "bg": "#39ff14",
+      "fg": "#03170a",
+      "fontFamily": "Press Start 2P, ui-monospace, monospace",
+      "fontSize": 56,
+      "align": "center",
+      "tracking": 0,
+      "rect": [
+        0.14,
+        0.7,
+        0.72,
+        0.1
+      ],
+      "fade": {
+        "in": 0.15,
+        "out": 0.15
+      }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/chrome-y2k.md
+++ b/src/video_studio/styles/chrome-y2k.md
@@ -1,0 +1,75 @@
+---
+name: chrome-y2k
+description: Nabla's colour chrome, which paints its own palette
+---
+
+# chrome-y2k
+
+Nabla is a colour font: its glyphs carry their own gradient, a bevelled chrome
+that looks like a 1999 CD-ROM menu. The card's `fg` does nothing to it — the
+face paints itself — which is the one thing to know before using it.
+
+Reach for it on tech, nostalgia, anything knowingly retro-futuristic. Because
+the title brings its own palette, everything around it is deliberately
+monochrome: white captions, a near-black kicker, no third colour.
+
+Set it on a dark frame. The chrome's highlights are pale, and on a bright
+background the whole word disappears into the picture.
+
+```json
+{
+  "captions": {
+    "color": "#f8fafc",
+    "highlight": "#a5f3fc",
+    "fontFamily": "Inter, Helvetica, sans-serif",
+    "stroke": "#09090b",
+    "strokeWidth": 7,
+    "fontSize": 52,
+    "uppercase": true,
+    "bounce": 1,
+    "wiggle": 0,
+    "wordsPerPage": 3,
+    "wordGap": 0.2,
+    "bottom": 0.12
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#ffffff",
+      "fontFamily": "Nabla, Impact, sans-serif",
+      "fontSize": 140,
+      "align": "center",
+      "tracking": 0.02,
+      "rect": [
+        0.04,
+        0.36,
+        0.92,
+        0.22
+      ],
+      "fade": {
+        "in": 0.3,
+        "out": 0.25
+      }
+    },
+    "label": {
+      "bg": "#09090b",
+      "fg": "#f8fafc",
+      "fontFamily": "Inter, Helvetica, sans-serif",
+      "weight": 700,
+      "fontSize": 28,
+      "align": "center",
+      "tracking": 0.3,
+      "rect": [
+        0.14,
+        0.62,
+        0.72,
+        0.05
+      ],
+      "fade": {
+        "in": 0.25,
+        "out": 0.2
+      }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/magazine-cover.md
+++ b/src/video_studio/styles/magazine-cover.md
@@ -43,8 +43,17 @@ spacing, four pages of them is work.
       "fontSize": 120,
       "align": "center",
       "tracking": -0.04,
-      "rect": [0.06, 0.3, 0.88, 0.3],
-      "fade": { "in": 0.6, "out": 0.4 }
+      "rect": [
+        0.06,
+        0.3,
+        0.88,
+        0.3
+      ],
+      "fade": {
+        "in": 0.6,
+        "out": 0.4
+      },
+      "fontFamily": "Bodoni Moda, Didot, Georgia, serif"
     },
     "label": {
       "bg": "#111111",
@@ -52,8 +61,17 @@ spacing, four pages of them is work.
       "fontSize": 22,
       "align": "center",
       "tracking": 0.24,
-      "rect": [0.2, 0.64, 0.6, 0.05],
-      "fade": { "in": 0.4, "out": 0.3 }
+      "rect": [
+        0.2,
+        0.64,
+        0.6,
+        0.05
+      ],
+      "fade": {
+        "in": 0.4,
+        "out": 0.3
+      },
+      "fontFamily": "Inter, Helvetica, sans-serif"
     },
     "stat": {
       "bg": "#e11d48",
@@ -61,8 +79,17 @@ spacing, four pages of them is work.
       "fontSize": 44,
       "align": "center",
       "tracking": 0.02,
-      "rect": [0.24, 0.72, 0.52, 0.1],
-      "fade": { "in": 0.4, "out": 0.3 }
+      "rect": [
+        0.24,
+        0.72,
+        0.52,
+        0.1
+      ],
+      "fade": {
+        "in": 0.4,
+        "out": 0.3
+      },
+      "fontFamily": "Bodoni Moda, Didot, Georgia, serif"
     }
   }
 }

--- a/src/video_studio/styles/neon-sign.md
+++ b/src/video_studio/styles/neon-sign.md
@@ -1,0 +1,75 @@
+---
+name: neon-sign
+description: Monoton tube lettering in hot pink over night
+---
+
+# neon-sign
+
+Monoton is drawn as a struck neon tube — parallel strokes with a gap down the
+middle — so at size it reads as a sign rather than as type. Hot pink title,
+cyan kicker, captions in something legible because the tube face is not.
+
+Reach for it at night: bars, venues, streets, anything already lit. In
+daylight there is nothing for it to be a sign against and it just looks like a
+novelty font.
+
+One word, centred, big. Monoton has no bold and no italic — weight and lean do
+nothing to it, and the tube reads as broken if you crowd two lines together.
+
+```json
+{
+  "captions": {
+    "color": "#fdf4ff",
+    "highlight": "#22d3ee",
+    "fontFamily": "Inter, Helvetica, sans-serif",
+    "stroke": "#160b1a",
+    "strokeWidth": 7,
+    "fontSize": 50,
+    "uppercase": true,
+    "bounce": 1.06,
+    "wiggle": 0,
+    "wordsPerPage": 3,
+    "wordGap": 0.22,
+    "bottom": 0.13
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#ff2fa8",
+      "fontFamily": "Monoton, Impact, sans-serif",
+      "fontSize": 96,
+      "align": "center",
+      "tracking": 0.02,
+      "rect": [
+        0.05,
+        0.36,
+        0.9,
+        0.22
+      ],
+      "fade": {
+        "in": 0.4,
+        "out": 0.3
+      }
+    },
+    "label": {
+      "bg": "transparent",
+      "fg": "#22d3ee",
+      "fontFamily": "Inter, Helvetica, sans-serif",
+      "weight": 800,
+      "fontSize": 30,
+      "align": "center",
+      "tracking": 0.34,
+      "rect": [
+        0.1,
+        0.6,
+        0.8,
+        0.05
+      ],
+      "fade": {
+        "in": 0.3,
+        "out": 0.25
+      }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/vhs-90s.md
+++ b/src/video_studio/styles/vhs-90s.md
@@ -43,8 +43,17 @@ perfectly still.
       "fontSize": 84,
       "align": "left",
       "tracking": 0.18,
-      "rect": [0.06, 0.38, 0.88, 0.22],
-      "fade": { "in": 0.3, "out": 0.2 }
+      "rect": [
+        0.06,
+        0.38,
+        0.88,
+        0.22
+      ],
+      "fade": {
+        "in": 0.3,
+        "out": 0.2
+      },
+      "fontFamily": "Courier New, ui-monospace, Menlo, monospace"
     },
     "label": {
       "bg": "#22d3ee",
@@ -52,8 +61,17 @@ perfectly still.
       "fontSize": 26,
       "align": "left",
       "tracking": 0.1,
-      "rect": [0.06, 0.06, 0.44, 0.06],
-      "fade": { "in": 0.2, "out": 0.2 }
+      "rect": [
+        0.06,
+        0.06,
+        0.44,
+        0.06
+      ],
+      "fade": {
+        "in": 0.2,
+        "out": 0.2
+      },
+      "fontFamily": "Courier New, ui-monospace, Menlo, monospace"
     }
   }
 }

--- a/src/video_studio/styles/wet-paint.md
+++ b/src/video_studio/styles/wet-paint.md
@@ -1,0 +1,74 @@
+---
+name: wet-paint
+description: Dripping letters, lime on black, loud on purpose
+---
+
+# wet-paint
+
+A title face whose letters drip, a fat rounded face for the kicker, and lime
+against black. Nothing here is subtle and nothing here is trying to be.
+
+Reach for it on food, drops, sales, chaos — anything where the point is energy
+rather than information. Avoid it on anything sincere: drips read as a joke,
+and a joke under a serious line is worse than a plain caption.
+
+The drips need room underneath or they collide with the next line, which is
+why the title sits high in the frame. Keep it to one or two words; a long
+string of dripping letters stops being readable at all.
+
+```json
+{
+  "captions": {
+    "color": "#eaff00",
+    "highlight": "#ffffff",
+    "fontFamily": "Inter, Helvetica, sans-serif",
+    "stroke": "#0b0b0b",
+    "strokeWidth": 9,
+    "fontSize": 58,
+    "uppercase": true,
+    "bounce": 1.18,
+    "wiggle": 2,
+    "wordsPerPage": 3,
+    "wordGap": 0.2,
+    "bottom": 0.15
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#eaff00",
+      "fontFamily": "Rubik Wet Paint, Impact, sans-serif",
+      "fontSize": 124,
+      "align": "center",
+      "tracking": 0.01,
+      "rect": [
+        0.05,
+        0.26,
+        0.9,
+        0.2
+      ],
+      "fade": {
+        "in": 0.2,
+        "out": 0.15
+      }
+    },
+    "label": {
+      "bg": "#0b0b0b",
+      "fg": "#eaff00",
+      "fontFamily": "Bagel Fat One, Impact, sans-serif",
+      "fontSize": 44,
+      "align": "center",
+      "tracking": 0.04,
+      "rect": [
+        0.16,
+        0.52,
+        0.68,
+        0.08
+      ],
+      "fade": {
+        "in": 0.2,
+        "out": 0.15
+      }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/zine-glitch.md
+++ b/src/video_studio/styles/zine-glitch.md
@@ -1,0 +1,74 @@
+---
+name: zine-glitch
+description: Photocopied glitch type, black and white and one red
+---
+
+# zine-glitch
+
+A title face that looks like a bad scan of itself, a heavy grotesque for the
+kicker, and one red on a black-and-white ground. The reference is a photocopied
+zine: cheap, fast, and legible in spite of itself.
+
+Reach for it on subculture, announcements, anything that should look made
+rather than designed. It is the wrong preset for a brand that sells
+reassurance — the whole face says this was run off in a hurry.
+
+Rubik Glitch damages its own letterforms, so the shorter the word the better.
+Two words is a headline; five is a smear.
+
+```json
+{
+  "captions": {
+    "color": "#fafafa",
+    "highlight": "#ff2d20",
+    "fontFamily": "Archivo Black, Impact, sans-serif",
+    "stroke": "#0a0a0a",
+    "strokeWidth": 8,
+    "fontSize": 54,
+    "uppercase": true,
+    "bounce": 1,
+    "wiggle": 1,
+    "wordsPerPage": 3,
+    "wordGap": 0.18,
+    "bottom": 0.14
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#fafafa",
+      "fontFamily": "Rubik Glitch, Impact, sans-serif",
+      "fontSize": 128,
+      "align": "center",
+      "tracking": 0.01,
+      "rect": [
+        0.04,
+        0.38,
+        0.92,
+        0.2
+      ],
+      "fade": {
+        "in": 0.15,
+        "out": 0.1
+      }
+    },
+    "label": {
+      "bg": "#ff2d20",
+      "fg": "#0a0a0a",
+      "fontFamily": "Archivo Black, Impact, sans-serif",
+      "fontSize": 34,
+      "align": "center",
+      "tracking": 0.12,
+      "rect": [
+        0.18,
+        0.6,
+        0.64,
+        0.06
+      ],
+      "fade": {
+        "in": 0.15,
+        "out": 0.1
+      }
+    }
+  }
+}
+```

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -86,7 +86,7 @@ def test_all_extra_is_absent_and_standard_exists():
     assert "all" not in d, "[all] was removed because it never meant all; it is back"
 
 
-@pytest.mark.parametrize("subdir,minimum", [("styles", 22), ("tutorials", 3), ("qc/data", 2),
+@pytest.mark.parametrize("subdir,minimum", [("styles", 27), ("tutorials", 3), ("qc/data", 2),
                                             ("formats", 11)])
 def test_wheel_ships_package_data(tmp_path, subdir, minimum):
     """Data files ride along only because the build sweeps the package tree.


### PR DESCRIPTION
Found by rendering all 27 presets over the same clip and reading the title card each one produced.

Three presets were written before a card could name a face, so their titles drew Inter while their prose said otherwise:

| Preset | Its own words | Drew | Now |
|---|---|---|---|
| `magazine-cover` | "a masthead-sized serif over the shot" | Inter | Bodoni Moda |
| `vhs-90s` | "a typewriter mono … burned in by the device" | Inter | Courier New |
| `analog-editorial` | "warm film stock under fashion-magazine serifs" | Inter cards, Fraunces captions | Fraunces italic throughout |

Seventeen of the 27 presets still name no title face, and that is correct for the fourteen that predate the feature — they describe themselves as palettes and deliver palettes. These three described type they were not setting.