### PR TITLE
Author title scenes as layouts, so every preset can wear them

### DIFF
--- a/packs/index.json
+++ b/packs/index.json
@@ -1,6 +1,6 @@
 {
   "format": "scrollmark.packindex/1",
-  "keyspace": "1.0.0",
+  "keyspace": "1.1.0",
   "packs": [
     {
       "id": "scrollmark-core",
@@ -10,9 +10,10 @@
       "tier": "free",
       "assetCounts": {
         "style": 29,
-        "format": 11
+        "format": 11,
+        "title-scene": 3
       },
-      "digest": "sha256-43d0b2f75c7459384fb99671c251f398338349f7971d7f915571fe35311d53e9",
+      "digest": "sha256-144eaa4e1cbdb17cc01e995aa20f1d881a3de49ee43ebd6acc8b1718112daa6f",
       "url": "scrollmark-core@1.0.0.json"
     }
   ]

--- a/packs/scrollmark-core@1.0.0.json
+++ b/packs/scrollmark-core@1.0.0.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "name": "Scrollmark Core",
   "description": "The looks and shapes this repository ships.",
-  "keyspace": "1.0.0",
+  "keyspace": "1.1.0",
   "tier": "free",
   "license": {
     "spdx": "CC-BY-4.0",
@@ -2342,6 +2342,63 @@
         "aspect": "source",
         "captions": "optional",
         "needs": "measure"
+      }
+    },
+    {
+      "id": "title-scene/chapter-break",
+      "kind": "title-scene",
+      "name": "chapter-break",
+      "description": "A number and a name, for the cut between sections",
+      "guidance": "# chapter-break\n\nThe card that says where you are. A `stat` layer for the number and a `title`\nlayer for the section name, in that order — the number is the backdrop and the\nname draws over it.\n\nShorter than the opening card on purpose. A chapter break is read in transit;\nit is punctuation, not a scene. At two seconds it starts to feel like the video\nhas stopped.\n\nUse it when the format has named sections — `daily-recap` and `how-to` both do.\nDo not use it to pad a video that has one continuous thought: a break between\nnothing and nothing reads as a mistake.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-dad01a32cb5743b0084077915b28411062b02824f379840b2d6783a6f9f92fbd",
+      "values": {
+        "seconds": 1.5,
+        "layers": [
+          {
+            "role": "stat"
+          },
+          {
+            "role": "title"
+          }
+        ]
+      }
+    },
+    {
+      "id": "title-scene/close-cta",
+      "kind": "title-scene",
+      "name": "close-cta",
+      "description": "The closing line, inverted, over the last beat",
+      "guidance": "# close-cta\n\nThe last card. One `cta` layer — which every preset styles as the inverse of\nits title, so the close reads as the open's answer rather than a repeat of it.\n\nTwo seconds, matching `open-wordmark`, because the pair is what makes a series\nrecognisable. A close that runs long is the second most common reason a recap\nloses its ending: the payoff has landed and the video is still going.\n\n**This asks for something.** Write the line as an instruction a person can act\non in the next five seconds — \"save this for Sunday\" beats \"follow for more\".\nThe words are the scene's; the preset supplies only the treatment.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-079623b4bb6448ece3699f9fc13feed88b4deced751b2592a5fb71f266048f0e",
+      "values": {
+        "seconds": 2,
+        "layers": [
+          {
+            "role": "cta"
+          }
+        ]
+      }
+    },
+    {
+      "id": "title-scene/open-wordmark",
+      "kind": "title-scene",
+      "name": "open-wordmark",
+      "description": "The wordmark alone, centre frame, for the first two seconds",
+      "guidance": "# open-wordmark\n\nThe opening card. One `title` layer and nothing else, held long enough to read\nand short enough that a viewer who already knows the channel is not waiting.\n\nIt carries no style of its own. A title scene is a LAYOUT, and every preset in\nthis library can wear it — `tourism` renders it as a wordmark on brand colour,\n`analog-editorial` as type on paper. Binding one layout to one look would mean\nauthoring this file twenty-nine times, and would make \"open this in the look\nthe video already uses\" impossible to ask for.\n\n**Two seconds is the whole argument.** A title that outstays it is the most\ncommon reason a recap loses its first viewer: the shape of the video is not yet\nvisible, so there is nothing to stay for. If the wordmark needs longer, it\nneeds a shot behind it, which is a different scene.\n\nThe words are the scene's. `heading` is what the layer says, and no preset may\nsupply it.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-02be7a95b7cd6366fa47c2a5db103dcb49cabc19f984fd509c1eed95a2db0af8",
+      "values": {
+        "seconds": 2,
+        "layers": [
+          {
+            "role": "title"
+          }
+        ]
       }
     }
   ]

--- a/scripts/build-packs.py
+++ b/scripts/build-packs.py
@@ -31,6 +31,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 STYLES = ROOT / "src" / "video_studio" / "styles"
 FORMATS = ROOT / "skills" / "video-formats" / "references" / "formats"
+TITLE_SCENES = ROOT / "src" / "video_studio" / "title_scenes"
 #: Committed, at the repo root rather than under `dist/`, which is gitignored
 #: as the Python build output -- putting the packs there would have published
 #: nothing at all. Consumers read it over raw.githubusercontent.com, the same
@@ -178,9 +179,83 @@ def format_assets(problems: list[str]) -> list[dict]:
     return assets
 
 
+def title_scene_assets(problems: list[str]) -> list[dict]:
+    """Layouts, not looks.
+
+    A title scene names roles and leaves both the treatment and the words to
+    someone else: the treatment to whichever style it is dressed in at apply
+    time, the words to the scene. That is why none of these files carries a
+    `styleRef` -- binding a layout to one of the 29 presets would mean writing
+    the same three files 29 times, and would make "open this in the look the
+    video already uses" impossible to ask for.
+    """
+    assets = []
+    known = keyspace.space("titleScene")
+    layer_keys = keyspace.space("titleSceneLayer")
+    for path in sorted(TITLE_SCENES.glob("*.md")):
+        text = path.read_text()
+        values = json_block(text)
+        meta = frontmatter(text)
+        if values is None:
+            problems.append(f"{path.name}: no json block")
+            continue
+        unknown = sorted(set(values) - known)
+        if unknown:
+            problems.append(f"{path.name}: not title-scene keys: {', '.join(unknown)}")
+            continue
+        if not isinstance(values.get("seconds"), (int, float)):
+            problems.append(f"{path.name}: seconds must be a number")
+            continue
+        layers = values.get("layers")
+        if not isinstance(layers, list) or not layers:
+            problems.append(f"{path.name}: needs at least one layer")
+            continue
+        bad = False
+        for index, layer in enumerate(layers):
+            if not isinstance(layer, dict) or not layer.get("role"):
+                problems.append(f"{path.name}: layer {index} has no role")
+                bad = True
+                continue
+            stray = sorted(set(layer) - layer_keys)
+            if stray:
+                problems.append(
+                    f"{path.name}: layer {index} sets {', '.join(stray)}, "
+                    "which is not a layer key"
+                )
+                bad = True
+            # The same line styles.py draws, from the other side. A layout that
+            # shipped `text` would be the pack writing the video's words, and
+            # the editor would render it as a deliberate choice.
+            if "text" in layer:
+                problems.append(
+                    f"{path.name}: layer {index} sets text; the words belong to the scene"
+                )
+                bad = True
+        if bad:
+            continue
+        assets.append(
+            {
+                "id": f"title-scene/{path.stem}",
+                "kind": "title-scene",
+                "name": meta.get("name", path.stem),
+                "description": meta.get("description", ""),
+                "guidance": guidance(text),
+                "status": "stable",
+                "revision": 1,
+                "digest": digest(values),
+                "values": values,
+            }
+        )
+    return assets
+
+
 def build() -> tuple[dict, dict, list[str]]:
     problems: list[str] = []
-    assets = style_assets(problems) + format_assets(problems)
+    assets = (
+        style_assets(problems)
+        + format_assets(problems)
+        + title_scene_assets(problems)
+    )
 
     pack = {
         "format": PACK_FORMAT,

--- a/src/video_studio/project/keyspace.json
+++ b/src/video_studio/project/keyspace.json
@@ -19,7 +19,7 @@
     "the render, and misleads whoever edits it next. Add a space when something",
     "starts validating against it, not in anticipation."
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "spaces": {
     "caption": {
       "$comment": "Caption keys the composer renders. Mirrored by captionStyleSchema in the editor's storyboard/captions.ts.",
@@ -68,18 +68,36 @@
         "the editor's guards need card and cardContent together to tell a",
         "mistyped key from a legitimate one."
       ],
-      "keys": ["heading", "subtext", "lines", "footnote"]
+      "keys": [
+        "heading",
+        "subtext",
+        "lines",
+        "footnote"
+      ]
     },
     "placement": {
       "$comment": "Keys that sit on the LAYER rather than under `card`, though a preset may set them for a role.",
-      "keys": ["rect", "pop", "fade", "atMs", "untilMs", "enter", "exit"]
+      "keys": [
+        "rect",
+        "pop",
+        "fade",
+        "atMs",
+        "untilMs",
+        "enter",
+        "exit"
+      ]
     },
     "music": {
       "$comment": "Unvalidated until now, so a typo here was accepted in silence -- the exact failure the rest of this file prevents.",
-      "keys": ["moods"]
+      "keys": [
+        "moods"
+      ]
     },
     "rhythm": {
-      "keys": ["bpm", "fps"]
+      "keys": [
+        "bpm",
+        "fps"
+      ]
     },
     "format": {
       "$comment": "Format frontmatter. All values are free text: `scenes: 3-6` is a human range, not a structure.",
@@ -96,12 +114,48 @@
         "music",
         "needs"
       ]
+    },
+    "titleSceneLayer": {
+      "$comment": [
+        "What one layer of a title scene may say. A layer names a ROLE and, at",
+        "most, when it appears and where -- never what it looks like, which comes",
+        "from the style the scene is dressed in, and never what it says, which is",
+        "the scene's own words supplied at apply time."
+      ],
+      "keys": [
+        "role",
+        "text",
+        "rect",
+        "atMs",
+        "untilMs",
+        "pop"
+      ]
+    },
+    "titleScene": {
+      "$comment": [
+        "The scene itself. `styleRef` is optional and usually absent: a title scene",
+        "is a LAYOUT that every preset can wear, and binding one to one look would",
+        "mean authoring the same three files twenty-nine times."
+      ],
+      "keys": [
+        "seconds",
+        "styleRef",
+        "overlayRef",
+        "layers",
+        "sfxRefs"
+      ]
     }
   },
   "enums": {
     "aspect": {
       "$comment": "`source` is a real answer: a format built on the user's own footage keeps its frame.",
-      "values": ["9:16", "16:9", "1:1", "4:5", "source"]
+      "values": [
+        "9:16",
+        "16:9",
+        "1:1",
+        "4:5",
+        "source"
+      ]
     }
   }
 }

--- a/src/video_studio/title_scenes/chapter-break.md
+++ b/src/video_studio/title_scenes/chapter-break.md
@@ -1,0 +1,29 @@
+---
+name: chapter-break
+description: A number and a name, for the cut between sections
+seconds: 1.5
+---
+
+# chapter-break
+
+The card that says where you are. A `stat` layer for the number and a `title`
+layer for the section name, in that order — the number is the backdrop and the
+name draws over it.
+
+Shorter than the opening card on purpose. A chapter break is read in transit;
+it is punctuation, not a scene. At two seconds it starts to feel like the video
+has stopped.
+
+Use it when the format has named sections — `daily-recap` and `how-to` both do.
+Do not use it to pad a video that has one continuous thought: a break between
+nothing and nothing reads as a mistake.
+
+```json
+{
+  "seconds": 1.5,
+  "layers": [
+    { "role": "stat" },
+    { "role": "title" }
+  ]
+}
+```

--- a/src/video_studio/title_scenes/close-cta.md
+++ b/src/video_studio/title_scenes/close-cta.md
@@ -1,0 +1,27 @@
+---
+name: close-cta
+description: The closing line, inverted, over the last beat
+seconds: 2
+---
+
+# close-cta
+
+The last card. One `cta` layer — which every preset styles as the inverse of
+its title, so the close reads as the open's answer rather than a repeat of it.
+
+Two seconds, matching `open-wordmark`, because the pair is what makes a series
+recognisable. A close that runs long is the second most common reason a recap
+loses its ending: the payoff has landed and the video is still going.
+
+**This asks for something.** Write the line as an instruction a person can act
+on in the next five seconds — "save this for Sunday" beats "follow for more".
+The words are the scene's; the preset supplies only the treatment.
+
+```json
+{
+  "seconds": 2,
+  "layers": [
+    { "role": "cta" }
+  ]
+}
+```

--- a/src/video_studio/title_scenes/open-wordmark.md
+++ b/src/video_studio/title_scenes/open-wordmark.md
@@ -1,0 +1,33 @@
+---
+name: open-wordmark
+description: The wordmark alone, centre frame, for the first two seconds
+seconds: 2
+---
+
+# open-wordmark
+
+The opening card. One `title` layer and nothing else, held long enough to read
+and short enough that a viewer who already knows the channel is not waiting.
+
+It carries no style of its own. A title scene is a LAYOUT, and every preset in
+this library can wear it — `tourism` renders it as a wordmark on brand colour,
+`analog-editorial` as type on paper. Binding one layout to one look would mean
+authoring this file twenty-nine times, and would make "open this in the look
+the video already uses" impossible to ask for.
+
+**Two seconds is the whole argument.** A title that outstays it is the most
+common reason a recap loses its first viewer: the shape of the video is not yet
+visible, so there is nothing to stay for. If the wordmark needs longer, it
+needs a shot behind it, which is a different scene.
+
+The words are the scene's. `heading` is what the layer says, and no preset may
+supply it.
+
+```json
+{
+  "seconds": 2,
+  "layers": [
+    { "role": "title" }
+  ]
+}
+```

--- a/tests/unit/test_packs.py
+++ b/tests/unit/test_packs.py
@@ -129,3 +129,55 @@ def test_the_index_points_at_a_file_that_exists(pack: dict):
     for entry in index["packs"]:
         assert (DIST / entry["url"]).exists()
         assert sum(entry["assetCounts"].values()) == len(pack["assets"])
+
+
+class TestTitleScenes:
+    """Layouts, and the two things they must never carry."""
+
+    def scenes(self, pack: dict) -> list[dict]:
+        return [a for a in pack["assets"] if a["kind"] == "title-scene"]
+
+    def test_they_are_in_the_pack(self, pack: dict) -> None:
+        assert self.scenes(pack), "title scenes are authored but not compiled"
+
+    def test_none_binds_itself_to_a_style(self, pack: dict) -> None:
+        # A title scene is a LAYOUT and every preset can wear it. One that
+        # named a style would have to be written 29 times, and would make
+        # "open this in the look the video already uses" impossible to ask
+        # for -- the editor's applier takes the style from the caller.
+        for scene in self.scenes(pack):
+            assert "styleRef" not in scene["values"], scene["id"]
+
+    def test_none_writes_the_video_s_words(self, pack: dict) -> None:
+        # The same line styles.py draws, from the other side. A layout
+        # shipping `text` would put the pack's copy in someone's video and
+        # the editor would render it as a deliberate choice.
+        for scene in self.scenes(pack):
+            for layer in scene["values"]["layers"]:
+                assert "text" not in layer, scene["id"]
+
+    def test_every_layer_names_a_role(self, pack: dict) -> None:
+        for scene in self.scenes(pack):
+            assert scene["values"]["layers"]
+            for layer in scene["values"]["layers"]:
+                assert layer.get("role"), scene["id"]
+
+    def test_every_role_is_one_some_preset_styles(self, pack: dict) -> None:
+        # Otherwise the scene compiles, ships, and rejects every layer at
+        # apply time for a reason nobody sees until they try it.
+        styled = {
+            role
+            for asset in pack["assets"]
+            if asset["kind"] == "style"
+            for role in (asset["values"].get("cards") or {})
+        }
+        for scene in self.scenes(pack):
+            for layer in scene["values"]["layers"]:
+                assert layer["role"] in styled, f"{scene['id']}: {layer['role']}"
+
+    def test_guidance_survives_the_compile(self, pack: dict) -> None:
+        # The prose is the only place "when to reach for this" has ever
+        # lived, and it is the same string the editor shows a person and
+        # hands an agent.
+        for scene in self.scenes(pack):
+            assert len(scene["guidance"]) > 200, scene["id"]


### PR DESCRIPTION
Three title scenes — an opening wordmark, a chapter break, a closing line — and **not one names a style**.

### That is the design, not an omission

A title scene is a **layout**. It names roles and leaves the treatment to whichever preset dresses it at apply time.

Binding a layout to one of the 29 presets would mean writing the same three files 29 times — and would make the thing people actually want, *"open this in the look the video already uses"*, impossible to express. The editor's applier takes the style from the caller and falls back to the asset's own default, which these deliberately do not set.

### The other thing they must never carry

Words. A layer that shipped `text` would put this repository's copy in somebody's video, and the editor would render it as a deliberate choice. The build refuses it **by name** — the same line `styles.py` already draws from the other side when it rejects a preset that sets `heading`.

### Two new key spaces

`titleScene` and `titleSceneLayer`, so both refusals check against an authored list rather than a literal inside one script. Keyspace to **1.1.0**: names were added, and the editor's generated copy follows in `scrollmark/editor`.

### The test worth having

Every role a title scene names must be one that some preset actually styles. Without it a scene compiles, ships, and then rejects every layer at apply time for a reason nobody sees until they try it.

### Verification

`build-packs.py --check` clean · 43 assets (29 style, 11 format, 3 title-scene) · `pytest` 141 passed.