### PR TITLE
Move the gallery's 21 curated pairings into the pack

### DIFF
--- a/packs/index.json
+++ b/packs/index.json
@@ -1,6 +1,6 @@
 {
   "format": "scrollmark.packindex/1",
-  "keyspace": "1.1.0",
+  "keyspace": "1.2.0",
   "packs": [
     {
       "id": "scrollmark-core",
@@ -11,9 +11,10 @@
       "assetCounts": {
         "style": 29,
         "format": 11,
-        "title-scene": 3
+        "title-scene": 3,
+        "template": 21
       },
-      "digest": "sha256-144eaa4e1cbdb17cc01e995aa20f1d881a3de49ee43ebd6acc8b1718112daa6f",
+      "digest": "sha256-caa0d94ef8e1f482a7655e7eb84d8ddfbfca501c0bfade25de372b1170da9d44",
       "url": "scrollmark-core@1.0.0.json"
     }
   ]

--- a/packs/scrollmark-core@1.0.0.json
+++ b/packs/scrollmark-core@1.0.0.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "name": "Scrollmark Core",
   "description": "The looks and shapes this repository ships.",
-  "keyspace": "1.1.0",
+  "keyspace": "1.2.0",
   "tier": "free",
   "license": {
     "spdx": "CC-BY-4.0",
@@ -2399,6 +2399,341 @@
             "role": "title"
           }
         ]
+      }
+    },
+    {
+      "id": "template/brand-origin-editorial-sage",
+      "kind": "template",
+      "name": "brand-origin-editorial-sage",
+      "description": "A Didone line and one script word, cream on a flat colour field.",
+      "guidance": "# brand-origin-editorial-sage\n\nA Didone line and one script word, cream on a flat colour field.\n\n`brand-origin` is the shape and `editorial-sage` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/brand-origin` for the structure and `style/editorial-sage` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-db9d6536fab666f52c418f165d272dbe92c7cabe13bfc3fa65284c4dcb50f0e6",
+      "values": {
+        "formatRef": "format/brand-origin",
+        "styleRef": "style/editorial-sage",
+        "why": "A Didone line and one script word, cream on a flat colour field.",
+        "previewCopy": {
+          "title": "THE everything you need",
+          "caption": "01 / 12"
+        }
+      }
+    },
+    {
+      "id": "template/brand-origin-magazine-cover",
+      "kind": "template",
+      "name": "brand-origin-magazine-cover",
+      "description": "One claim, one masthead, one red. Nothing else on screen.",
+      "guidance": "# brand-origin-magazine-cover\n\nOne claim, one masthead, one red. Nothing else on screen.\n\n`brand-origin` is the shape and `magazine-cover` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/brand-origin` for the structure and `style/magazine-cover` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-93fa7ae82d1a8952fa4d313353a162a98d0d1b4eab8383625f3a210d58ac6562",
+      "values": {
+        "formatRef": "format/brand-origin",
+        "styleRef": "style/magazine-cover",
+        "why": "One claim, one masthead, one red. Nothing else on screen."
+      }
+    },
+    {
+      "id": "template/brand-origin-warm-minimal",
+      "kind": "template",
+      "name": "brand-origin-warm-minimal",
+      "description": "One from-here-to-there story, told quietly enough to be believed.",
+      "guidance": "# brand-origin-warm-minimal\n\nOne from-here-to-there story, told quietly enough to be believed.\n\n`brand-origin` is the shape and `warm-minimal` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/brand-origin` for the structure and `style/warm-minimal` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-c0c6b1427a9ab9da7eb4e7634a94f5759bc7a324bbaad63495a48fb55d13a9c3",
+      "values": {
+        "formatRef": "format/brand-origin",
+        "styleRef": "style/warm-minimal",
+        "why": "One from-here-to-there story, told quietly enough to be believed."
+      }
+    },
+    {
+      "id": "template/brand-origin-zine-glitch",
+      "kind": "template",
+      "name": "brand-origin-zine-glitch",
+      "description": "Type photocopied until it breaks, and exactly one red.",
+      "guidance": "# brand-origin-zine-glitch\n\nType photocopied until it breaks, and exactly one red.\n\n`brand-origin` is the shape and `zine-glitch` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/brand-origin` for the structure and `style/zine-glitch` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-5c50edb2fc9d370fedd2c2245fa4c291951d3b002768d2148bee41076f87b3d9",
+      "values": {
+        "formatRef": "format/brand-origin",
+        "styleRef": "style/zine-glitch",
+        "why": "Type photocopied until it breaks, and exactly one red."
+      }
+    },
+    {
+      "id": "template/cinematic-documentary",
+      "kind": "template",
+      "name": "cinematic-documentary",
+      "description": "Cut to the track, captions off, colour left alone. The look is the footage.",
+      "guidance": "# cinematic-documentary\n\nCut to the track, captions off, colour left alone. The look is the footage.\n\n`cinematic` is the shape and `documentary` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/cinematic` for the structure and `style/documentary` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-65f8b95fd02216268efb4a78597e353b68672cff5c0e58ca8e2a07b030bd40b9",
+      "values": {
+        "formatRef": "format/cinematic",
+        "styleRef": "style/documentary",
+        "why": "Cut to the track, captions off, colour left alone. The look is the footage."
+      }
+    },
+    {
+      "id": "template/cinematic-neon-sign",
+      "kind": "template",
+      "name": "cinematic-neon-sign",
+      "description": "One word in struck neon tube, over a street that is already lit.",
+      "guidance": "# cinematic-neon-sign\n\nOne word in struck neon tube, over a street that is already lit.\n\n`cinematic` is the shape and `neon-sign` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/cinematic` for the structure and `style/neon-sign` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-5d25f28a4d60c5d579fcd82575dbc9a82b759f4b2e666a06d6a41242d90170a7",
+      "values": {
+        "formatRef": "format/cinematic",
+        "styleRef": "style/neon-sign",
+        "why": "One word in struck neon tube, over a street that is already lit."
+      }
+    },
+    {
+      "id": "template/cinematic-weekend-gothic",
+      "kind": "template",
+      "name": "cinematic-weekend-gothic",
+      "description": "One blackletter word over neon, and nothing else competing.",
+      "guidance": "# cinematic-weekend-gothic\n\nOne blackletter word over neon, and nothing else competing.\n\n`cinematic` is the shape and `weekend-gothic` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/cinematic` for the structure and `style/weekend-gothic` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-c10c9ff92d22c09ccc7eaab9286a6a055f79b651cbc0f2fdfbdc903c45403ce3",
+      "values": {
+        "formatRef": "format/cinematic",
+        "styleRef": "style/weekend-gothic",
+        "why": "One blackletter word over neon, and nothing else competing.",
+        "previewCopy": {
+          "title": "Weekend",
+          "caption": "added to the list"
+        }
+      }
+    },
+    {
+      "id": "template/daily-recap-pov-serif",
+      "kind": "template",
+      "name": "daily-recap-pov-serif",
+      "description": "Three panels of an afternoon, captioned like a thought rather than a title.",
+      "guidance": "# daily-recap-pov-serif\n\nThree panels of an afternoon, captioned like a thought rather than a title.\n\n`daily-recap` is the shape and `pov-serif` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/daily-recap` for the structure and `style/pov-serif` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-e450b305ce9d58bb223c21a5b1b12c0c859b206ec2437c551ad60971ed78697b",
+      "values": {
+        "formatRef": "format/daily-recap",
+        "styleRef": "style/pov-serif",
+        "why": "Three panels of an afternoon, captioned like a thought rather than a title.",
+        "previewCopy": {
+          "title": "pov: capturing everything so you can rewatch it later",
+          "caption": "three panels, one afternoon"
+        }
+      }
+    },
+    {
+      "id": "template/daily-recap-summer-scrapbook",
+      "kind": "template",
+      "name": "daily-recap-summer-scrapbook",
+      "description": "A season of phone footage, with one sentence worth keeping.",
+      "guidance": "# daily-recap-summer-scrapbook\n\nA season of phone footage, with one sentence worth keeping.\n\n`daily-recap` is the shape and `summer-scrapbook` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/daily-recap` for the structure and `style/summer-scrapbook` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-dd7392045caaed67a6141bec7cdfa5c02b5b34267b5eaf241b0c3f9ac84a4052",
+      "values": {
+        "formatRef": "format/daily-recap",
+        "styleRef": "style/summer-scrapbook",
+        "why": "A season of phone footage, with one sentence worth keeping.",
+        "previewCopy": {
+          "title": "Summer Vibes",
+          "caption": "let the sun melt the stress"
+        }
+      }
+    },
+    {
+      "id": "template/daily-recap-vhs-90s",
+      "kind": "template",
+      "name": "daily-recap-vhs-90s",
+      "description": "A day as a run of short beats, cut on the track, stamped like a camcorder.",
+      "guidance": "# daily-recap-vhs-90s\n\nA day as a run of short beats, cut on the track, stamped like a camcorder.\n\n`daily-recap` is the shape and `vhs-90s` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/daily-recap` for the structure and `style/vhs-90s` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-01147c92d6860127119a862377ccabfa7aa84d05bc239a22cde413c140b96c53",
+      "values": {
+        "formatRef": "format/daily-recap",
+        "styleRef": "style/vhs-90s",
+        "why": "A day as a run of short beats, cut on the track, stamped like a camcorder."
+      }
+    },
+    {
+      "id": "template/daily-recap-wet-paint",
+      "kind": "template",
+      "name": "daily-recap-wet-paint",
+      "description": "Letters that drip, lime on black, for a day with no sincerity in it.",
+      "guidance": "# daily-recap-wet-paint\n\nLetters that drip, lime on black, for a day with no sincerity in it.\n\n`daily-recap` is the shape and `wet-paint` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/daily-recap` for the structure and `style/wet-paint` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-5477e72317a2b689a100eb19326650f5de23e5bcda78243393994d3b034db731",
+      "values": {
+        "formatRef": "format/daily-recap",
+        "styleRef": "style/wet-paint",
+        "why": "Letters that drip, lime on black, for a day with no sincerity in it."
+      }
+    },
+    {
+      "id": "template/explainer-clean-corporate",
+      "kind": "template",
+      "name": "explainer-clean-corporate",
+      "description": "A concept walked through end to end, in the flat palette a deck already uses.",
+      "guidance": "# explainer-clean-corporate\n\nA concept walked through end to end, in the flat palette a deck already uses.\n\n`explainer` is the shape and `clean-corporate` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/explainer` for the structure and `style/clean-corporate` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-c2269d8056e14a5ee5a2623ed8f295429bb9897363b7505bdf2e9b4631d88ed6",
+      "values": {
+        "formatRef": "format/explainer",
+        "styleRef": "style/clean-corporate",
+        "why": "A concept walked through end to end, in the flat palette a deck already uses."
+      }
+    },
+    {
+      "id": "template/product-launch-tech-startup",
+      "kind": "template",
+      "name": "product-launch-tech-startup",
+      "description": "Three capabilities and a name to land, in a palette built to look shipped.",
+      "guidance": "# product-launch-tech-startup\n\nThree capabilities and a name to land, in a palette built to look shipped.\n\n`product-launch` is the shape and `tech-startup` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/product-launch` for the structure and `style/tech-startup` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-1977a2df2746498a28ad022d08dd1179c49f2ca3bd8f1ab54401e0742d4d65a3",
+      "values": {
+        "formatRef": "format/product-launch",
+        "styleRef": "style/tech-startup",
+        "why": "Three capabilities and a name to land, in a palette built to look shipped."
+      }
+    },
+    {
+      "id": "template/talking-head-loud-social",
+      "kind": "template",
+      "name": "talking-head-loud-social",
+      "description": "One person to camera, captions loud enough to work on mute.",
+      "guidance": "# talking-head-loud-social\n\nOne person to camera, captions loud enough to work on mute.\n\n`talking-head` is the shape and `loud-social` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/talking-head` for the structure and `style/loud-social` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-2c20bb088844ceb06523bd807b557a90ac330907f4751f359192500f49e7c98a",
+      "values": {
+        "formatRef": "format/talking-head",
+        "styleRef": "style/loud-social",
+        "why": "One person to camera, captions loud enough to work on mute."
+      }
+    },
+    {
+      "id": "template/talking-head-pov-quiet",
+      "kind": "template",
+      "name": "talking-head-pov-quiet",
+      "description": "A held moment, captioned mid-frame in a voice that does not raise.",
+      "guidance": "# talking-head-pov-quiet\n\nA held moment, captioned mid-frame in a voice that does not raise.\n\n`talking-head` is the shape and `pov-quiet` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/talking-head` for the structure and `style/pov-quiet` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-9c77069f7ba58a4c38672795b83d484566c956f8a9457b3be4b026aac11a26af",
+      "values": {
+        "formatRef": "format/talking-head",
+        "styleRef": "style/pov-quiet",
+        "why": "A held moment, captioned mid-frame in a voice that does not raise."
+      }
+    },
+    {
+      "id": "template/timeline-explainer-3b1b-dark",
+      "kind": "template",
+      "name": "timeline-explainer-3b1b-dark",
+      "description": "Numbered beats on a dark ground, the way a maths lecture counts.",
+      "guidance": "# timeline-explainer-3b1b-dark\n\nNumbered beats on a dark ground, the way a maths lecture counts.\n\n`timeline-explainer` is the shape and `3b1b-dark` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/timeline-explainer` for the structure and `style/3b1b-dark` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-0fcb9ec7a6a0331a6442071d9b5c491e1e5e202cb611f169e280311db3e5f3ad",
+      "values": {
+        "formatRef": "format/timeline-explainer",
+        "styleRef": "style/3b1b-dark",
+        "why": "Numbered beats on a dark ground, the way a maths lecture counts."
+      }
+    },
+    {
+      "id": "template/timeline-explainer-arcade-crt",
+      "kind": "template",
+      "name": "timeline-explainer-arcade-crt",
+      "description": "Phosphor green pixels counting up, the way a score does.",
+      "guidance": "# timeline-explainer-arcade-crt\n\nPhosphor green pixels counting up, the way a score does.\n\n`timeline-explainer` is the shape and `arcade-crt` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/timeline-explainer` for the structure and `style/arcade-crt` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-05a9a9126d8a691c79ccf8622e60f3bd02c5cd5a66adbc58fd5418b05fcd3ccc",
+      "values": {
+        "formatRef": "format/timeline-explainer",
+        "styleRef": "style/arcade-crt",
+        "why": "Phosphor green pixels counting up, the way a score does."
+      }
+    },
+    {
+      "id": "template/timeline-explainer-lookbook-sage",
+      "kind": "template",
+      "name": "timeline-explainer-lookbook-sage",
+      "description": "A collection that counts itself, in cream on sage.",
+      "guidance": "# timeline-explainer-lookbook-sage\n\nA collection that counts itself, in cream on sage.\n\n`timeline-explainer` is the shape and `lookbook-sage` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/timeline-explainer` for the structure and `style/lookbook-sage` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-52657ef4e7f7924f0c044ec3fd6fbdc809125556c00110690208b0a4e81b3ddb",
+      "values": {
+        "formatRef": "format/timeline-explainer",
+        "styleRef": "style/lookbook-sage",
+        "why": "A collection that counts itself, in cream on sage."
+      }
+    },
+    {
+      "id": "template/titled-video-analog-editorial",
+      "kind": "template",
+      "name": "titled-video-analog-editorial",
+      "description": "A clip you already have, titled as though it were printed on paper.",
+      "guidance": "# titled-video-analog-editorial\n\nA clip you already have, titled as though it were printed on paper.\n\n`titled-video` is the shape and `analog-editorial` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/titled-video` for the structure and `style/analog-editorial` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-056b3c1e006a9e1178b3aafb7c1bbf7a299bc95e61076a423eb77a816333e276",
+      "values": {
+        "formatRef": "format/titled-video",
+        "styleRef": "style/analog-editorial",
+        "why": "A clip you already have, titled as though it were printed on paper."
+      }
+    },
+    {
+      "id": "template/titled-video-chrome-y2k",
+      "kind": "template",
+      "name": "titled-video-chrome-y2k",
+      "description": "A colour font that paints its own bevelled chrome, on a dark frame.",
+      "guidance": "# titled-video-chrome-y2k\n\nA colour font that paints its own bevelled chrome, on a dark frame.\n\n`titled-video` is the shape and `chrome-y2k` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/titled-video` for the structure and `style/chrome-y2k` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-6f6460086365b557a2485d8d27bdbc340489290ca0044227b64738e36e9f6c42",
+      "values": {
+        "formatRef": "format/titled-video",
+        "styleRef": "style/chrome-y2k",
+        "why": "A colour font that paints its own bevelled chrome, on a dark frame."
+      }
+    },
+    {
+      "id": "template/titled-video-postcard-serif",
+      "kind": "template",
+      "name": "titled-video-postcard-serif",
+      "description": "A place name across the top, tracked until it is almost a line.",
+      "guidance": "# titled-video-postcard-serif\n\nA place name across the top, tracked until it is almost a line.\n\n`titled-video` is the shape and `postcard-serif` is the look. The pairing is the thing\nsomebody actually picks: a format alone does not say what it looks like and a\nstyle alone does not say how long it runs or how many scenes it wants.\n\nRead `format/titled-video` for the structure and `style/postcard-serif` for the treatment.\nBoth are in this pack, and applying this template applies the style and\nsurfaces the format as guidance -- a format's values are human ranges\n(\"8-14 scenes\", \"1.5-3s\"), and pretending to apply them mechanically would be\ninventing a promise the format never made.",
+      "status": "stable",
+      "revision": 1,
+      "digest": "sha256-f477c075c0f00ab439ee38bcdb8daf4f1f1625ed04c3639e11972c333c9421d1",
+      "values": {
+        "formatRef": "format/titled-video",
+        "styleRef": "style/postcard-serif",
+        "why": "A place name across the top, tracked until it is almost a line.",
+        "previewCopy": {
+          "title": "New York",
+          "caption": "travel · vacation"
+        }
       }
     }
   ]

--- a/scripts/build-packs.py
+++ b/scripts/build-packs.py
@@ -32,6 +32,7 @@ ROOT = Path(__file__).resolve().parent.parent
 STYLES = ROOT / "src" / "video_studio" / "styles"
 FORMATS = ROOT / "skills" / "video-formats" / "references" / "formats"
 TITLE_SCENES = ROOT / "src" / "video_studio" / "title_scenes"
+TEMPLATES = ROOT / "src" / "video_studio" / "templates"
 #: Committed, at the repo root rather than under `dist/`, which is gitignored
 #: as the Python build output -- putting the packs there would have published
 #: nothing at all. Consumers read it over raw.githubusercontent.com, the same
@@ -249,13 +250,95 @@ def title_scene_assets(problems: list[str]) -> list[dict]:
     return assets
 
 
+def template_assets(problems: list[str]) -> list[dict]:
+    """The curated pairing, which is the thing a person actually browses for.
+
+    A format is a shape and a style is a look; neither alone is what anyone
+    picks. Until these existed the pairings lived as two hand-kept Python
+    literals inside the gallery site's `sync-gallery.py` -- which meant the
+    editor could offer "summer-scrapbook" and could not offer "a season of
+    phone footage, with one sentence worth keeping."
+
+    Moving them here is a one-way door and worth naming as one: adding a
+    template is now a release of this repository rather than a commit to the
+    site. That is the point -- the editor cannot see a site commit -- and it
+    does slow down purely editorial changes.
+    """
+    assets = []
+    known = keyspace.space("template")
+    copy_keys = keyspace.space("previewCopy")
+    for path in sorted(TEMPLATES.glob("*.md")):
+        text = path.read_text()
+        values = json_block(text)
+        meta = frontmatter(text)
+        if values is None:
+            problems.append(f"{path.name}: no json block")
+            continue
+        unknown = sorted(set(values) - known)
+        if unknown:
+            problems.append(f"{path.name}: not template keys: {', '.join(unknown)}")
+            continue
+        for key in ("formatRef", "styleRef", "why"):
+            if not values.get(key):
+                problems.append(f"{path.name}: {key} is required")
+        copy = values.get("previewCopy")
+        if copy is not None:
+            if not isinstance(copy, dict):
+                problems.append(f"{path.name}: previewCopy must be an object")
+            else:
+                stray = sorted(set(copy) - copy_keys)
+                if stray:
+                    problems.append(
+                        f"{path.name}: previewCopy sets {', '.join(stray)}"
+                    )
+        assets.append(
+            {
+                "id": f"template/{path.stem}",
+                "kind": "template",
+                "name": meta.get("name", path.stem),
+                "description": meta.get("description", ""),
+                "guidance": guidance(text),
+                "status": "stable",
+                "revision": 1,
+                "digest": digest(values),
+                "values": values,
+            }
+        )
+    return assets
+
+
+def resolve_refs(assets: list[dict], problems: list[str]) -> None:
+    """Every ref must name an asset in this same pack.
+
+    Checked at BUILD time because the alternative is finding out at apply
+    time: a template whose style was renamed still compiles, still ships, and
+    then applies nothing -- which reads as the template being broken rather
+    than the ref being stale.
+    """
+    ids = {asset["id"] for asset in assets}
+    single = ("formatRef", "styleRef", "overlayRef", "titleSceneRef")
+    for asset in assets:
+        values = asset.get("values")
+        if not isinstance(values, dict):
+            continue
+        refs = [values[key] for key in single if isinstance(values.get(key), str)]
+        listed = values.get("sfxRefs")
+        if isinstance(listed, list):
+            refs += [ref for ref in listed if isinstance(ref, str)]
+        for ref in refs:
+            if ref not in ids:
+                problems.append(f"{asset['id']}: {ref} is not in this pack")
+
+
 def build() -> tuple[dict, dict, list[str]]:
     problems: list[str] = []
     assets = (
         style_assets(problems)
         + format_assets(problems)
         + title_scene_assets(problems)
+        + template_assets(problems)
     )
+    resolve_refs(assets, problems)
 
     pack = {
         "format": PACK_FORMAT,

--- a/src/video_studio/project/keyspace.json
+++ b/src/video_studio/project/keyspace.json
@@ -19,7 +19,7 @@
     "the render, and misleads whoever edits it next. Add a space when something",
     "starts validating against it, not in anticipation."
   ],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "spaces": {
     "caption": {
       "$comment": "Caption keys the composer renders. Mirrored by captionStyleSchema in the editor's storyboard/captions.ts.",
@@ -143,6 +143,36 @@
         "overlayRef",
         "layers",
         "sfxRefs"
+      ]
+    },
+    "template": {
+      "$comment": [
+        "The curated pairing -- the thing a person actually browses for. A format",
+        "alone does not say what it looks like and a style alone does not say how",
+        "long it runs, so neither is what anyone picks.",
+        "Refs resolve WITHIN the same pack. Reaching across packs needs a",
+        "dependency resolver nobody has asked for, and a ref that silently found",
+        "nothing would render as a styling choice."
+      ],
+      "keys": [
+        "formatRef",
+        "styleRef",
+        "overlayRef",
+        "titleSceneRef",
+        "sfxRefs",
+        "why",
+        "previewCopy",
+        "preview"
+      ]
+    },
+    "previewCopy": {
+      "$comment": [
+        "What a preview tile SAYS, so it shows the template's own line rather than",
+        "its format's name. Curation, not content: these words never reach a video."
+      ],
+      "keys": [
+        "title",
+        "caption"
       ]
     }
   },

--- a/src/video_studio/templates/brand-origin-editorial-sage.md
+++ b/src/video_studio/templates/brand-origin-editorial-sage.md
@@ -1,0 +1,30 @@
+---
+name: brand-origin-editorial-sage
+description: A Didone line and one script word, cream on a flat colour field.
+---
+
+# brand-origin-editorial-sage
+
+A Didone line and one script word, cream on a flat colour field.
+
+`brand-origin` is the shape and `editorial-sage` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/brand-origin` for the structure and `style/editorial-sage` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/brand-origin",
+  "styleRef": "style/editorial-sage",
+  "why": "A Didone line and one script word, cream on a flat colour field.",
+  "previewCopy": {
+    "title": "THE everything you need",
+    "caption": "01 / 12"
+  }
+}
+```

--- a/src/video_studio/templates/brand-origin-magazine-cover.md
+++ b/src/video_studio/templates/brand-origin-magazine-cover.md
@@ -1,0 +1,26 @@
+---
+name: brand-origin-magazine-cover
+description: One claim, one masthead, one red. Nothing else on screen.
+---
+
+# brand-origin-magazine-cover
+
+One claim, one masthead, one red. Nothing else on screen.
+
+`brand-origin` is the shape and `magazine-cover` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/brand-origin` for the structure and `style/magazine-cover` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/brand-origin",
+  "styleRef": "style/magazine-cover",
+  "why": "One claim, one masthead, one red. Nothing else on screen."
+}
+```

--- a/src/video_studio/templates/brand-origin-warm-minimal.md
+++ b/src/video_studio/templates/brand-origin-warm-minimal.md
@@ -1,0 +1,26 @@
+---
+name: brand-origin-warm-minimal
+description: One from-here-to-there story, told quietly enough to be believed.
+---
+
+# brand-origin-warm-minimal
+
+One from-here-to-there story, told quietly enough to be believed.
+
+`brand-origin` is the shape and `warm-minimal` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/brand-origin` for the structure and `style/warm-minimal` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/brand-origin",
+  "styleRef": "style/warm-minimal",
+  "why": "One from-here-to-there story, told quietly enough to be believed."
+}
+```

--- a/src/video_studio/templates/brand-origin-zine-glitch.md
+++ b/src/video_studio/templates/brand-origin-zine-glitch.md
@@ -1,0 +1,26 @@
+---
+name: brand-origin-zine-glitch
+description: Type photocopied until it breaks, and exactly one red.
+---
+
+# brand-origin-zine-glitch
+
+Type photocopied until it breaks, and exactly one red.
+
+`brand-origin` is the shape and `zine-glitch` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/brand-origin` for the structure and `style/zine-glitch` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/brand-origin",
+  "styleRef": "style/zine-glitch",
+  "why": "Type photocopied until it breaks, and exactly one red."
+}
+```

--- a/src/video_studio/templates/cinematic-documentary.md
+++ b/src/video_studio/templates/cinematic-documentary.md
@@ -1,0 +1,26 @@
+---
+name: cinematic-documentary
+description: Cut to the track, captions off, colour left alone. The look is the footage.
+---
+
+# cinematic-documentary
+
+Cut to the track, captions off, colour left alone. The look is the footage.
+
+`cinematic` is the shape and `documentary` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/cinematic` for the structure and `style/documentary` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/cinematic",
+  "styleRef": "style/documentary",
+  "why": "Cut to the track, captions off, colour left alone. The look is the footage."
+}
+```

--- a/src/video_studio/templates/cinematic-neon-sign.md
+++ b/src/video_studio/templates/cinematic-neon-sign.md
@@ -1,0 +1,26 @@
+---
+name: cinematic-neon-sign
+description: One word in struck neon tube, over a street that is already lit.
+---
+
+# cinematic-neon-sign
+
+One word in struck neon tube, over a street that is already lit.
+
+`cinematic` is the shape and `neon-sign` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/cinematic` for the structure and `style/neon-sign` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/cinematic",
+  "styleRef": "style/neon-sign",
+  "why": "One word in struck neon tube, over a street that is already lit."
+}
+```

--- a/src/video_studio/templates/cinematic-weekend-gothic.md
+++ b/src/video_studio/templates/cinematic-weekend-gothic.md
@@ -1,0 +1,30 @@
+---
+name: cinematic-weekend-gothic
+description: One blackletter word over neon, and nothing else competing.
+---
+
+# cinematic-weekend-gothic
+
+One blackletter word over neon, and nothing else competing.
+
+`cinematic` is the shape and `weekend-gothic` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/cinematic` for the structure and `style/weekend-gothic` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/cinematic",
+  "styleRef": "style/weekend-gothic",
+  "why": "One blackletter word over neon, and nothing else competing.",
+  "previewCopy": {
+    "title": "Weekend",
+    "caption": "added to the list"
+  }
+}
+```

--- a/src/video_studio/templates/daily-recap-pov-serif.md
+++ b/src/video_studio/templates/daily-recap-pov-serif.md
@@ -1,0 +1,30 @@
+---
+name: daily-recap-pov-serif
+description: Three panels of an afternoon, captioned like a thought rather than a title.
+---
+
+# daily-recap-pov-serif
+
+Three panels of an afternoon, captioned like a thought rather than a title.
+
+`daily-recap` is the shape and `pov-serif` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/daily-recap` for the structure and `style/pov-serif` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/daily-recap",
+  "styleRef": "style/pov-serif",
+  "why": "Three panels of an afternoon, captioned like a thought rather than a title.",
+  "previewCopy": {
+    "title": "pov: capturing everything so you can rewatch it later",
+    "caption": "three panels, one afternoon"
+  }
+}
+```

--- a/src/video_studio/templates/daily-recap-summer-scrapbook.md
+++ b/src/video_studio/templates/daily-recap-summer-scrapbook.md
@@ -1,0 +1,30 @@
+---
+name: daily-recap-summer-scrapbook
+description: A season of phone footage, with one sentence worth keeping.
+---
+
+# daily-recap-summer-scrapbook
+
+A season of phone footage, with one sentence worth keeping.
+
+`daily-recap` is the shape and `summer-scrapbook` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/daily-recap` for the structure and `style/summer-scrapbook` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/daily-recap",
+  "styleRef": "style/summer-scrapbook",
+  "why": "A season of phone footage, with one sentence worth keeping.",
+  "previewCopy": {
+    "title": "Summer Vibes",
+    "caption": "let the sun melt the stress"
+  }
+}
+```

--- a/src/video_studio/templates/daily-recap-vhs-90s.md
+++ b/src/video_studio/templates/daily-recap-vhs-90s.md
@@ -1,0 +1,26 @@
+---
+name: daily-recap-vhs-90s
+description: A day as a run of short beats, cut on the track, stamped like a camcorder.
+---
+
+# daily-recap-vhs-90s
+
+A day as a run of short beats, cut on the track, stamped like a camcorder.
+
+`daily-recap` is the shape and `vhs-90s` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/daily-recap` for the structure and `style/vhs-90s` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/daily-recap",
+  "styleRef": "style/vhs-90s",
+  "why": "A day as a run of short beats, cut on the track, stamped like a camcorder."
+}
+```

--- a/src/video_studio/templates/daily-recap-wet-paint.md
+++ b/src/video_studio/templates/daily-recap-wet-paint.md
@@ -1,0 +1,26 @@
+---
+name: daily-recap-wet-paint
+description: Letters that drip, lime on black, for a day with no sincerity in it.
+---
+
+# daily-recap-wet-paint
+
+Letters that drip, lime on black, for a day with no sincerity in it.
+
+`daily-recap` is the shape and `wet-paint` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/daily-recap` for the structure and `style/wet-paint` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/daily-recap",
+  "styleRef": "style/wet-paint",
+  "why": "Letters that drip, lime on black, for a day with no sincerity in it."
+}
+```

--- a/src/video_studio/templates/explainer-clean-corporate.md
+++ b/src/video_studio/templates/explainer-clean-corporate.md
@@ -1,0 +1,26 @@
+---
+name: explainer-clean-corporate
+description: A concept walked through end to end, in the flat palette a deck already uses.
+---
+
+# explainer-clean-corporate
+
+A concept walked through end to end, in the flat palette a deck already uses.
+
+`explainer` is the shape and `clean-corporate` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/explainer` for the structure and `style/clean-corporate` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/explainer",
+  "styleRef": "style/clean-corporate",
+  "why": "A concept walked through end to end, in the flat palette a deck already uses."
+}
+```

--- a/src/video_studio/templates/product-launch-tech-startup.md
+++ b/src/video_studio/templates/product-launch-tech-startup.md
@@ -1,0 +1,26 @@
+---
+name: product-launch-tech-startup
+description: Three capabilities and a name to land, in a palette built to look shipped.
+---
+
+# product-launch-tech-startup
+
+Three capabilities and a name to land, in a palette built to look shipped.
+
+`product-launch` is the shape and `tech-startup` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/product-launch` for the structure and `style/tech-startup` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/product-launch",
+  "styleRef": "style/tech-startup",
+  "why": "Three capabilities and a name to land, in a palette built to look shipped."
+}
+```

--- a/src/video_studio/templates/talking-head-loud-social.md
+++ b/src/video_studio/templates/talking-head-loud-social.md
@@ -1,0 +1,26 @@
+---
+name: talking-head-loud-social
+description: One person to camera, captions loud enough to work on mute.
+---
+
+# talking-head-loud-social
+
+One person to camera, captions loud enough to work on mute.
+
+`talking-head` is the shape and `loud-social` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/talking-head` for the structure and `style/loud-social` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/talking-head",
+  "styleRef": "style/loud-social",
+  "why": "One person to camera, captions loud enough to work on mute."
+}
+```

--- a/src/video_studio/templates/talking-head-pov-quiet.md
+++ b/src/video_studio/templates/talking-head-pov-quiet.md
@@ -1,0 +1,26 @@
+---
+name: talking-head-pov-quiet
+description: A held moment, captioned mid-frame in a voice that does not raise.
+---
+
+# talking-head-pov-quiet
+
+A held moment, captioned mid-frame in a voice that does not raise.
+
+`talking-head` is the shape and `pov-quiet` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/talking-head` for the structure and `style/pov-quiet` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/talking-head",
+  "styleRef": "style/pov-quiet",
+  "why": "A held moment, captioned mid-frame in a voice that does not raise."
+}
+```

--- a/src/video_studio/templates/timeline-explainer-3b1b-dark.md
+++ b/src/video_studio/templates/timeline-explainer-3b1b-dark.md
@@ -1,0 +1,26 @@
+---
+name: timeline-explainer-3b1b-dark
+description: Numbered beats on a dark ground, the way a maths lecture counts.
+---
+
+# timeline-explainer-3b1b-dark
+
+Numbered beats on a dark ground, the way a maths lecture counts.
+
+`timeline-explainer` is the shape and `3b1b-dark` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/timeline-explainer` for the structure and `style/3b1b-dark` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/timeline-explainer",
+  "styleRef": "style/3b1b-dark",
+  "why": "Numbered beats on a dark ground, the way a maths lecture counts."
+}
+```

--- a/src/video_studio/templates/timeline-explainer-arcade-crt.md
+++ b/src/video_studio/templates/timeline-explainer-arcade-crt.md
@@ -1,0 +1,26 @@
+---
+name: timeline-explainer-arcade-crt
+description: Phosphor green pixels counting up, the way a score does.
+---
+
+# timeline-explainer-arcade-crt
+
+Phosphor green pixels counting up, the way a score does.
+
+`timeline-explainer` is the shape and `arcade-crt` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/timeline-explainer` for the structure and `style/arcade-crt` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/timeline-explainer",
+  "styleRef": "style/arcade-crt",
+  "why": "Phosphor green pixels counting up, the way a score does."
+}
+```

--- a/src/video_studio/templates/timeline-explainer-lookbook-sage.md
+++ b/src/video_studio/templates/timeline-explainer-lookbook-sage.md
@@ -1,0 +1,26 @@
+---
+name: timeline-explainer-lookbook-sage
+description: A collection that counts itself, in cream on sage.
+---
+
+# timeline-explainer-lookbook-sage
+
+A collection that counts itself, in cream on sage.
+
+`timeline-explainer` is the shape and `lookbook-sage` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/timeline-explainer` for the structure and `style/lookbook-sage` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/timeline-explainer",
+  "styleRef": "style/lookbook-sage",
+  "why": "A collection that counts itself, in cream on sage."
+}
+```

--- a/src/video_studio/templates/titled-video-analog-editorial.md
+++ b/src/video_studio/templates/titled-video-analog-editorial.md
@@ -1,0 +1,26 @@
+---
+name: titled-video-analog-editorial
+description: A clip you already have, titled as though it were printed on paper.
+---
+
+# titled-video-analog-editorial
+
+A clip you already have, titled as though it were printed on paper.
+
+`titled-video` is the shape and `analog-editorial` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/titled-video` for the structure and `style/analog-editorial` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/titled-video",
+  "styleRef": "style/analog-editorial",
+  "why": "A clip you already have, titled as though it were printed on paper."
+}
+```

--- a/src/video_studio/templates/titled-video-chrome-y2k.md
+++ b/src/video_studio/templates/titled-video-chrome-y2k.md
@@ -1,0 +1,26 @@
+---
+name: titled-video-chrome-y2k
+description: A colour font that paints its own bevelled chrome, on a dark frame.
+---
+
+# titled-video-chrome-y2k
+
+A colour font that paints its own bevelled chrome, on a dark frame.
+
+`titled-video` is the shape and `chrome-y2k` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/titled-video` for the structure and `style/chrome-y2k` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/titled-video",
+  "styleRef": "style/chrome-y2k",
+  "why": "A colour font that paints its own bevelled chrome, on a dark frame."
+}
+```

--- a/src/video_studio/templates/titled-video-postcard-serif.md
+++ b/src/video_studio/templates/titled-video-postcard-serif.md
@@ -1,0 +1,30 @@
+---
+name: titled-video-postcard-serif
+description: A place name across the top, tracked until it is almost a line.
+---
+
+# titled-video-postcard-serif
+
+A place name across the top, tracked until it is almost a line.
+
+`titled-video` is the shape and `postcard-serif` is the look. The pairing is the thing
+somebody actually picks: a format alone does not say what it looks like and a
+style alone does not say how long it runs or how many scenes it wants.
+
+Read `format/titled-video` for the structure and `style/postcard-serif` for the treatment.
+Both are in this pack, and applying this template applies the style and
+surfaces the format as guidance -- a format's values are human ranges
+("8-14 scenes", "1.5-3s"), and pretending to apply them mechanically would be
+inventing a promise the format never made.
+
+```json
+{
+  "formatRef": "format/titled-video",
+  "styleRef": "style/postcard-serif",
+  "why": "A place name across the top, tracked until it is almost a line.",
+  "previewCopy": {
+    "title": "New York",
+    "caption": "travel · vacation"
+  }
+}
+```

--- a/tests/unit/test_packs.py
+++ b/tests/unit/test_packs.py
@@ -181,3 +181,55 @@ class TestTitleScenes:
         # hands an agent.
         for scene in self.scenes(pack):
             assert len(scene["guidance"]) > 200, scene["id"]
+
+
+class TestTemplates:
+    """The curated pairing, which is the thing a person actually browses for."""
+
+    def templates(self, pack: dict) -> list[dict]:
+        return [a for a in pack["assets"] if a["kind"] == "template"]
+
+    def test_every_pairing_the_gallery_curated_is_here(self, pack: dict) -> None:
+        # 21, the count that lived as a Python literal in the gallery site.
+        # Losing one in the migration is silent: the site would simply render
+        # a shorter page.
+        assert len(self.templates(pack)) == 21
+
+    def test_every_ref_resolves_inside_the_pack(self, pack: dict) -> None:
+        # Checked at build time too. Here as well because the consequence is
+        # invisible: a template whose style was renamed compiles, ships, and
+        # then applies nothing, which reads as the template being broken.
+        ids = {a["id"] for a in pack["assets"]}
+        for template in self.templates(pack):
+            assert template["values"]["formatRef"] in ids, template["id"]
+            assert template["values"]["styleRef"] in ids, template["id"]
+
+    def test_every_one_says_why(self, pack: dict) -> None:
+        # The one sentence on a gallery card that is written rather than read
+        # from a preset. It is the whole reason `template` is a kind.
+        for template in self.templates(pack):
+            assert len(template["values"]["why"]) > 20, template["id"]
+
+    def test_preview_copy_is_curation_and_never_reaches_a_video(
+        self, pack: dict
+    ) -> None:
+        # Two keys, both about what a TILE says. Anything else here would be
+        # the pack writing the video's words.
+        for template in self.templates(pack):
+            copy = template["values"].get("previewCopy")
+            if copy is not None:
+                assert set(copy) <= {"title", "caption"}, template["id"]
+
+    def test_the_five_recreations_kept_their_lines(self, pack: dict) -> None:
+        # These are the moving previews and the ones somebody arriving is most
+        # likely to be looking for. Their copy was hand-chosen against a
+        # reference and is the easiest thing to lose in a migration.
+        by_id = {a["id"]: a for a in self.templates(pack)}
+        expected = {
+            "template/daily-recap-summer-scrapbook": "Summer Vibes",
+            "template/cinematic-weekend-gothic": "Weekend",
+            "template/titled-video-postcard-serif": "New York",
+        }
+        for asset_id, title in expected.items():
+            assert asset_id in by_id, asset_id
+            assert by_id[asset_id]["values"]["previewCopy"]["title"] == title


### PR DESCRIPTION
A format is a shape and a style is a look; **neither alone is what anyone picks.**

Until now the pairing existed only as two hand-kept Python literals — `PAIRINGS` and `PREVIEW_COPY` — inside the gallery site's `sync-gallery.py`. So the editor could offer *"summer-scrapbook"* and could not offer *"a season of phone footage, with one sentence worth keeping"*, which is the thing somebody is actually looking for.

### This is a one-way door, and worth naming as one

Adding a template is now a **release of this repository** rather than a commit to the site. That is the point — the editor cannot see a site commit — and it does slow down purely editorial changes.

What does **not** move: the **ordering** that puts the five moving-preview recreations first, and the stock stills and clips. Those are presentation, and stay site-owned.

### Refs resolve inside the pack, checked at build time

The alternative is finding out at apply time: a template whose style was renamed still compiles, still ships, and then applies nothing — which reads as the template being broken rather than the ref being stale.

Verified by renaming one:

```
template/cinematic-documentary: style/gone is not in this pack
1 problem(s); nothing written
```

### `previewCopy` is two keys and stays two keys

It is what a **tile** says, so a preview shows the template's own line rather than its format's name. Curation, not content — anything else there would be the pack writing the video's words.

### The tests worth having

A count pinned at 21, and the three hand-chosen preview lines from the reference recreations. Losing one in a migration is silent: the site would simply render a shorter page.

### Verification

Keyspace to **1.2.0** · 64 assets (29 style, 11 format, 3 title-scene, 21 template) · `--check` clean · `pytest` 152 passed.