### PR TITLE
Author the key names once, and check the two that never were

### DIFF
--- a/src/video_studio/project/formats.py
+++ b/src/video_studio/project/formats.py
@@ -31,6 +31,7 @@ import re
 from pathlib import Path
 
 from video_studio.paths import studio_root
+from video_studio.project import keyspace
 
 SKILL_ROOT = studio_root()
 USER_FORMATS = Path.home() / ".config" / "video-studio" / "formats"
@@ -47,19 +48,10 @@ PACKAGE_FORMATS = Path(__file__).resolve().parent.parent / "formats"
 
 #: Keys a format document may declare. Anything else is a typo, and a typo in
 #: frontmatter is invisible: it parses, it stores, and nothing ever reads it.
-FORMAT_KEYS = {
-    "name",          # the id, and the file stem
-    "title",         # the composer-facing name, e.g. TimelineExplainer
-    "description",   # one line, for a list
-    "aspect",        # the frame it is composed for
-    "alsoWorks",     # a second frame it survives
-    "scenes",        # how many, as a range
-    "sceneSeconds",  # how long each runs, as a range
-    "captions",      # on / off / optional
-    "narration",     # one voice / two voices / on camera / optional
-    "music",         # required, where the format does not work without it
-    "needs",         # a program that must run before this format can build
-}
+#: Format frontmatter keys, read from the shared key space rather than retyped
+#: -- see ``keyspace.json`` beside this module. The comments that used to sit
+#: against each name live there now, where both consumers can read them.
+FORMAT_KEYS = keyspace.space("format")
 
 #: Programs that ship inside a skill folder rather than in the package, so
 #: they are not in ``COMMANDS`` and a ``needs:`` naming one would otherwise be
@@ -70,7 +62,7 @@ BUNDLED = {"doctor", "measure", "normalize_audio", "poster", "prekey", "qc_rende
 
 #: ``aspect`` values that mean something downstream. ``source`` is a real
 #: answer: a format built on the user's own footage keeps its frame.
-ASPECTS = {"9:16", "16:9", "1:1", "4:5", "source"}
+ASPECTS = keyspace.enum("aspect")
 
 
 def format_roots(project: Path | None) -> list[Path]:

--- a/src/video_studio/project/keyspace.json
+++ b/src/video_studio/project/keyspace.json
@@ -1,0 +1,107 @@
+{
+  "$comment": [
+    "The key names a preset, a format and a storyboard card may use.",
+    "",
+    "Authored here and consumed twice: styles.py and formats.py load this file",
+    "directly, and scrollmark/editor generates packs/keyspace.generated.ts from",
+    "it. Before this existed the same lists were retyped in Python and in",
+    "TypeScript, in two repositories, and stayed in step only because one person",
+    "remembered to change both.",
+    "",
+    "Only NAMES and closed value sets live here. Types, units and constraints",
+    "stay on whichever side needs them -- the editor's zod schemas carry things",
+    "like `wordsPerPage` being a positive integer, and the comments explaining",
+    "why `bottom` is measured up from the bottom edge are worth more than any",
+    "generated version of them would be.",
+    "",
+    "Every space below has a consumer TODAY. A key space with no reader is the",
+    "failure styles.py exists to prevent: it stays in the file, stops matching",
+    "the render, and misleads whoever edits it next. Add a space when something",
+    "starts validating against it, not in anticipation."
+  ],
+  "version": "1.0.0",
+  "spaces": {
+    "caption": {
+      "$comment": "Caption keys the composer renders. Mirrored by captionStyleSchema in the editor's storyboard/captions.ts.",
+      "keys": [
+        "color",
+        "highlight",
+        "fontFamily",
+        "palette",
+        "stroke",
+        "strokeWidth",
+        "fontSize",
+        "bounce",
+        "wiggle",
+        "uppercase",
+        "bottom",
+        "wordsPerPage",
+        "wordGap"
+      ]
+    },
+    "cardStyle": {
+      "$comment": [
+        "How a card LOOKS. This is what a style preset is allowed to set, and",
+        "deliberately excludes cardContent: a preset supplies the treatment, never",
+        "the words. `fontFamily`/`italic`/`weight` arrived with scrollmark/editor#175;",
+        "before them a card could choose its colours and its size and then drew",
+        "Inter whatever it asked for, which is most of what a design template is."
+      ],
+      "keys": [
+        "bg",
+        "fg",
+        "tracking",
+        "fontSize",
+        "align",
+        "size",
+        "fontFamily",
+        "italic",
+        "weight",
+        "flat"
+      ]
+    },
+    "cardContent": {
+      "$comment": [
+        "What a card SAYS. Separate from `card` because the two lists answer",
+        "different questions and only look alike: a preset that set `heading`",
+        "would be writing the video's words, so styles.py rejects these, while",
+        "the editor's guards need card and cardContent together to tell a",
+        "mistyped key from a legitimate one."
+      ],
+      "keys": ["heading", "subtext", "lines", "footnote"]
+    },
+    "placement": {
+      "$comment": "Keys that sit on the LAYER rather than under `card`, though a preset may set them for a role.",
+      "keys": ["rect", "pop", "fade", "atMs", "untilMs", "enter", "exit"]
+    },
+    "music": {
+      "$comment": "Unvalidated until now, so a typo here was accepted in silence -- the exact failure the rest of this file prevents.",
+      "keys": ["moods"]
+    },
+    "rhythm": {
+      "keys": ["bpm", "fps"]
+    },
+    "format": {
+      "$comment": "Format frontmatter. All values are free text: `scenes: 3-6` is a human range, not a structure.",
+      "keys": [
+        "name",
+        "title",
+        "description",
+        "aspect",
+        "alsoWorks",
+        "scenes",
+        "sceneSeconds",
+        "captions",
+        "narration",
+        "music",
+        "needs"
+      ]
+    }
+  },
+  "enums": {
+    "aspect": {
+      "$comment": "`source` is a real answer: a format built on the user's own footage keeps its frame.",
+      "values": ["9:16", "16:9", "1:1", "4:5", "source"]
+    }
+  }
+}

--- a/src/video_studio/project/keyspace.py
+++ b/src/video_studio/project/keyspace.py
@@ -1,0 +1,53 @@
+"""The key names a preset, a format and a storyboard card may use.
+
+One authored file, ``keyspace.json``, read by everything that validates against
+it. Before this, ``styles.py`` and ``formats.py`` each held their own literals
+and ``scrollmark/editor`` held a third copy in TypeScript -- three lists that
+agreed only because somebody remembered to change all three.
+
+Read from disk at import: no build step, no network, and the editor's toolchain
+never has to run Python. The editor generates ``packs/keyspace.generated.ts``
+from this same file and a CI job fails when the two drift.
+
+Only names and closed value sets live here. Types, units and the reasoning
+behind them stay on whichever side needs them -- generating zod constraints
+from this would produce a worse version of something that already works.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+PATH = Path(__file__).resolve().parent / "keyspace.json"
+
+_DATA = json.loads(PATH.read_text())
+
+VERSION: str = _DATA["version"]
+
+
+def space(name: str) -> set[str]:
+    """The key names in one space.
+
+    Raises rather than returning an empty set for an unknown name: a space that
+    silently has no keys accepts everything, which turns a validator into a
+    formality and is the failure this whole file exists to prevent.
+    """
+    try:
+        return set(_DATA["spaces"][name]["keys"])
+    except KeyError:
+        raise KeyError(
+            f"{name} is not a key space in {PATH.name}; "
+            f"known: {', '.join(sorted(_DATA['spaces']))}"
+        ) from None
+
+
+def enum(name: str) -> set[str]:
+    """The permitted values of one closed set."""
+    try:
+        return set(_DATA["enums"][name]["values"])
+    except KeyError:
+        raise KeyError(
+            f"{name} is not an enum in {PATH.name}; "
+            f"known: {', '.join(sorted(_DATA['enums']))}"
+        ) from None

--- a/src/video_studio/project/styles.py
+++ b/src/video_studio/project/styles.py
@@ -44,22 +44,34 @@ import sys
 from pathlib import Path
 
 from video_studio.paths import studio_root
+from video_studio.project import keyspace
 
 SKILL_ROOT = studio_root()
 USER_STYLES = Path.home() / ".config" / "video-studio" / "styles"
 
+#: The key names, read rather than retyped.
+#:
+#: These lists used to live here as literals and again in TypeScript, in
+#: scrollmark/editor, and stayed in step only because somebody remembered to
+#: change both. They are one authored file now -- ``keyspace.json`` beside this
+#: module -- which the editor generates its copy from. Loaded at import from
+#: disk, so there is no build step, no network, and no Python in the editor's
+#: toolchain.
+KEYSPACE_VERSION = keyspace.VERSION
+
 #: Keys the composer actually renders for captions. Anything else in a preset
 #: is a typo, and a typo that renders as nothing is the expensive kind.
-CAPTION_KEYS = {"color", "highlight", "fontFamily", "palette", "stroke",
-                "strokeWidth", "fontSize", "bounce", "wiggle", "uppercase",
-                "bottom", "wordsPerPage", "wordGap"}
-#: Card keys the composer renders, plus the placement keys that sit beside it.
-CARD_KEYS = {"bg", "fg", "tracking", "fontSize", "align", "size",
-             # The face, as of scrollmark/editor#175. Before it, a card could
-             # pick its colours and its size and then drew Inter whatever it
-             # asked for -- which is most of what a design template is.
-             "fontFamily", "italic", "weight", "flat"}
-PLACEMENT_KEYS = {"rect", "pop", "fade", "atMs", "untilMs", "enter", "exit"}
+CAPTION_KEYS = keyspace.space("caption")
+#: How a card LOOKS -- what a preset is allowed to set.
+CARD_KEYS = keyspace.space("cardStyle")
+#: What a card SAYS. A preset supplying these would be writing the video's
+#: words, so ``validate`` names them specifically rather than lumping them in
+#: with a misspelling: "that is content, not style" is a more useful thing to
+#: be told than "that is not a card key".
+CARD_CONTENT_KEYS = keyspace.space("cardContent")
+PLACEMENT_KEYS = keyspace.space("placement")
+MUSIC_KEYS = keyspace.space("music")
+RHYTHM_KEYS = keyspace.space("rhythm")
 
 
 #: Presets shipped inside the installed package. Lowest precedence of all, so
@@ -131,8 +143,28 @@ def validate(values: dict) -> list[str]:
             problems.append(f"captions.{k} is not a caption key the composer renders")
     for role, spec in values.get("cards", {}).items():
         for k in spec:
-            if k not in CARD_KEYS | PLACEMENT_KEYS:
+            if k in CARD_CONTENT_KEYS:
+                # Worth its own sentence. This one is not a typo -- it is a
+                # real card key, used in the wrong place, and "not a card key"
+                # would send someone looking for a misspelling that is not
+                # there. A preset styles every card of a role; the words
+                # belong to the one scene that says them.
+                problems.append(
+                    f"cards.{role}.{k} is card CONTENT, not style: a preset sets "
+                    f"how a card looks, and the scene sets what it says")
+            elif k not in CARD_KEYS | PLACEMENT_KEYS:
                 problems.append(f"cards.{role}.{k} is not a card or placement key")
+    # `music` and `rhythm` went unchecked until scrollmark/editor's pack work
+    # went looking for the key space and found that half of it was never
+    # validated: eleven presets set them, and a typo in one was accepted in
+    # silence -- precisely the failure the captions and cards checks exist to
+    # prevent, sitting two keys away from them.
+    for k in values.get("music", {}):
+        if k not in MUSIC_KEYS:
+            problems.append(f"music.{k} is not a music key")
+    for k in values.get("rhythm", {}):
+        if k not in RHYTHM_KEYS:
+            problems.append(f"rhythm.{k} is not a rhythm key")
     return problems
 
 

--- a/tests/unit/test_keyspace.py
+++ b/tests/unit/test_keyspace.py
@@ -1,0 +1,85 @@
+"""One authored list of key names, read rather than retyped.
+
+The lists in `styles.py` and `formats.py` used to be literals, and
+`scrollmark/editor` held a third copy in TypeScript. Three copies agreed only
+because somebody remembered to change all three, and nothing would have said so
+if they stopped agreeing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from video_studio.project import formats, keyspace, styles
+
+STYLES_DIR = Path(__file__).resolve().parents[2] / "src" / "video_studio" / "styles"
+
+
+def test_the_modules_read_the_file_rather_than_their_own_copy():
+    """Every derived set is exactly its space. A literal that drifted back into
+    one of these modules would show up here rather than at render time."""
+    assert styles.CAPTION_KEYS == keyspace.space("caption")
+    assert styles.CARD_KEYS == keyspace.space("cardStyle")
+    assert styles.CARD_CONTENT_KEYS == keyspace.space("cardContent")
+    assert styles.PLACEMENT_KEYS == keyspace.space("placement")
+    assert styles.MUSIC_KEYS == keyspace.space("music")
+    assert styles.RHYTHM_KEYS == keyspace.space("rhythm")
+    assert formats.FORMAT_KEYS == keyspace.space("format")
+    assert formats.ASPECTS == keyspace.enum("aspect")
+
+
+def test_style_and_content_keys_never_overlap():
+    """The invariant the split rests on.
+
+    `card` is how a card looks and `cardContent` is what it says. If a name
+    ever appeared in both, `validate` would report it as content and refuse a
+    preset that was legitimately styling it -- so the two lists being disjoint
+    is load-bearing, not tidiness.
+    """
+    assert keyspace.space("cardStyle") & keyspace.space("cardContent") == set()
+
+
+def test_an_unknown_space_raises_rather_than_accepting_everything():
+    """A space that quietly returned an empty set would accept every key and
+    turn its validator into a formality."""
+    with pytest.raises(KeyError, match="not a key space"):
+        keyspace.space("no-such-space")
+    with pytest.raises(KeyError, match="not an enum"):
+        keyspace.enum("no-such-enum")
+
+
+def test_a_preset_setting_card_content_is_told_which_mistake_it_made():
+    """`heading` is a real card key used in the wrong place, not a typo, and
+    saying "not a card key" sends someone hunting for a misspelling."""
+    problems = styles.validate({"cards": {"title": {"heading": "TOKYO"}}})
+    assert len(problems) == 1
+    assert "CONTENT, not style" in problems[0]
+
+
+def test_music_and_rhythm_are_checked_at_all():
+    """They were not, until this change. Eleven presets set them, so a typo
+    there was accepted in silence two keys away from checks that would have
+    caught the same mistake anywhere else."""
+    problems = styles.validate({"music": {"mood": ["warm"]}, "rhythm": {"fpss": 30}})
+    assert problems == [
+        "music.mood is not a music key",
+        "rhythm.fpss is not a rhythm key",
+    ]
+
+
+def test_every_shipped_preset_still_validates():
+    """The regression guard for widening validation: turning on `music` and
+    `rhythm` must not have made any preset we ship invalid."""
+    failures = {}
+    for path in sorted(STYLES_DIR.glob("*.md")):
+        block = re.search(r"```json\n(.*?)```", path.read_text(), re.S)
+        if not block:
+            continue
+        problems = styles.validate(json.loads(block.group(1)))
+        if problems:
+            failures[path.stem] = problems
+    assert failures == {}

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -104,6 +104,26 @@ def test_wheel_ships_package_data(tmp_path, subdir, minimum):
     assert len(found) >= minimum, f"{subdir}: expected >={minimum} data files in the wheel, got {len(found)}"
 
 
+def test_wheel_ships_the_keyspace(tmp_path):
+    """`keyspace.json` is read at IMPORT, not on demand.
+
+    Every other data file in this package is read when something asks for it,
+    so a missing one is a failure in one command. This one is loaded when
+    `video_studio.project.keyspace` is imported, which `styles` and `formats`
+    both do at module level -- so leaving it out of the wheel is an ImportError
+    for every installed user, on every command, not a missing preset.
+    """
+    r = subprocess.run([sys.executable, "-m", "build", "--wheel", "--outdir", str(tmp_path)],
+                       capture_output=True, text=True, cwd=REPO)
+    if r.returncode != 0:
+        pytest.skip(f"wheel build unavailable: {r.stderr[-200:]}")
+    wheel = sorted(tmp_path.glob("*.whl"))[-1]
+    names = zipfile.ZipFile(wheel).namelist()
+    assert any(n.endswith("video_studio/project/keyspace.json") for n in names), (
+        f"keyspace.json is not in the wheel; project/ holds: "
+        f"{[n for n in names if '/project/' in n]}")
+
+
 def test_every_skill_has_at_least_one_scenario():
     """TESTING.md states this rule; nothing enforced it, and 9 of 16 skills
     were missing one — all of them arrivals from the consolidation, which is


### PR DESCRIPTION
PR 1 of the template-packs plan: stop maintaining the same key lists in two languages across two repositories.

`styles.py` and `formats.py` each held their own literals, and `scrollmark/editor` holds a third copy in TypeScript. `keyspace.json` is the authored copy now, read at import by a small `keyspace` module both programs use — no build step, no network, and the editor's toolchain still never runs Python (it generates its own module from this file; the CI drift job lands with the editor half).

Only **names and closed value sets** live there. Types, units and the reasoning behind them stay on whichever side needs them — generating zod constraints from this would produce a worse version of something that already works.

### Two things fell out of writing it down

**`music` and `rhythm` were never validated.** `validate()` only ever walked `captions` and `cards`. Eleven presets set `music.moods` / `rhythm.bpm`, so a typo in either was accepted in silence — two keys away from checks that exist to prevent exactly that. Now checked; all 29 shipped presets still pass (there's a regression test for that).

**The card keys are two lists, not one.** The editor's fourteen include `heading`, `subtext`, `lines`, `footnote`; this module's ten don't — and that difference is deliberate, not drift. A preset says how a card *looks*; the scene says what it *says*. Unifying them, which is what "the same list maintained twice" implied, would have let a preset write the video's words. They're `card` and `cardContent`, their disjointness is asserted (it's load-bearing: an overlap would make `validate` refuse a preset that was legitimately styling a key), and a preset setting `heading` is now told which mistake it made rather than sent hunting for a misspelling that isn't there.

### Packaging

`keyspace.json` is read at **import**, not on demand — so unlike every other data file here, leaving it out of the wheel is an ImportError on every command for every installed user. The packaging test builds the wheel and checks for it; I confirmed by hand that it's in there and that the test isn't silently skipping.

### Verification

`pytest tests/unit` 132 passed. All 29 presets validate clean. `video-studio formats --list` still lists 11.