### PR TITLE
Set display type at the size the reference sets it

### DIFF
--- a/src/video_studio/styles/analog-editorial.md
+++ b/src/video_studio/styles/analog-editorial.md
@@ -40,7 +40,7 @@ picture having some texture of its own.
     "title": {
       "bg": "#f4ece1",
       "fg": "#2b2118",
-      "fontSize": 78,
+      "fontSize": 150,
       "align": "left",
       "tracking": 0.08,
       "rect": [

--- a/src/video_studio/styles/arcade-crt.md
+++ b/src/video_studio/styles/arcade-crt.md
@@ -38,7 +38,7 @@ the automatic sizing, which is calibrated to Inter and will overshoot badly.
       "bg": "transparent",
       "fg": "#39ff14",
       "fontFamily": "Press Start 2P, ui-monospace, monospace",
-      "fontSize": 72,
+      "fontSize": 120,
       "align": "center",
       "tracking": 0.02,
       "rect": [

--- a/src/video_studio/styles/chrome-y2k.md
+++ b/src/video_studio/styles/chrome-y2k.md
@@ -37,7 +37,7 @@ background the whole word disappears into the picture.
       "bg": "transparent",
       "fg": "#ffffff",
       "fontFamily": "Nabla, Impact, sans-serif",
-      "fontSize": 140,
+      "fontSize": 200,
       "align": "center",
       "tracking": 0.02,
       "rect": [

--- a/src/video_studio/styles/editorial-sage.md
+++ b/src/video_studio/styles/editorial-sage.md
@@ -38,7 +38,7 @@ light enough that a busy frame eats it, which is what the sage is for.
       "fg": "#efe6d2",
       "fontFamily": "Bodoni Moda, Didot, Georgia, serif",
       "weight": 400,
-      "fontSize": 118,
+      "fontSize": 176,
       "align": "center",
       "tracking": -0.01,
       "rect": [
@@ -58,7 +58,7 @@ light enough that a busy frame eats it, which is what the sage is for.
       "fontFamily": "Playfair Display, Georgia, serif",
       "italic": true,
       "weight": 500,
-      "fontSize": 104,
+      "fontSize": 150,
       "align": "center",
       "tracking": 0,
       "rect": [

--- a/src/video_studio/styles/lookbook-sage.md
+++ b/src/video_studio/styles/lookbook-sage.md
@@ -39,7 +39,7 @@ in every scene is a slide deck.
       "fontFamily": "Bodoni Moda, Didot, Georgia, serif",
       "italic": false,
       "weight": 400,
-      "fontSize": 116,
+      "fontSize": 168,
       "align": "center",
       "tracking": -0.01,
       "rect": [

--- a/src/video_studio/styles/magazine-cover.md
+++ b/src/video_studio/styles/magazine-cover.md
@@ -40,7 +40,7 @@ spacing, four pages of them is work.
     "title": {
       "bg": "#ffffff",
       "fg": "#111111",
-      "fontSize": 120,
+      "fontSize": 190,
       "align": "center",
       "tracking": -0.04,
       "rect": [

--- a/src/video_studio/styles/neon-sign.md
+++ b/src/video_studio/styles/neon-sign.md
@@ -37,7 +37,7 @@ nothing to it, and the tube reads as broken if you crowd two lines together.
       "bg": "transparent",
       "fg": "#ff2fa8",
       "fontFamily": "Monoton, Impact, sans-serif",
-      "fontSize": 96,
+      "fontSize": 172,
       "align": "center",
       "tracking": 0.02,
       "rect": [

--- a/src/video_studio/styles/postcard-serif.md
+++ b/src/video_studio/styles/postcard-serif.md
@@ -39,7 +39,7 @@ words is the ceiling — write the line to fit rather than tightening it.
       "fg": "#fdfdfb",
       "fontFamily": "Prata, Playfair Display, Didot, serif",
       "weight": 400,
-      "fontSize": 124,
+      "fontSize": 196,
       "align": "center",
       "tracking": 0.0,
       "rect": [

--- a/src/video_studio/styles/summer-scrapbook.md
+++ b/src/video_studio/styles/summer-scrapbook.md
@@ -40,7 +40,7 @@ competes for the same brightness.
       "fontFamily": "Gwendolyn, Playfair Display, Georgia, serif",
       "italic": true,
       "weight": 700,
-      "fontSize": 170,
+      "fontSize": 232,
       "align": "center",
       "tracking": -0.02,
       "rect": [
@@ -78,7 +78,7 @@ competes for the same brightness.
       "fg": "#f7ecd8",
       "fontFamily": "Cormorant Garamond, Georgia, serif",
       "weight": 500,
-      "fontSize": 30,
+      "fontSize": 34,
       "align": "center",
       "tracking": 0.01,
       "rect": [

--- a/src/video_studio/styles/vhs-90s.md
+++ b/src/video_studio/styles/vhs-90s.md
@@ -40,7 +40,7 @@ perfectly still.
     "title": {
       "bg": "#0b0b0f",
       "fg": "#ff3ea5",
-      "fontSize": 84,
+      "fontSize": 150,
       "align": "left",
       "tracking": 0.18,
       "rect": [

--- a/src/video_studio/styles/weekend-gothic.md
+++ b/src/video_studio/styles/weekend-gothic.md
@@ -39,7 +39,7 @@ and never for anything a viewer actually has to read to follow the video.
       "fg": "#e5342a",
       "fontFamily": "UnifrakturMaguntia, Pirata One, Georgia, serif",
       "weight": 400,
-      "fontSize": 104,
+      "fontSize": 236,
       "align": "center",
       "tracking": 0.01,
       "rect": [

--- a/src/video_studio/styles/wet-paint.md
+++ b/src/video_studio/styles/wet-paint.md
@@ -37,7 +37,7 @@ string of dripping letters stops being readable at all.
       "bg": "transparent",
       "fg": "#eaff00",
       "fontFamily": "Rubik Wet Paint, Impact, sans-serif",
-      "fontSize": 124,
+      "fontSize": 190,
       "align": "center",
       "tracking": 0.01,
       "rect": [

--- a/src/video_studio/styles/zine-glitch.md
+++ b/src/video_studio/styles/zine-glitch.md
@@ -37,7 +37,7 @@ Two words is a headline; five is a smear.
       "bg": "transparent",
       "fg": "#fafafa",
       "fontFamily": "Rubik Glitch, Impact, sans-serif",
-      "fontSize": 128,
+      "fontSize": 196,
       "align": "center",
       "tracking": 0.01,
       "rect": [


### PR DESCRIPTION
The reference panels set their titles to fill most of the frame — "Weekend" spans about **85% of the width**. Ours computed to **37%**, because sizes were picked one at a time against a demo title rather than against the proportion the look depends on.

Thirteen presets move. Measured with the advances the editor uses, a short reference word now lands at:

| | |
|---|---|
| `Weekend` in weekend-gothic | 96% of its band |
| `NO RULES` in zine-glitch | 98% |
| `The Rooms` in editorial-sage | 99% |
| `New York` in postcard-serif | 91% |

A long title is cut down to fit by the card's width clamp, which is exactly what that clamp is for — so a preset used with the copy it was written for is loud, and one handed a fourteen-character title still stays on the card.

**The quiet presets are untouched.** `pov-quiet` and `pov-serif` are small on purpose, and the reference's own quiet panel is small too.