### PR TITLE
Retune three looks to the faces the reference actually uses, and add two

### DIFF
--- a/src/video_studio/styles/editorial-sage.md
+++ b/src/video_studio/styles/editorial-sage.md
@@ -1,0 +1,96 @@
+---
+name: editorial-sage
+description: Cream Didone on sage, with one script line
+---
+
+# editorial-sage
+
+A light Didone for the flat lines, a script for the one word that leans, and a
+running number in the corner. Cream on a muted sage, with nothing else on
+screen.
+
+Reach for it on a collection, a lookbook, a numbered walk through anything
+with an order. Two faces is the whole idea: the Didone holds the structure and
+the script carries the single word worth emphasising. A third face breaks it.
+
+Set it on a plain ground -- a flat colour, a wall, a backdrop. The type is
+light enough that a busy frame eats it, which is what the sage is for.
+
+```json
+{
+  "captions": {
+    "color": "#efe6d2",
+    "highlight": "#c9a227",
+    "fontFamily": "Cormorant Garamond, Georgia, serif",
+    "stroke": "#2c4038",
+    "strokeWidth": 4,
+    "fontSize": 44,
+    "uppercase": false,
+    "bounce": 1,
+    "wiggle": 0,
+    "wordsPerPage": 4,
+    "wordGap": 0.14,
+    "bottom": 0.12
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#efe6d2",
+      "fontFamily": "Bodoni Moda, Didot, Georgia, serif",
+      "weight": 400,
+      "fontSize": 118,
+      "align": "center",
+      "tracking": -0.01,
+      "rect": [
+        0.06,
+        0.3,
+        0.88,
+        0.16
+      ],
+      "fade": {
+        "in": 0.6,
+        "out": 0.4
+      }
+    },
+    "stat": {
+      "bg": "transparent",
+      "fg": "#efe6d2",
+      "fontFamily": "Playfair Display, Georgia, serif",
+      "italic": true,
+      "weight": 500,
+      "fontSize": 104,
+      "align": "center",
+      "tracking": 0,
+      "rect": [
+        0.08,
+        0.44,
+        0.84,
+        0.14
+      ],
+      "fade": {
+        "in": 0.7,
+        "out": 0.5
+      }
+    },
+    "label": {
+      "bg": "transparent",
+      "fg": "#efe6d2",
+      "fontFamily": "Inter, Helvetica, sans-serif",
+      "weight": 500,
+      "fontSize": 24,
+      "align": "center",
+      "tracking": 0.22,
+      "rect": [
+        0.06,
+        0.07,
+        0.2,
+        0.04
+      ],
+      "fade": {
+        "in": 0.4,
+        "out": 0.3
+      }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/lookbook-sage.md
+++ b/src/video_studio/styles/lookbook-sage.md
@@ -36,9 +36,9 @@ in every scene is a slide deck.
     "title": {
       "bg": "transparent",
       "fg": "#efe4cd",
-      "fontFamily": "Playfair Display, Didot, Georgia, serif",
-      "italic": true,
-      "weight": 500,
+      "fontFamily": "Bodoni Moda, Didot, Georgia, serif",
+      "italic": false,
+      "weight": 400,
       "fontSize": 116,
       "align": "center",
       "tracking": -0.01,
@@ -75,7 +75,7 @@ in every scene is a slide deck.
     "stat": {
       "bg": "#5f8b7c",
       "fg": "#efe4cd",
-      "fontFamily": "Cormorant Garamond, Georgia, serif",
+      "fontFamily": "Playfair Display, Georgia, serif",
       "weight": 600,
       "fontSize": 48,
       "align": "center",
@@ -89,7 +89,8 @@ in every scene is a slide deck.
       "fade": {
         "in": 0.5,
         "out": 0.35
-      }
+      },
+      "italic": true
     }
   }
 }

--- a/src/video_studio/styles/pov-serif.md
+++ b/src/video_studio/styles/pov-serif.md
@@ -1,0 +1,79 @@
+---
+name: pov-serif
+description: A workhorse serif set mid-frame, said quietly
+---
+
+# pov-serif
+
+Small serif lines sitting in the middle of the frame rather than along the
+bottom, in near-white with a thin dark outline. A sturdier face than a
+display serif: this is meant to read as a thought typed over the picture, not
+as a masthead.
+
+Reach for it on the `pov:` register -- a held moment, a memory, anything whose
+effect is that it is understated. Three or four lines is the ceiling; it is a
+caption pretending to be a sentence, and a paragraph mid-frame is a wall.
+
+Georgia is named first on purpose: it was drawn for screens at small sizes,
+which is exactly the job here, and it is installed nearly everywhere so the
+fallback rarely fires.
+
+```json
+{
+  "captions": {
+    "color": "#f7f5f2",
+    "highlight": "#e4d9c6",
+    "fontFamily": "Georgia, EB Garamond, serif",
+    "stroke": "#14120f",
+    "strokeWidth": 3,
+    "fontSize": 40,
+    "uppercase": false,
+    "bounce": 1,
+    "wiggle": 0,
+    "wordsPerPage": 5,
+    "wordGap": 0.12,
+    "bottom": 0.44
+  },
+  "cards": {
+    "title": {
+      "bg": "transparent",
+      "fg": "#f7f5f2",
+      "fontFamily": "Georgia, EB Garamond, serif",
+      "italic": true,
+      "weight": 400,
+      "fontSize": 58,
+      "align": "center",
+      "tracking": 0,
+      "rect": [
+        0.12,
+        0.42,
+        0.76,
+        0.16
+      ],
+      "fade": {
+        "in": 1.0,
+        "out": 0.8
+      }
+    },
+    "label": {
+      "bg": "transparent",
+      "fg": "#f7f5f2",
+      "fontFamily": "Inter, Helvetica, sans-serif",
+      "weight": 500,
+      "fontSize": 20,
+      "align": "center",
+      "tracking": 0.2,
+      "rect": [
+        0.3,
+        0.88,
+        0.4,
+        0.04
+      ],
+      "fade": {
+        "in": 0.6,
+        "out": 0.5
+      }
+    }
+  }
+}
+```

--- a/src/video_studio/styles/summer-scrapbook.md
+++ b/src/video_studio/styles/summer-scrapbook.md
@@ -37,10 +37,10 @@ competes for the same brightness.
     "title": {
       "bg": "transparent",
       "fg": "#f7ecd8",
-      "fontFamily": "Playfair Display, Didot, Georgia, serif",
+      "fontFamily": "Gwendolyn, Playfair Display, Georgia, serif",
       "italic": true,
       "weight": 700,
-      "fontSize": 128,
+      "fontSize": 170,
       "align": "center",
       "tracking": -0.02,
       "rect": [

--- a/src/video_studio/styles/weekend-gothic.md
+++ b/src/video_studio/styles/weekend-gothic.md
@@ -37,9 +37,9 @@ and never for anything a viewer actually has to read to follow the video.
     "title": {
       "bg": "transparent",
       "fg": "#e5342a",
-      "fontFamily": "Pirata One, UnifrakturMaguntia, Georgia, serif",
+      "fontFamily": "UnifrakturMaguntia, Pirata One, Georgia, serif",
       "weight": 400,
-      "fontSize": 150,
+      "fontSize": 104,
       "align": "center",
       "tracking": 0.01,
       "rect": [

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -86,7 +86,7 @@ def test_all_extra_is_absent_and_standard_exists():
     assert "all" not in d, "[all] was removed because it never meant all; it is back"
 
 
-@pytest.mark.parametrize("subdir,minimum", [("styles", 27), ("tutorials", 3), ("qc/data", 2),
+@pytest.mark.parametrize("subdir,minimum", [("styles", 29), ("tutorials", 3), ("qc/data", 2),
                                             ("formats", 11)])
 def test_wheel_ships_package_data(tmp_path, subdir, minimum):
     """Data files ride along only because the build sweeps the package tree.


### PR DESCRIPTION
A font identification of the five reference panels, **checked by rendering the candidates side by side** rather than taken on trust.

## Taken

| Preset | Was | Now | Why |
|---|---|---|---|
| `weekend-gothic` | Pirata One | **UnifrakturMaguntia** | the reference is a *textura* (Cloister Black class); Pirata One is a rougher, condensed gothic. Smaller size, because it sets much wider |
| `lookbook-sage` | Playfair Display italic | **Bodoni Moda** | the display type is a light Didone, which Playfair is not |
| `summer-scrapbook` | Playfair Display italic | **Gwendolyn** | the title is a script-serif with a long S swash; an upright italic has no swash to give |
| `editorial-sage` | — | new | Bodoni Moda + a Playfair italic script line, cream on sage |
| `pov-serif` | — | new | Georgia first on purpose: drawn for screens at small sizes, and installed nearly everywhere |

## Not taken

The identification said **Georgia Bold** for the travel masthead. Georgia is a low-contrast Scotch face with thick bracketed serifs; the reference has hairline thins and flat unbracketed serifs — a Didone. `postcard-serif` keeps **Prata**. Specimens are in the reels folder as `FONT-candidates.html` if you want to judge it yourself.

The script line was identified as Pinyon Script, a formal copperplate with a rigid baseline. The reference's leaning word is a swashed italic serif, so it stays Playfair Display Italic.

## One honest limit

**The colours here are read by eye, not sampled.** The panel artwork lives inside their app — I checked seven published assets on their site (two template recordings, the hero, the ultra reel, the preview still, the webp set) and none of them is it. Sampling would be strictly better and is not available.

29 presets; the wheel-data minimum moves with it.