### PR TITLE
Stop the pack recording a commit it cannot know

### DIFF
--- a/packs/scrollmark-core@1.0.0.json
+++ b/packs/scrollmark-core@1.0.0.json
@@ -11,8 +11,7 @@
     "holder": "Scrollmark"
   },
   "provenance": {
-    "repo": "scrollmark/social-skills",
-    "commit": "e58f849d5fdb0ba13e90b6778f74125ed795ac64"
+    "repo": "scrollmark/social-skills"
   },
   "assets": [
     {

--- a/scripts/build-packs.py
+++ b/scripts/build-packs.py
@@ -25,7 +25,6 @@ import argparse
 import hashlib
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -179,15 +178,6 @@ def format_assets(problems: list[str]) -> list[dict]:
     return assets
 
 
-def commit() -> str:
-    try:
-        return subprocess.run(
-            ["git", "rev-parse", "HEAD"], cwd=ROOT, capture_output=True, text=True, check=True
-        ).stdout.strip()
-    except Exception:  # noqa: BLE001 -- provenance is nice to have, not required
-        return ""
-
-
 def build() -> tuple[dict, dict, list[str]]:
     problems: list[str] = []
     assets = style_assets(problems) + format_assets(problems)
@@ -201,7 +191,12 @@ def build() -> tuple[dict, dict, list[str]]:
         "keyspace": keyspace.VERSION,
         "tier": "free",
         "license": {"spdx": "CC-BY-4.0", "holder": "Scrollmark"},
-        "provenance": {"repo": "scrollmark/social-skills", "commit": commit()},
+        # No commit SHA and no timestamp. Both change on every build, and this
+        # file is COMMITTED and compared against a rebuild -- so either one
+        # makes the drift check fail forever, which is exactly what happened:
+        # the SHA recorded is necessarily the one BEFORE the commit that
+        # carries it, so it could never be right either.
+        "provenance": {"repo": "scrollmark/social-skills"},
         "assets": assets,
     }
 
@@ -223,7 +218,7 @@ def build() -> tuple[dict, dict, list[str]]:
                 "description": pack["description"],
                 "tier": pack["tier"],
                 "assetCounts": counts,
-                "digest": digest({k: v for k, v in pack.items() if k != "provenance"}),
+        "digest": digest({k: v for k, v in pack.items() if k != "provenance"}),
                 "url": f"{PACK_ID}@{PACK_VERSION}.json",
             }
         ],

--- a/tests/unit/test_packs.py
+++ b/tests/unit/test_packs.py
@@ -40,6 +40,22 @@ def test_the_committed_pack_matches_the_presets():
     assert result.returncode == 0, result.stderr
 
 
+def test_the_pack_records_nothing_that_changes_between_builds(pack: dict):
+    """No timestamp, and no commit SHA.
+
+    Both change on every build, and this file is COMMITTED and compared against
+    a rebuild -- so either one makes the drift check fail forever. It did: the
+    first version embedded `git rev-parse HEAD`, which is necessarily the
+    commit BEFORE the one carrying it, so it could never have been right
+    either. CI caught it; the local run could not, because locally HEAD had not
+    moved since the build.
+    """
+    volatile = {"commit", "builtAt", "generatedAt", "timestamp"}
+    assert set(pack.get("provenance", {})) & volatile == set()
+    index = json.loads((DIST / "index.json").read_text())
+    assert set(index) & volatile == set()
+
+
 def test_the_build_is_deterministic():
     """`--check` compares a rebuild against the committed file, so a build that
     changed nothing must produce an identical one -- otherwise the check


### PR DESCRIPTION
**Fixes master, which #52 left red.** I merged it with a failing `test` check — there's no branch protection to have stopped me, and I should have looked before merging rather than after.

The drift check failed in CI the moment #52 landed, and **could not have failed locally**: the pack embedded `provenance.commit` from `git rev-parse HEAD`, so a rebuild after any new commit differs from the committed file. Locally HEAD hadn't moved since the build, so it passed.

The SHA could never have been right anyway — it's necessarily the commit *before* the one carrying it, so the artefact claimed to be built from a commit that doesn't contain it.

I'd avoided a timestamp in the index for exactly this reason (a build that changed nothing must produce identical output, or `--check` reports drift on every run and stops meaning anything) and then put a commit SHA in the pack, which is the same mistake wearing a different field name.

Provenance keeps `repo`, which doesn't move. A new test asserts that neither the pack nor the index carries any field that changes between builds — named rather than described, so the next volatile field has to argue with a test.

Verified the way CI does it: build, commit something else, re-check — still current. `pytest tests/unit/test_packs.py` 9 passed.